### PR TITLE
Run snakemake workflows with explicit binary paths

### DIFF
--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -91,15 +91,11 @@ class SnakemakeRunner:
             workflow_api = snakemake_api.workflow(
                 snakefile=snakefile,
                 resource_settings=ResourceSettings(cores=config_args["cores"]),
-                config_settings=ConfigSettings(
-                    config=config_args,
-                ),
+                config_settings=ConfigSettings(config=config_args),
                 workdir=workdir,
             )
             dag_api = workflow_api.dag(
-                dag_settings=DAGSettings(
-                    targets=targetset,
-                ),
+                dag_settings=DAGSettings(targets=targetset),
             )
             dag_api.unlock()
             dag_api.execute_workflow()

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -61,10 +61,8 @@ rule delta:
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
-    run:
-        shell(
-            "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --{params.mode} {input.genomeA} {input.genomeB}"
-        )
+    shell:
+        "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --{params.mode} {input.genomeA} {input.genomeB}"
 
 
 # The filter rule runs delta-filter wrapper for nucmer
@@ -75,7 +73,5 @@ rule filter:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
-    run:
-        shell(
-            "delta-filter -1 {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"
-        )
+    shell:
+        "delta-filter -1 {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -56,11 +56,11 @@ rule delta:
         indir=config["indir"],
         mode=config["mode"],
         outdir=config["outdir"],
-    output:
-        "{outdir}/{genomeA}_vs_{genomeB}.delta",
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
+    output:
+        "{outdir}/{genomeA}_vs_{genomeB}.delta",
     shell:
         "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --{params.mode} {input.genomeA} {input.genomeB}"
 

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -72,6 +72,7 @@ rule delta:
 rule filter:
     params:
         delta_filter=config["delta_filter"],
+        outdir=config["outdir"],
     input:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     output:

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -53,6 +53,7 @@ def get_genomeB(wildcards):
 # the calling code
 rule delta:
     params:
+        nucmer=config["nucmer"],
         indir=config["indir"],
         mode=config["mode"],
         outdir=config["outdir"],
@@ -62,16 +63,18 @@ rule delta:
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     shell:
-        "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --{params.mode} {input.genomeA} {input.genomeB}"
+        "{params.nucmer} -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --{params.mode} {input.genomeA} {input.genomeB}"
 
 
 # The filter rule runs delta-filter wrapper for nucmer
 # NOTE: This rule is used for ANIm in the context of pyani_plus. The .filter file
 # is used to calculate ANI values
 rule filter:
+    params:
+        delta_filter=config["delta_filter"],
     input:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
     shell:
-        "delta-filter -1 {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"
+        "{params.delta_filter} -1 {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"

--- a/pyani_plus/workflows/snakemake_dnadiff.smk
+++ b/pyani_plus/workflows/snakemake_dnadiff.smk
@@ -19,11 +19,11 @@ rule delta:
     params:
         indir=config["indir"],
         outdir=config["outdir"],
-    output:
-        "{outdir}/{genomeA}_vs_{genomeB}.delta",
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
+    output:
+        "{outdir}/{genomeA}_vs_{genomeB}.delta",
     shell:
         "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --maxmatch {input.genomeA} {input.genomeB}"
 

--- a/pyani_plus/workflows/snakemake_dnadiff.smk
+++ b/pyani_plus/workflows/snakemake_dnadiff.smk
@@ -24,10 +24,8 @@ rule delta:
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
-    run:
-        shell(
-            "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --maxmatch {input.genomeA} {input.genomeB}"
-        )
+    shell:
+        "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --maxmatch {input.genomeA} {input.genomeB}"
 
 
 # The filter rule runs delta-filter wrapper for nucmer
@@ -38,10 +36,8 @@ rule filter:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
-    run:
-        shell(
-            "delta-filter -m {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"
-        )
+    shell:
+        "delta-filter -m {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"
 
 
 # The filter rule runs show-diff wrapper for nucmer
