### PR TITLE
Fix installation of the Python files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pycodestyle.max-line-length = 120
 ignore = ["ANN101", "ANN102", "COM812", "D203", "D213", "S603"]
 
 [tool.setuptools.packages.find]
-where = ["pyani_plus"]
+include = ["pyani_plus"]
 
 [project.urls]
 Homepage = "https://github.com/pyani-plus/pyani-plus"


### PR DESCRIPTION
Closes #58

It seems there is more than one way to express this but this seems explicit and clear:

https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages

