### PR TITLE
Run tests in parallel using pytest-xdist

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -56,10 +56,10 @@ jobs:
         run: pip install -e .
 
       - name: Check pytest modules
-        run: python -m pytest -v -m "not slurm" --collect-only
+        run: python -m pytest -v -n auto -m "not slurm" --collect-only
 
       - name: Run Tests with pytest
-        run: python -m pytest -v -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-linux-${{ matrix.python-version }}.xml
+        run: python -m pytest -v -n auto -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-linux-${{ matrix.python-version }}.xml
 
       - name: Store coverage Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -56,10 +56,12 @@ jobs:
         run: pip install -e .
 
       - name: Check pytest modules
-        run: python -m pytest -v -n auto -m "not slurm" --collect-only
+        run: python -m pytest -v -m "not slurm" --collect-only
 
       - name: Run Tests with pytest
-        run: python -m pytest -v -n auto -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-linux-${{ matrix.python-version }}.xml
+        # Currently single-threaded on macOS workers as faster there,
+        # but on Linux using -n auto to test in parallel
+        run: python -m pytest -v -m "not slurm" -n auto --cov=pyani_plus --cov-report=xml:.coverage-linux-${{ matrix.python-version }}.xml
 
       - name: Store coverage Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -56,10 +56,10 @@ jobs:
         run: pip install -e .
 
       - name: Check pytest modules
-        run: python -m pytest -v -m "not slurm" --collect-only
+        run: python -m pytest -v -n auto -m "not slurm" --collect-only
 
       - name: Run Tests with pytest
-        run: python -m pytest -v -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-macos-${{ matrix.python-version }}.xml
+        run: python -m pytest -v -n auto -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-macos-${{ matrix.python-version }}.xml
 
       - name: Store coverage Results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -56,10 +56,12 @@ jobs:
         run: pip install -e .
 
       - name: Check pytest modules
-        run: python -m pytest -v -n auto -m "not slurm" --collect-only
+        run: python -m pytest -v -m "not slurm" --collect-only
 
       - name: Run Tests with pytest
-        run: python -m pytest -v -n auto -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-macos-${{ matrix.python-version }}.xml
+        # Currently single-threaded on macOS workers as faster there,
+        # but on Linux using -n auto to test in parallel
+        run: python -m pytest -v -m "not slurm" --cov=pyani_plus --cov-report=xml:.coverage-macos-${{ matrix.python-version }}.xml
 
       - name: Store coverage Results
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ setup_dev_macos: setup_conda setup_conda-dev
 # Run tests
 # When the tests complete, the coverage output will be opened in a browser
 test:
-	@python -m pytest --cov-report=html --cov=pyani_plus -v tests/ && open htmlcov/index.html
+	@python -m pytest -n auto --cov-report=html --cov=pyani_plus -v tests/ && open htmlcov/index.html
 
 # Clean up test output
 clean_test:

--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -73,7 +73,9 @@ class SnakemakeRunner:
         """Initialise SnakemakeRunner with SnakeMake workflow filename."""
         self.workflow_filename = workflow_filename
 
-    def run_workflow(self, targetset: list, config_args: dict) -> None:
+    def run_workflow(
+        self, targetset: list, config_args: dict, workdir: Path | None = None
+    ) -> None:
         """Run the snakemake workflow.
 
         :param targets: (list) List of target files that the workflow should return.
@@ -92,6 +94,7 @@ class SnakemakeRunner:
                 config_settings=ConfigSettings(
                     config=config_args,
                 ),
+                workdir=workdir,
             )
             dag_api = workflow_api.dag(
                 dag_settings=DAGSettings(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ pycodestyle.max-line-length = 120
 ignore = ["ANN101", "ANN102", "COM812", "D203", "D213", "S603"]
 
 [tool.setuptools.packages.find]
-where = ["pyani_plus"]
+include = ["pyani_plus"]
 
 [project.urls]
 Homepage = "https://github.com/pyani-plus/pyani-plus"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ coverage
 pre-commit
 pytest
 pytest-cov
+pytest-xdist
 ruff
 types-tqdm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def anim_nucmer_targets_filter_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during ANIm testing
     """
-    return Path(tmp_path) / "nucmer_filter_output"
+    return Path(tmp_path).resolve() / "nucmer_filter_output"
 
 
 @pytest.fixture()