@@ -52,8 +48,8 @@ rule show_diff:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.rdiff",
-    run:
-        shell("show-diff -rH {input} > {output}")
+    shell:
+        "show-diff -rH {input} > {output}"
 
 
 # The filter rule runs show-coords wrapper for nucmer
@@ -64,5 +60,5 @@ rule show_coords:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.mcoords",
-    run:
-        shell("show-coords {input} > {output}")
+    shell:
+        "show-coords {input} > {output}"

--- a/pyani_plus/workflows/snakemake_dnadiff.smk
+++ b/pyani_plus/workflows/snakemake_dnadiff.smk
@@ -17,6 +17,7 @@ def get_genomeB(wildcards):
 # the calling code
 rule delta:
     params:
+        nucmer=config["nucmer"],
         indir=config["indir"],
         outdir=config["outdir"],
     input:
@@ -25,40 +26,46 @@ rule delta:
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     shell:
-        "nucmer -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --maxmatch {input.genomeA} {input.genomeB}"
+        "{params.nucmer} -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --maxmatch {input.genomeA} {input.genomeB}"
 
 
 # The filter rule runs delta-filter wrapper for nucmer
 # NOTE: This rule is used for dnadiff in the context of pyani_plus. The .filter file
 # is used to generate delta-filter files, which are used to replicate AlignedBases.
 rule filter:
+    params:
+        delta_filter=config["delta_filter"],
     input:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
     shell:
-        "delta-filter -m {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"
+        "{params.delta_filter} -m {input} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter"
 
 
 # The filter rule runs show-diff wrapper for nucmer
 # NOTE: This rule is used for dnadiff in the context of pyani_plus. The .filter file
 # is used to generate show-diff files, which are used to replicate AlignedBases.
 rule show_diff:
+    params:
+        show_diff=config["show_diff"],
     input:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.rdiff",
     shell:
-        "show-diff -rH {input} > {output}"
+        "{params.show_diff} -rH {input} > {output}"
 
 
 # The filter rule runs show-coords wrapper for nucmer
 # NOTE: This rule is used for dnadiff in the context of pyani_plus. The .filter file
 # is used to generate show-coords files, which are used to replicate AlignedBases.
 rule show_coords:
+    params:
+        show_coords=config["show_coords"],
     input:
         "{outdir}/{genomeA}_vs_{genomeB}.filter",
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.mcoords",
     shell:
-        "show-coords {input} > {output}"
+        "{params.show_coords} {input} > {output}"

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -23,7 +23,5 @@ rule fastani:
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
-    run:
-        shell(
-            "fastANI -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"
-        )
+    shell:
+        "fastANI -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -14,6 +14,7 @@ def get_genomeB(wildcards):
 # The fastani rule runs fastANI
 rule fastani:
     params:
+        fastani=config["fastani"],
         indir=config["indir"],
         fragLen=config["fragLen"],
         kmerSize=config["kmerSize"],
@@ -24,4 +25,4 @@ rule fastani:
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.fastani",
     shell:
-        "fastANI -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"
+        "{params.fastani} -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -18,10 +18,10 @@ rule fastani:
         fragLen=config["fragLen"],
         kmerSize=config["kmerSize"],
         minFrac=config["minFrac"],
-    output:
-        "{outdir}/{genomeA}_vs_{genomeB}.fastani",
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
+    output:
+        "{outdir}/{genomeA}_vs_{genomeB}.fastani",
     shell:
         "fastANI -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.0.1"
 authors = [
     { name = "Leighton Pritchard", email = "leighton.pritchard@strath.ac.uk" },
     { name = "Angelika Kiepas", email = "angelika.kiepas@strath.ac.uk" },
+    { name = "Peter J. A. Cock", email = "peter.cock@strath.ac.uk" },
 ]
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -49,6 +49,7 @@ import pytest
 # We're testing the workflow, as called through the pyani_plus
 # wrapper code, so import only that module
 from pyani_plus.snakemake import snakemake_scheduler
+from pyani_plus.tools import get_delta_filter, get_nucmer
 
 
 @pytest.fixture
