### PR TITLE
Cap snakemake cores by available CPUs duing tests

### DIFF
--- a/tests/snakemake/conftest.py
+++ b/tests/snakemake/conftest.py
@@ -1,0 +1,64 @@
+# (c) The University of Strathclude 2024-present
+# Author: Peter Cock
+#
+# Contact:
+# peter.cock@strath.ac.uk
+#
+# Peter Cock,
+# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
+# The University of Strathclyde
+# 161 Cathedral Street
+# Glasgow
+# G4 0RE
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# (c) The University of Strathclude 2024-present
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Pytest configuration file for our snakemake tests."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def snakemake_cores() -> int:
+    """How many CPU cores/threads for snakemake, 8 unless capped by those available to use.
+
+    Returns 8 cores, unless capped by the system limits (e.g. SLURM might only give 4 cores,
+    or GitHub Actions only 2 cores).
+    """
+    try:
+        # This will take into account SLURM limits,
+        # so don't need to check $SLURM_CPUS_PER_TASK explicitly.
+        # Probably don't need to check $NSLOTS on SGE either.
+        available = len(os.sched_getaffinity(0))  # type: ignore[attr-defined]
+    except AttributeError:
+        # Unavailable on macOS or Windows, use this instead
+        # Can return None
+        cpus = os.cpu_count()
+        if not cpus:
+            msg = "Cannot determine CPU count"
+            raise RuntimeError(msg) from None
+        available = cpus
+    return min(8, available)

--- a/tests/snakemake/conftest.py
+++ b/tests/snakemake/conftest.py
@@ -41,7 +41,7 @@ import os
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def snakemake_cores() -> int:
     """How many CPU cores/threads for snakemake, 8 unless capped by those available to use.
 

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -55,6 +55,7 @@ from pyani_plus.snakemake import snakemake_scheduler
 def config_filter_args(
     anim_nucmer_targets_filter_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for testing snakemake filter rule.
 
@@ -64,7 +65,7 @@ def config_filter_args(
     return {
         "outdir": anim_nucmer_targets_filter_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
         "mode": "mum",
     }
 
@@ -73,6 +74,7 @@ def config_filter_args(
 def config_delta_args(
     anim_nucmer_targets_delta_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for testing snakemake delta rule.
 
@@ -82,7 +84,7 @@ def config_delta_args(
     return {
         "outdir": anim_nucmer_targets_delta_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
         "mode": "mum",
     }
 

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -52,6 +52,7 @@ from pyani_plus.snakemake import snakemake_scheduler
 def config_delta_args(
     dnadiff_nucmer_targets_delta_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for testing snakemake delta rule.
 
@@ -61,7 +62,7 @@ def config_delta_args(
     return {
         "outdir": dnadiff_nucmer_targets_delta_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
         "mode": "mum",
     }
 
@@ -70,6 +71,7 @@ def config_delta_args(
 def config_filter_args(
     dnadiff_nucmer_targets_filter_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for testing snakemake dnadiff filter rule.
 
@@ -79,7 +81,7 @@ def config_filter_args(
     return {
         "outdir": dnadiff_nucmer_targets_filter_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
         "mode": "mum",
     }
 
@@ -88,12 +90,13 @@ def config_filter_args(
 def config_dnadiff_showdiff_args(
     dnadiff_targets_showdiff_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for testing snakemake show_diff rule."""
     return {
         "outdir": dnadiff_targets_showdiff_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
     }
 
 
@@ -101,12 +104,13 @@ def config_dnadiff_showdiff_args(
 def config_dnadiff_showcoords_args(
     dnadiff_targets_showcoords_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for snakemake show_coords rule."""
     return {
         "outdir": dnadiff_targets_showcoords_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
     }
 
 

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -52,12 +52,13 @@ from pyani_plus.snakemake import snakemake_scheduler
 def config_fastani_args(
     fastani_targets_outdir: Path,
     input_genomes_small: Path,
+    snakemake_cores: int,
 ) -> dict:
     """Return configuration settings for testing snakemake fastANI rule."""
     return {
         "outdir": fastani_targets_outdir,
         "indir": str(input_genomes_small),
-        "cores": 8,
+        "cores": snakemake_cores,
         "fragLen": 3000,
         "kmerSize": 16,
         "minFrac": 0.2,


### PR DESCRIPTION
This is important on older machines and the GitHub Actions works (which typically have only 2 to 4 CPUs available), and when running under an HPC cluster system like SLURM.

This partly addresses point one of #62.