### PR TITLE
Install MiniForge rather than MiniConda

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -24,9 +24,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Install Miniconda (Python ${{ matrix.python-version }})
+      - name: Install MiniForge (Python ${{ matrix.python-version }})
         uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           activate-environment: pyani-github

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -24,9 +24,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Install Miniconda (Python ${{ matrix.python-version }})
+      - name: Install MiniForge (Python ${{ matrix.python-version }})
         uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           activate-environment: pyani-github


### PR DESCRIPTION
We want to completely avoid the non-free Anaconda defaults channel.

Despite the name, https://github.com/conda-incubator/setup-miniconda is a conda implementation agnostic GitHub Action.

This builds on #42 which dropped the defaults channel.