### PR TITLE
Use snakefmt in pre-commit hook for snamemake files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,10 @@ repos:
       args: [
         '--config=format.docstring-code-format=true'
       ]
+- repo: https://github.com/snakemake/snakefmt
+  rev: v0.10.2
+  hooks:
+    - id: snakefmt
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
   hooks:


### PR DESCRIPTION
See https://github.com/snakemake/snakefmt?tab=readme-ov-file#version-control-integration

Currently this seems happy with all the formatting in our snakemake files 👍 

Tested by deliberately using alternative quotes and indentation in one ``*.smk`` file:

```
$ git commit -m "Test this is rejected" pyani_plus/workflows/snakemake_fastani.smk
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check that scripts with shebangs are executable..........................Passed
check for broken symlinks............................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
debug statements (python)............................(no files to check)Skipped
detect destroyed symlinks................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Passed
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
snakefmt.................................................................Failed
- hook id: snakefmt
- files were modified by this hook

[INFO] Writing formatted content to pyani_plus/workflows/snakemake_fastani.smk
[INFO] All done 🎉

codespell................................................................Passed
mypy.................................................(no files to check)Skipped
```

This restored the file to the previous state. i.e. The autofixer worked nicely.