### PR TITLE
Introduce pytest marker for slurm specific tests

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -56,10 +56,10 @@ jobs:
         run: pip install -e .
 
       - name: Check pytest modules
-        run: python -m pytest -v --collect-only
+        run: python -m pytest -v -m "not slurm" --collect-only
 
       - name: Run Tests with pytest
-        run: python -m pytest -v --cov=pyani_plus --cov-report=xml:.coverage-linux-${{ matrix.python-version }}.xml
+        run: python -m pytest -v -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-linux-${{ matrix.python-version }}.xml
 
       - name: Store coverage Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -56,10 +56,10 @@ jobs:
         run: pip install -e .
 
       - name: Check pytest modules
-        run: python -m pytest -v --collect-only
+        run: python -m pytest -v -m "not slurm" --collect-only
 
       - name: Run Tests with pytest
-        run: python -m pytest -v --cov=pyani_plus --cov-report=xml:.coverage-macos-${{ matrix.python-version }}.xml
+        run: python -m pytest -v -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-macos-${{ matrix.python-version }}.xml
 
       - name: Store coverage Results
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,11 @@ where = ["pyani_plus"]
 [project.urls]
 Homepage = "https://github.com/pyani-plus/pyani-plus"
 Issues = "https://github.com/pyani-plus/pyani-plus/issues"
+
+[tool.pytest.ini_options]
+# Using --strict-markers ensures any new marker decoration used has
+# a matching definition here in the configuration file:
+addopts = "--strict-markers"
+markers = [
+    "slurm: Tests using the SLURM job scheduler (deselect with '-m \"not slurm\"')",
+]

--- a/tests/snakemake/test_snakemake_slurm.py
+++ b/tests/snakemake/test_snakemake_slurm.py
@@ -197,6 +197,7 @@ def compare_show_diff_files(file1: Path, file2: Path) -> bool:
     return True
 
 
+@pytest.mark.slurm()
 def test_snakemake_rule_delta_slurm(
     anim_nucmer_targets_delta_slurm: list[str],
     anim_nucmer_targets_delta_indir: Path,
@@ -229,6 +230,7 @@ def test_snakemake_rule_delta_slurm(
         )
 
 
+@pytest.mark.slurm()
 def test_snakemake_rule_filter_slurm(
     anim_nucmer_targets_filter_slurm: list[str],
     anim_nucmer_targets_filter_indir: Path,
@@ -261,6 +263,7 @@ def test_snakemake_rule_filter_slurm(
         )
 
 
+@pytest.mark.slurm()
 def test_snakemake_rule_fastani_slurm(
     fastani_targets_slurm: list[str],
     fastani_targets_slurm_outdir: Path,
@@ -287,6 +290,7 @@ def test_snakemake_rule_fastani_slurm(
         )
 
 
+@pytest.mark.slurm()
 def test_dnadiff_rule_delta_slurm(
     dnadiff_nucmer_targets_delta_slurm: list[str],
     dnadiff_nucmer_targets_delta_indir: Path,
@@ -319,6 +323,7 @@ def test_dnadiff_rule_delta_slurm(
         )
 
 
+@pytest.mark.slurm()
 def test_dnadiff_rule_filter_slurm(
     dnadiff_nucmer_targets_filter_slurm: list[str],
     dnadiff_nucmer_targets_filter_indir: Path,
@@ -351,6 +356,7 @@ def test_dnadiff_rule_filter_slurm(
         )
 
 
+@pytest.mark.slurm()
 def test_dnadiff_rule_show_diff_slurm(
     dnadiff_targets_showdiff_slurm: list[str],
     dnadiff_targets_showdiff_indir: Path,


### PR DESCRIPTION
Use this new marker to skip the slurm tests on GitHub Actions.

Closes #50.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [ ] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
