### PR TITLE
BioConda mummer package fixed

### DIFF
--- a/requirements-thirdparty-macos.txt
+++ b/requirements-thirdparty-macos.txt
@@ -1,5 +1,5 @@
 blast
 blast-legacy
-mummer=3.23=h6de7cb9_11
+mummer=3.23
 fastani
 gsl=2.7=h93259b0_0


### PR DESCRIPTION
As of yesterday, we should be able to use the current and default version of mummer 3.23 on BioConda:

https://anaconda.org/bioconda/mummer

I was able to update the recipe to fix the hash-bang issue (which was why #1 pinned to a specific older build of mummer 3.23) and compile it on osx-arm64 as well:

https://github.com/bioconda/bioconda-recipes/pull/49870