### PR TITLE
Fix or ignore remaining ruff checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.4.1
+  rev: v0.5.6
   hooks:
     # Run the linter.
     - id: ruff

--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -35,9 +35,9 @@
 # THE SOFTWARE.
 """Snakemake scheduler for pairwise comparisons for ANI analysis."""
 
+import importlib.resources as impresources
 from pathlib import Path
 
-import importlib.resources as impresources
 from snakemake.api import ConfigSettings, DAGSettings, ResourceSettings, SnakemakeApi
 
 from pyani_plus import workflows
@@ -53,9 +53,13 @@ def check_input_stems(indir) -> dict[str, Path]:
     stems = [_.stem for _ in Path(indir).glob("*") if _.suffix in extensions]
 
     if len(stems) == len(set(stems)):
-        input_files = {_.stem: _ for _ in Path(indir).glob("*") if _.suffix in extensions}
+        input_files = {
+            _.stem: _ for _ in Path(indir).glob("*") if _.suffix in extensions
+        }
     else:
-        duplicates = [item for item in stems if stems.count(item) > 1 and item in set(stems)]
+        duplicates = [
+            item for item in stems if stems.count(item) > 1 and item in set(stems)
+        ]
         msg = f"Duplicated stems found for {list(set(duplicates))}. Please investigate."
         raise ValueError(msg)
 

--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -43,7 +43,7 @@ from snakemake.api import ConfigSettings, DAGSettings, ResourceSettings, Snakema
 from pyani_plus import workflows
 
 
-def check_input_stems(indir) -> dict[str, Path]:
+def check_input_stems(indir: str) -> dict[str, Path]:
     """Check input files against approved list of extensions.
 
     If duplicate stems with approved extensions are present

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = ["snakemake"]
 [tool.ruff.lint]
 select = ["ALL"]
 pycodestyle.max-line-length = 120
-ignore = ["S603"]
+ignore = ["COM812", "D203", "D213", "S603"]
 
 [tool.setuptools.packages.find]
 where = ["pyani_plus"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = ["snakemake"]
 [tool.ruff.lint]
 select = ["ALL"]
 pycodestyle.max-line-length = 120
-ignore = ["COM812", "D203", "D213", "S603"]
+ignore = ["ANN101", "ANN102", "COM812", "D203", "D213", "S603"]
 
 [tool.setuptools.packages.find]
 where = ["pyani_plus"]

--- a/tests/generate_fixtures/generate_target_anim_files.py
+++ b/tests/generate_fixtures/generate_target_anim_files.py
@@ -60,7 +60,7 @@ inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
     subprocess.run(
-        [
+        [  # noqa: S607
             "nucmer",
             "-p",
             DELTA_DIR / stem,
@@ -75,7 +75,7 @@ for genomes in comparisons:
     # pipe from within the call to stdout
     with (FILTER_DIR / (stem + ".filter")).open("w") as ofh:
         subprocess.run(
-            ["delta-filter", "-1", DELTA_DIR / (stem + ".delta")],
+            ["delta-filter", "-1", DELTA_DIR / (stem + ".delta")],  # noqa: S607
             check=True,
             stdout=ofh,
         )

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -66,7 +66,7 @@ inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
     subprocess.run(
-        [
+        [  # noqa: S607
             "nucmer",
             "-p",
             DELTA_DIR / stem,
@@ -81,21 +81,21 @@ for genomes in comparisons:
     # pipe from within the call to stdout
     with (FILTER_DIR / (stem + ".filter")).open("w") as ofh:
         subprocess.run(
-            ["delta-filter", "-m", DELTA_DIR / (stem + ".delta")],
+            ["delta-filter", "-m", DELTA_DIR / (stem + ".delta")],  # noqa: S607
             check=True,
             stdout=ofh,
         )
 
     with (SHOW_DIFF_DIR / (stem + ".rdiff")).open("w") as ofh:
         subprocess.run(
-            ["show-diff", "-rH", FILTER_DIR / (stem + ".filter")],
+            ["show-diff", "-rH", FILTER_DIR / (stem + ".filter")],  # noqa: S607
             check=True,
             stdout=ofh,
         )
 
     with (SHOW_COORDS_DIR / (stem + ".mcoords")).open("w") as ofh:
         subprocess.run(
-            ["show-coords", FILTER_DIR / (stem + ".filter")],
+            ["show-coords", FILTER_DIR / (stem + ".filter")],  # noqa: S607
             check=True,
             stdout=ofh,
         )

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -59,7 +59,7 @@ inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
     subprocess.run(
-        [
+        [  # noqa: S607
             "fastANI",
             "-q",
             inputs[genomes[0]],


### PR DESCRIPTION
This is some minor housekeeping to resolve the currently failing pre-commit checks.

Adds local ignores for S607 pending a proper fix.

Closes #36, cherry-picking the pre-commit tool updates.

Given the existence of conflicting and deprecated rules in ruff check, there ought to be a better approach to using ruff with all rules...

