### PR TITLE
Helper module of get-path-and-version functions for command line tools

### DIFF
--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -124,14 +124,14 @@ def get_blastn(cmd: str | Path = "blastn") -> ExternalToolData:
     return ExternalToolData(exe_path, version)
 
 
-def get_fastani(cmd: str | Path = "fastani") -> ExternalToolData:
+def get_fastani(cmd: str | Path = "fastANI") -> ExternalToolData:
     """Return FastANI path and version as a named tuple.
 
     We expect the tool to behave as follows:
 
     .. code-block:: bash
 
-        $ fastani -v
+        $ fastANI -v
         version 1.33
 
     Here the function would return the binary path and "1.33" as the version.

--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -1,0 +1,197 @@
+# (c) The University of Strathclyde 2024-present
+# Author: Peter Cock
+#
+# Contact:
+# peter.cock@strath.ac.uk
+#
+# Peter Cock,
+# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
+# The University of Strathclyde
+# 161 Cathedral Street
+# Glasgow
+# G4 0RE
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# (c) The University of Strathclyde 2024-present
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Assorted functions for capturing command line tool version information.
+
+The pyANI-plus software relies on multiple separate command line tools
+such as ``nucmer`` from mummer3 to computer average nucleotide identity.
+This module contains helper functions to get the version of such tools,
+typically by executing them and parsing the stdout. These can be used for
+logging, as the exact versions used can sometimes be important for full
+reproducibility of results.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+
+class ExternalToolData(NamedTuple):
+    """Convenience struct for tool path and version information."""
+
+    exe_path: Path
+    version: str
+
+
+def check_cmd(cmd: str | Path) -> Path:
+    """Return full Path of given command, or raise RuntimeError."""
+    if not cmd:
+        msg = "Function check_cmd requires a command or full path."
+        raise ValueError(msg)
+
+    exe_str = shutil.which(cmd)
+    if not exe_str:
+        msg = (
+            f"{cmd} is not executable"
+            if "/" in str(cmd)
+            else f"{cmd} not found on $PATH"
+        )
+        raise RuntimeError(msg)
+
+    # Turn into an absolute path in case later use a temp working dir:
+    return Path(exe_str).absolute()
+
+
+def _get_path_and_version_output(
+    cmd: str | Path, args: list[str] | None = None
+) -> tuple[Path, str]:
+    """Determine path of command, run it with args, capture combined stdout and stderr."""
+    # Might later need to add check=True as an optional argument,
+    # e.g. NCBI legacy blast doesn't have a version option and uses return code 1.
+    exe_path = check_cmd(cmd)
+    result = subprocess.run(
+        [str(exe_path), *(args if args else [])],
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=True,
+        text=True,
+    )
+    assert isinstance(result.stdout, str)  # noqa: S101
+    return exe_path, result.stdout
+
+
+def get_blastn(cmd: str | Path = "blastn") -> ExternalToolData:
+    """Return NCBI BLAST+ blastn path and version as a named tuple.
+
+    We expect the tool to behave as follows:
+
+    .. code-block:: bash
+
+        $ blastn -version
+        blastn: 2.16.0+
+         Package: blast 2.16.0, build Aug  6 2024 15:58:44
+
+    Here the function would return the binary path and "2.16.0+" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    version cannot be inferred - this likely indicates a dramatically
+    different version of the tool with different behaviour.
+    """
+    exe_path, output = _get_path_and_version_output(cmd, ["-version"])
+
+    match = re.search(r"(?<=blastn:\s)[0-9\.]*\+", output)
+    version = match.group().strip() if match else None
+    if not version:
+        msg = f"Executable exists at {exe_path} but could not retrieve version"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)
+
+
+def get_fastani(cmd: str | Path = "fastani") -> ExternalToolData:
+    """Return FastANI path and version as a named tuple.
+
+    We expect the tool to behave as follows:
+
+    .. code-block:: bash
+
+        $ fastani -v
+        version 1.33
+
+    Here the function would return the binary path and "1.33" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    version cannot be inferred - this likely indicates a dramatically
+    different version of the tool with different behaviour.
+    """
+    exe_path, output = _get_path_and_version_output(cmd, ["-v"])
+
+    match = re.search(r"(?<=version\s)[0-9\.]*", output)
+    version = match.group().strip() if match else None
+    if not version:
+        msg = f"Executable exists at {exe_path} but could not retrieve version"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)
+
+
+def get_nucmer(cmd: str | Path = "nucmer") -> ExternalToolData:
+    """Return NUCmer path and version as a named tuple.
+
+    :param cmd:  path to NUCmer executable.
+
+    We expect NUCmer v3 to return a string on STDERR as
+
+    .. code-block:: bash
+
+        $ nucmer -V
+        nucmer
+        NUCmer (NUCleotide MUMmer) version 3.1
+
+    In this case the return value would be the full path of the
+    command, and "3.1" as the version.
+
+    For v4, the output is shorter and to STDOUT:
+
+    .. code-block:: bash
+
+        $ nucmer -V
+        4.0.0rc1
+
+    Here the function would return "4.0.0.rc1" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    version cannot be inferred - this likely indicates a dramatically
+    different version of the tool with different behaviour.
+    """
+    exe_path, output = _get_path_and_version_output(cmd, ["-V"])
+
+    version = None
+    # Try nucmer v3 style
+    match = re.search(r"(?<=version\s)[0-9\.]*", output)
+    version = match.group().strip() if match else None
+    if not version:
+        # Try nucmer v4 style
+        match = re.search(r"[0-9a-z\.]*", output)
+        version = match.group().strip() if match else None
+    if not version:
+        msg = f"Executable exists at {exe_path} but could not retrieve version"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ select = ["ALL"]
 pycodestyle.max-line-length = 120
 ignore = ["ANN101", "ANN102", "COM812", "D203", "D213", "S603"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101"]
+
 [tool.setuptools.packages.find]
 include = ["pyani_plus"]
 

--- a/tests/fixtures/tools/cutting_edge
+++ b/tests/fixtures/tools/cutting_edge
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This is a dummy test script for version checking
+echo "This is the cutting edge very lastest version!"

--- a/tests/fixtures/tools/just_one
+++ b/tests/fixtures/tools/just_one
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This is a dummy test script for version checking
+echo "1.0.0"

--- a/tests/fixtures/tools/mock_blastn
+++ b/tests/fixtures/tools/mock_blastn
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This is a dummy test script for version checking
+echo "blastn: 2.16.0+"
+echo " Package: blast 2.16.0, build Aug  6 2024 15:58:44"

--- a/tests/fixtures/tools/non_executable_script
+++ b/tests/fixtures/tools/non_executable_script
@@ -1,0 +1,3 @@
+# This is a dummy test script for version checking
+# It has no hash-bang, and is not marked as executable
+echo "1.0.0"

--- a/tests/fixtures/tools/version_one
+++ b/tests/fixtures/tools/version_one
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This is a dummy test script for version checking
+echo "version 1.0.0"

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -137,7 +137,7 @@ def test_snakemake_rule_filter(
 
     # Check output against target fixtures
     for fname in anim_nucmer_targets_filter:
-        assert compare_files_with_skip(  # noqa: S101
+        assert compare_files_with_skip(
             anim_nucmer_targets_filter_indir / fname,
             anim_nucmer_targets_filter_outdir / fname,
         )
@@ -173,7 +173,7 @@ def test_snakemake_rule_delta(
 
     # Check output against target fixtures
     for fname in anim_nucmer_targets_delta:
-        assert compare_files_with_skip(  # noqa: S101
+        assert compare_files_with_skip(
             anim_nucmer_targets_delta_indir / fname,
             anim_nucmer_targets_delta_outdir / fname,
         )

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -172,7 +172,7 @@ def test_snakemake_rule_delta(
 
     # Check output against target fixtures
     for fname in dnadiff_nucmer_targets_delta:
-        assert compare_files_with_skip(  # noqa: S101
+        assert compare_files_with_skip(
             dnadiff_nucmer_targets_delta_indir / fname,
             dnadiff_nucmer_targets_delta_outdir / fname,
         )
@@ -207,7 +207,7 @@ def test_snakemake_rule_filter(
 
     # Check output against target fixtures
     for fname in dnadiff_nucmer_targets_filter:
-        assert compare_files_with_skip(  # noqa: S101
+        assert compare_files_with_skip(
             dnadiff_nucmer_targets_filter_indir / fname,
             dnadiff_nucmer_targets_filter_outdir / fname,
         )
@@ -243,7 +243,7 @@ def test_snakemake_rule_show_diff(
 
     # Check output against target fixtures
     for fname in dnadiff_targets_showdiff:
-        assert compare_files_with_skip(  # noqa: S101
+        assert compare_files_with_skip(
             dnadiff_targets_showdiff_indir / fname,
             dnadiff_targets_showdiff_outdir / fname,
             skip=0,
@@ -282,7 +282,7 @@ def test_snakemake_rule_show_coords(
 
     # Check output against target fixtures
     for fname in dnadiff_targets_showcoords:
-        assert compare_files_with_skip(  # noqa: S101
+        assert compare_files_with_skip(
             dnadiff_targets_showcoords_indir / fname,
             dnadiff_targets_showcoords_outdir / fname,
             skip=0,

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -108,7 +108,7 @@ def test_snakemake_rule_fastani(
 
     # Check output against target fixtures
     for fname in fastani_targets:
-        assert compare_fastani_files(  # noqa: S101
+        assert compare_fastani_files(
             fastani_targets_indir / fname,
             fastani_targets_outdir / fname,
         )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -21,6 +21,14 @@ import pytest
 from pyani_plus import tools
 
 
+def test_bad_path_missing() -> None:
+    """Confirm giving an empty path fails."""
+    with pytest.raises(
+        ValueError, match="Function check_cmd requires a command or full path."
+    ):
+        tools.get_nucmer("")
+
+
 def test_bad_path() -> None:
     """Confirm giving an invalid binary path fails."""
     with pytest.raises(RuntimeError, match="/does/not/exist/nucmer is not executable"):
@@ -44,6 +52,10 @@ def test_non_exec() -> None:
 
 def test_fake_blastn() -> None:
     """Confirm simple blastn version parsing works."""
+    info = tools.get_blastn("tests/fixtures/tools/mock_blastn")  # parsed like mummer v4
+    assert info.exe_path == Path("tests/fixtures/tools/mock_blastn").resolve()
+    assert info.version == "2.16.0+"
+
     cmd = Path("tests/fixtures/tools/version_one")  # outputs "version 1.0.0"
     msg = f"Executable exists at {cmd.resolve()} but could not retrieve version"
     with pytest.raises(RuntimeError, match=msg):
@@ -78,6 +90,11 @@ def test_fake_nucmer() -> None:
     info = tools.get_nucmer("tests/fixtures/tools/version_one")  # parsed like mummer v3
     assert info.exe_path == Path("tests/fixtures/tools/version_one").resolve()
     assert info.version == "1.0.0"
+
+    cmd = Path("tests/fixtures/tools/cutting_edge")  # no numerical output
+    msg = f"Executable exists at {cmd.resolve()} but could not retrieve version"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_nucmer(cmd)
 
 
 def test_find_blastn() -> None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,108 @@
+"""Tests for the pyani_plus/tools.py module.
+
+These tests are intended to be run from the repository root using:
+
+pytest -v
+
+The ``test_bad_*`` tests look at various failures in the command itself,
+using a selection of the ``tools.get_*`` functions (which all should behave
+the same way).
+
+The ``test_fake_*`` tests call simple bash scripts which echo known strings.
+Depending on the tools, this may or may not be parsed as a valid version.
+
+The ``test_find_*`` tests are live and check for the real binary on ``$PATH``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pyani_plus import tools
+
+
+def test_bad_path() -> None:
+    """Confirm giving an invalid binary path fails."""
+    with pytest.raises(RuntimeError, match="/does/not/exist/nucmer is not executable"):
+        tools.get_nucmer("/does/not/exist/nucmer")
+
+
+def test_bad_binary_name() -> None:
+    """Confirm giving an invalid binary name fails."""
+    with pytest.raises(RuntimeError, match=r"there-is-no-blastn not found on \$PATH"):
+        tools.get_blastn("there-is-no-blastn")
+
+
+def test_non_exec() -> None:
+    """Confirm a non-executable binary fails."""
+    with pytest.raises(
+        RuntimeError,
+        match="tests/fixtures/tools/non_executable_script is not executable",
+    ):
+        tools.get_fastani("tests/fixtures/tools/non_executable_script")
+
+
+def test_fake_blastn() -> None:
+    """Confirm simple blastn version parsing works."""
+    cmd = Path("tests/fixtures/tools/version_one")  # outputs "version 1.0.0"
+    msg = f"Executable exists at {cmd.resolve()} but could not retrieve version"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_blastn(cmd)
+
+    cmd = Path("tests/fixtures/tools/just_one")  # outputs "1.0.0"
+    msg = f"Executable exists at {cmd.resolve()} but could not retrieve version"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_blastn(cmd)
+
+
+def test_fake_fastani() -> None:
+    """Confirm simple fastani version parsing works."""
+    info = tools.get_fastani(
+        "tests/fixtures/tools/version_one"
+    )  # outputs "version 1.0.0"
+    assert info.exe_path == Path("tests/fixtures/tools/version_one").resolve()
+    assert info.version == "1.0.0"
+
+    cmd = Path("tests/fixtures/tools/just_one")  # outputs just "1.0.0"
+    msg = f"Executable exists at {cmd.resolve()} but could not retrieve version"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_fastani(cmd)
+
+
+def test_fake_nucmer() -> None:
+    """Confirm simple fastani version parsing works."""
+    info = tools.get_nucmer("tests/fixtures/tools/just_one")  # parsed like mummer v4
+    assert info.exe_path == Path("tests/fixtures/tools/just_one").resolve()
+    assert info.version == "1.0.0"
+
+    info = tools.get_nucmer("tests/fixtures/tools/version_one")  # parsed like mummer v3
+    assert info.exe_path == Path("tests/fixtures/tools/version_one").resolve()
+    assert info.version == "1.0.0"
+
+
+def test_find_blastn() -> None:
+    """Confirm can find NCBI blastn if on $PATH and determine its version."""
+    # At the time of writing this dependency is NOT installed for CI testing
+    try:
+        info = tools.get_blastn("blastn")
+    except RuntimeError as err:
+        assert str(err) == "blastn not found on $PATH"  # noqa: PT017
+    else:
+        assert info.exe_path.parts[-1] == "blastn"
+        assert info.version.startswith("2.")
+
+
+def test_find_fastani() -> None:
+    """Confirm can find fastANI on $PATH and determine its version."""
+    # At the time of writing this dependency is installed for CI testing
+    info = tools.get_fastani()
+    assert info.exe_path.parts[-1] == "fastani"
+    assert info.version.startswith("1.")
+
+
+def test_find_nucmer() -> None:
+    """Confirm can find nucmer on $PATH and determine its version."""
+    # At the time of writing this dependency is installed for CI testing
+    info = tools.get_nucmer()
+    assert info.exe_path.parts[-1] == "nucmer"
+    assert info.version.startswith("3.")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -96,7 +96,7 @@ def test_find_fastani() -> None:
     """Confirm can find fastANI on $PATH and determine its version."""
     # At the time of writing this dependency is installed for CI testing
     info = tools.get_fastani()
-    assert info.exe_path.parts[-1] == "fastani"
+    assert info.exe_path.parts[-1] == "fastANI"
     assert info.version.startswith("1.")
 
 


### PR DESCRIPTION
Work towards #32.

Currently based on a mixture of the existing get_version functions in pyani (e.g. pyani/anim.py and pyani/fastani.py) and my similar code in THAPBI PICT: https://github.com/peterjc/thapbi-pict/blob/v1.0.13/thapbi_pict/versions.py

Then tweaked to pass the ruff checks and refactored to reduce duplicated code.

TODO: Do we really need to catch stdout and stderr separately?