@@ -71,7 +71,7 @@ def anim_nucmer_targets_filter_slurm_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during ANIm testing
     """
-    return Path(tmp_path) / "nucmer_filter_slurm_output"
+    return Path(tmp_path).resolve() / "nucmer_filter_slurm_output"
 
 
 @pytest.fixture()
@@ -87,7 +87,7 @@ def anim_nucmer_targets_delta_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during ANIm testing
     """
-    return Path(tmp_path) / "nucmer_delta_output"
+    return Path(tmp_path).resolve() / "nucmer_delta_output"
 
 
 @pytest.fixture()
@@ -97,7 +97,7 @@ def anim_nucmer_targets_delta_slurm_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during ANIm testing
     """
-    return Path(tmp_path) / "nucmer_delta_slurm_output"
+    return Path(tmp_path).resolve() / "nucmer_delta_slurm_output"
 
 
 @pytest.fixture()
@@ -159,7 +159,7 @@ def fastani_targets_outdir(tmp_path: str) -> Path:
     This path indicates the location to which fastANI should write
     its output files during fastani testing
     """
-    return Path(tmp_path) / "fastani_output"
+    return Path(tmp_path).resolve() / "fastani_output"
 
 
 @pytest.fixture()
@@ -169,7 +169,7 @@ def fastani_targets_slurm_outdir(tmp_path: str) -> Path:
     This path indicates the location to which fastANI should write
     its output files during fastani testing
     """
-    return Path(tmp_path) / "fastani_slurm_output"
+    return Path(tmp_path).resolve() / "fastani_slurm_output"
 
 
 @pytest.fixture()
@@ -220,7 +220,7 @@ def dnadiff_nucmer_targets_filter_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_nucmer_filter_output"
+    return Path(tmp_path).resolve() / "dnadiff_nucmer_filter_output"
 
 
 @pytest.fixture()
@@ -230,7 +230,7 @@ def dnadiff_nucmer_targets_filter_slurm_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_nucmer_filter_slurm_output"
+    return Path(tmp_path).resolve() / "dnadiff_nucmer_filter_slurm_output"
 
 
 @pytest.fixture()
@@ -246,7 +246,7 @@ def dnadiff_nucmer_targets_delta_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_nucmer_delta_output"
+    return Path(tmp_path).resolve() / "dnadiff_nucmer_delta_output"
 
 
 @pytest.fixture()
@@ -256,7 +256,7 @@ def dnadiff_nucmer_targets_delta_slurm_outdir(tmp_path: str) -> Path:
     This path indicates the location to which MUMmer should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_nucmer_delta_slurm_output"
+    return Path(tmp_path).resolve() / "dnadiff_nucmer_delta_slurm_output"
 
 
 @pytest.fixture()
@@ -272,7 +272,7 @@ def dnadiff_targets_showdiff_outdir(tmp_path: str) -> Path:
     This path indicates the location to which dnadiff should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_show_diff_output"
+    return Path(tmp_path).resolve() / "dnadiff_show_diff_output"
 
 
 @pytest.fixture()
@@ -288,7 +288,7 @@ def dnadiff_targets_showcoords_outdir(tmp_path: str) -> Path:
     This path indicates the location to which dnadiff should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_show_coords_output"
+    return Path(tmp_path).resolve() / "dnadiff_show_coords_output"
 
 
 @pytest.fixture()
@@ -298,7 +298,7 @@ def dnadiff_targets_showdiff_slurm_outdir(tmp_path: str) -> Path:
     This path indicates the location to which dnadiff should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path) / "dnadiff_showdiff_slurm_output"
+    return Path(tmp_path).resolve() / "dnadiff_showdiff_slurm_output"
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,8 @@ import pytest
 # Path to tests, contains tests and data subdirectories
 # This conftest.py file should be found in the top directory of the tests
 # module. The fixture data should be in a subdirectory named fixtures
-TESTSPATH = Path(__file__).parents[0]
+# Resolve this to an absolute path so that the working directory can be changed
+TESTSPATH = Path(__file__).parents[0].resolve()
 FIXTUREPATH = TESTSPATH / "fixtures"
 
 

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -112,6 +112,7 @@ def test_snakemake_rule_filter(
     anim_nucmer_targets_filter_indir: Path,
     anim_nucmer_targets_filter_outdir: Path,
     config_filter_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer filter snakemake wrapper.
 
@@ -130,7 +131,9 @@ def test_snakemake_rule_filter(
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_anim.smk")
 
-    runner.run_workflow(anim_nucmer_targets_filter, config_filter_args)
+    runner.run_workflow(
+        anim_nucmer_targets_filter, config_filter_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in anim_nucmer_targets_filter:
@@ -145,6 +148,7 @@ def test_snakemake_rule_delta(
     anim_nucmer_targets_delta_indir: Path,
     anim_nucmer_targets_delta_outdir: Path,
     config_delta_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer delta snakemake wrapper.
 
@@ -163,7 +167,9 @@ def test_snakemake_rule_delta(
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_anim.smk")
 
-    runner.run_workflow(anim_nucmer_targets_delta, config_delta_args)
+    runner.run_workflow(
+        anim_nucmer_targets_delta, config_delta_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in anim_nucmer_targets_delta:

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -147,6 +147,7 @@ def test_snakemake_rule_delta(
     dnadiff_nucmer_targets_delta_indir: Path,
     dnadiff_nucmer_targets_delta_outdir: Path,
     config_delta_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer delta snakemake wrapper.
 
@@ -165,7 +166,9 @@ def test_snakemake_rule_delta(
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
 
-    runner.run_workflow(dnadiff_nucmer_targets_delta, config_delta_args)
+    runner.run_workflow(
+        dnadiff_nucmer_targets_delta, config_delta_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_nucmer_targets_delta:
@@ -180,6 +183,7 @@ def test_snakemake_rule_filter(
     dnadiff_nucmer_targets_filter_indir: Path,
     dnadiff_nucmer_targets_filter_outdir: Path,
     config_filter_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer filter snakemake wrapper.
 
@@ -197,7 +201,9 @@ def test_snakemake_rule_filter(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
-    runner.run_workflow(dnadiff_nucmer_targets_filter, config_filter_args)
+    runner.run_workflow(
+        dnadiff_nucmer_targets_filter, config_filter_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_nucmer_targets_filter:
@@ -212,6 +218,7 @@ def test_snakemake_rule_show_diff(
     dnadiff_targets_showdiff_indir: Path,
     dnadiff_targets_showdiff_outdir: Path,
     config_dnadiff_showdiff_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test dnadiff show-diff snakemake wrapper.
 
@@ -230,7 +237,9 @@ def test_snakemake_rule_show_diff(
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
 
-    runner.run_workflow(dnadiff_targets_showdiff, config_dnadiff_showdiff_args)
+    runner.run_workflow(
+        dnadiff_targets_showdiff, config_dnadiff_showdiff_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_targets_showdiff:
@@ -246,6 +255,7 @@ def test_snakemake_rule_show_coords(
     dnadiff_targets_showcoords_indir: Path,
     dnadiff_targets_showcoords_outdir: Path,
     config_dnadiff_showcoords_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test dnadiff show-coords snakemake wrapper.
 
@@ -264,7 +274,11 @@ def test_snakemake_rule_show_coords(
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
 
-    runner.run_workflow(dnadiff_targets_showcoords, config_dnadiff_showcoords_args)
+    runner.run_workflow(
+        dnadiff_targets_showcoords,
+        config_dnadiff_showcoords_args,
+        workdir=Path(tmp_path),
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_targets_showcoords:

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -91,6 +91,7 @@ def test_snakemake_rule_fastani(
     fastani_targets_outdir: Path,
     config_fastani_args: dict,
     fastani_targets_indir: Path,
+    tmp_path: str,
 ) -> None:
     """Test fastANI snakemake wrapper.
 
