### PR TITLE
Simplify thirdparty conda dependencies

### DIFF
--- a/requirements-thirdparty-linux.txt
+++ b/requirements-thirdparty-linux.txt
@@ -1,3 +1,2 @@
 fastani
-gsl=2.7
 mummer=3.23

--- a/requirements-thirdparty-linux.txt
+++ b/requirements-thirdparty-linux.txt
@@ -1,5 +1,3 @@
 gsl=2.7
 fastani
-blast
-blast-legacy
 mummer=3.23

--- a/requirements-thirdparty-linux.txt
+++ b/requirements-thirdparty-linux.txt
@@ -1,3 +1,3 @@
-gsl=2.7
 fastani
+gsl=2.7
 mummer=3.23

--- a/requirements-thirdparty-macos.txt
+++ b/requirements-thirdparty-macos.txt
@@ -1,3 +1,3 @@
-mummer=3.23
 fastani
 gsl=2.7=h93259b0_0
+mummer=3.23

--- a/requirements-thirdparty-macos.txt
+++ b/requirements-thirdparty-macos.txt
@@ -1,5 +1,3 @@
-blast
-blast-legacy
 mummer=3.23
 fastani
 gsl=2.7=h93259b0_0

--- a/requirements-thirdparty-macos.txt
+++ b/requirements-thirdparty-macos.txt
@@ -1,3 +1,2 @@
 fastani
-gsl=2.7=h93259b0_0
 mummer=3.23


### PR DESCRIPTION
This does some cleanup of the third-party dependencies:

- both macos and linux files are now sorted for ease of comparison (now identical, if this remains true long term we might merge these)
- dropped currently unused BLAST dependencies (slightly faster for CI; see #13)
- dropped explicit gsl dependency (no longer need to pin specific build on macOS)

With these changes ``conda install --file requirements-thirdparty-macos.txt`` will now run on Apple ARM (``osx-arm64``) and thus almost resolves #41.