@@ -63,6 +64,8 @@ def config_filter_args(
     small set of input genomes as arguments.
     """
     return {
+        "nucmer": get_nucmer().exe_path,
+        "delta_filter": get_delta_filter().exe_path,
         "outdir": anim_nucmer_targets_filter_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,
@@ -82,6 +85,8 @@ def config_delta_args(
     small set of input genomes as arguments.
     """
     return {
+        "nucmer": get_nucmer().exe_path,
+        "delta_filter": get_delta_filter().exe_path,
         "outdir": anim_nucmer_targets_delta_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -46,6 +46,12 @@ from pathlib import Path
 import pytest
 
 from pyani_plus.snakemake import snakemake_scheduler
+from pyani_plus.tools import (
+    get_delta_filter,
+    get_nucmer,
+    get_show_coords,
+    get_show_diff,
+)
 
 
 @pytest.fixture
@@ -60,6 +66,10 @@ def config_delta_args(
     small set of input genomes as arguments.
     """
     return {
+        "nucmer": get_nucmer().exe_path,
+        "delta_filter": get_delta_filter().exe_path,
+        "show_coords": get_show_coords().exe_path,
+        "show_diff": get_show_diff().exe_path,
         "outdir": dnadiff_nucmer_targets_delta_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,
@@ -79,6 +89,10 @@ def config_filter_args(
     small set of input genomes as arguments.
     """
     return {
+        "nucmer": get_nucmer().exe_path,
+        "delta_filter": get_delta_filter().exe_path,
+        "show_coords": get_show_coords().exe_path,
+        "show_diff": get_show_diff().exe_path,
         "outdir": dnadiff_nucmer_targets_filter_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,
@@ -94,6 +108,10 @@ def config_dnadiff_showdiff_args(
 ) -> dict:
     """Return configuration settings for testing snakemake show_diff rule."""
     return {
+        "nucmer": get_nucmer().exe_path,
+        "delta_filter": get_delta_filter().exe_path,
+        "show_coords": get_show_coords().exe_path,
+        "show_diff": get_show_diff().exe_path,
         "outdir": dnadiff_targets_showdiff_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,
@@ -108,6 +126,10 @@ def config_dnadiff_showcoords_args(
 ) -> dict:
     """Return configuration settings for snakemake show_coords rule."""
     return {
+        "nucmer": get_nucmer().exe_path,
+        "delta_filter": get_delta_filter().exe_path,
+        "show_coords": get_show_coords().exe_path,
+        "show_diff": get_show_diff().exe_path,
         "outdir": dnadiff_targets_showcoords_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -46,6 +46,7 @@ from pathlib import Path
 import pytest
 
 from pyani_plus.snakemake import snakemake_scheduler
+from pyani_plus.tools import get_fastani
 
 
 @pytest.fixture
@@ -56,6 +57,7 @@ def config_fastani_args(
 ) -> dict:
     """Return configuration settings for testing snakemake fastANI rule."""
     return {
+        "fastani": get_fastani().exe_path,
         "outdir": fastani_targets_outdir,
         "indir": str(input_genomes_small),
         "cores": snakemake_cores,


### PR DESCRIPTION
Would close #32, building on #65 and #68.

[Initial draft included work now moved to #68; this branch now continues directly on from that branch via ``git rebase``]

Can now set an explicit path to binary in the snakemake workflow, rather than leaving it as ``nucmer`` and resolved via the ``$PATH`` at run time inside snakemake. This is done via the ``config`` dictionary, re-exported via ``params`` which seems to be a widely used pattern (although I'm not 100% sure why).

Adding configuration to allow the paths to be set explicitly can come later (probably via the optional argument to ``get_nucmer()`` etc). For now this still resolves via the ``$PATH`` but _before_ calling snakemake - and we can then add some logging of the full path and version identified and error handling for missing dependencies.

It seems that I wasn't able to make the first word of the shell command (i.e. the binary name) dynamic with the original ``run:`` ``shell(...)`` syntax, thus the switch to the ``shell:`` syntax.