@@ -103,7 +104,7 @@ def test_snakemake_rule_fastani(
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_fastani.smk")
 
-    runner.run_workflow(fastani_targets, config_fastani_args)
+    runner.run_workflow(fastani_targets, config_fastani_args, workdir=Path(tmp_path))
 
     # Check output against target fixtures
     for fname in fastani_targets:

--- a/tests/snakemake/test_snakemake_slurm.py
+++ b/tests/snakemake/test_snakemake_slurm.py
@@ -167,6 +167,7 @@ def test_snakemake_rule_delta_slurm(
     anim_nucmer_targets_delta_indir: Path,
     anim_nucmer_targets_delta_slurm_outdir: Path,
     config_delta_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer delta snakemake wrapper.
 
@@ -184,7 +185,9 @@ def test_snakemake_rule_delta_slurm(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_anim.smk")
-    runner.run_workflow(anim_nucmer_targets_delta_slurm, config_delta_args)
+    runner.run_workflow(
+        anim_nucmer_targets_delta_slurm, config_delta_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in anim_nucmer_targets_delta_slurm:
@@ -200,6 +203,7 @@ def test_snakemake_rule_filter_slurm(
     anim_nucmer_targets_filter_indir: Path,
     anim_nucmer_targets_filter_slurm_outdir: Path,
     config_filter_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer filter snakemake wrapper.
 
@@ -217,7 +221,9 @@ def test_snakemake_rule_filter_slurm(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_anim.smk")
-    runner.run_workflow(anim_nucmer_targets_filter_slurm, config_filter_args)
+    runner.run_workflow(
+        anim_nucmer_targets_filter_slurm, config_filter_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in anim_nucmer_targets_filter_slurm:
@@ -233,6 +239,7 @@ def test_snakemake_rule_fastani_slurm(
     fastani_targets_slurm_outdir: Path,
     config_fastani_args: dict,
     fastani_targets_indir: Path,
+    tmp_path: str,
 ) -> None:
     """Test fastANI snakemake wrapper.
 
@@ -244,7 +251,9 @@ def test_snakemake_rule_fastani_slurm(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_fastani.smk")
-    runner.run_workflow(fastani_targets_slurm, config_fastani_args)
+    runner.run_workflow(
+        fastani_targets_slurm, config_fastani_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in fastani_targets_slurm:
@@ -260,6 +269,7 @@ def test_dnadiff_rule_delta_slurm(
     dnadiff_nucmer_targets_delta_indir: Path,
     dnadiff_nucmer_targets_delta_slurm_outdir: Path,
     config_delta_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer delta snakemake wrapper.
 
@@ -277,7 +287,9 @@ def test_dnadiff_rule_delta_slurm(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
-    runner.run_workflow(dnadiff_nucmer_targets_delta_slurm, config_delta_args)
+    runner.run_workflow(
+        dnadiff_nucmer_targets_delta_slurm, config_delta_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_nucmer_targets_delta_slurm:
@@ -293,6 +305,7 @@ def test_dnadiff_rule_filter_slurm(
     dnadiff_nucmer_targets_filter_indir: Path,
     dnadiff_nucmer_targets_filter_slurm_outdir: Path,
     config_filter_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test nucmer filter snakemake wrapper.
 
@@ -310,7 +323,9 @@ def test_dnadiff_rule_filter_slurm(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
-    runner.run_workflow(dnadiff_nucmer_targets_filter_slurm, config_filter_args)
+    runner.run_workflow(
+        dnadiff_nucmer_targets_filter_slurm, config_filter_args, workdir=Path(tmp_path)
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_nucmer_targets_filter_slurm:
@@ -326,6 +341,7 @@ def test_dnadiff_rule_show_diff_slurm(
     dnadiff_targets_showdiff_indir: Path,
     dnadiff_targets_showdiff_slurm_outdir: Path,
     config_dnadiff_showdiff_args: dict,
+    tmp_path: str,
 ) -> None:
     """Test dnadiff show-diff snakemake wrapper.
 
@@ -343,7 +359,11 @@ def test_dnadiff_rule_show_diff_slurm(
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_dnadiff.smk")
-    runner.run_workflow(dnadiff_targets_showdiff_slurm, config_dnadiff_showdiff_args)
+    runner.run_workflow(
+        dnadiff_targets_showdiff_slurm,
+        config_dnadiff_showdiff_args,
+        workdir=Path(tmp_path),
+    )
 
     # Check output against target fixtures
     for fname in dnadiff_targets_showdiff_slurm:


### PR DESCRIPTION
Currently a work in progress, aims to close #51.

In preparation for this:

* #56 avoids the possibility of tests competing to write to the same files
* #59 fixed a problem running the tests from a different directory

To try to avoid snakemake locking clashes, this writes all the test output to temp folders, and runs the tests in temp working directories (which requires changes to how the input/output locations as specified - they can't be relative to the repository root anymore).