### PR TITLE
Issue 32 continuation - get path & version functions now used in fixture generation

### DIFF
--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -195,3 +195,84 @@ def get_nucmer(cmd: str | Path = "nucmer") -> ExternalToolData:
         raise RuntimeError(msg)
 
     return ExternalToolData(exe_path, version)
+
+
+def get_delta_filter(cmd: str | Path = "delta-filter") -> ExternalToolData:
+    """Return mummer script delta-filter path and empty version as a named tuple.
+
+    :param cmd:  path to mummer delta-filter script.
+
+    Sadly the NUCmer Perl scripts have no explicit version themselves:
+
+    .. code-block:: bash
+
+        $ delta-filter -h
+        ...
+
+    Therefore the return value would be the full path of the command,
+    and "" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    help output does not match a simple check.
+    """
+    version = ""
+    exe_path, output = _get_path_and_version_output(cmd, ["-h"])
+    if "Reads a delta alignment file from either nucmer or promer" not in output:
+        msg = f"Executable exists at {exe_path} but does not seem to be from mummer"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)
+
+
+def get_show_coords(cmd: str | Path = "show-coords") -> ExternalToolData:
+    """Return mummer script show-coords path and empty version as a named tuple.
+
+    :param cmd:  path to mummer show-coords script.
+
+    Sadly the NUCmer Perl scripts have no explicit version themselves:
+
+    .. code-block:: bash
+
+        $ show-coords -h
+        ...
+
+    Therefore the return value would be the full path of the command,
+    and "" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    help output does not match a simple check.
+    """
+    version = ""
+    exe_path, output = _get_path_and_version_output(cmd, ["-h"])
+    if 'Input is the .delta output of either the "nucmer" or' not in output:
+        msg = f"Executable exists at {exe_path} but does not seem to be from mummer"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)
+
+
+def get_show_diff(cmd: str | Path = "show-diff") -> ExternalToolData:
+    """Return mummer script show-diff path and empty version as a named tuple.
+
+    :param cmd:  path to mummer show-diff script.
+
+    Sadly the NUCmer Perl scripts have no explicit version themselves:
+
+    .. code-block:: bash
+
+        $ show-diff -h
+        ...
+
+    Therefore the return value would be the full path of the command,
+    and "" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    help output does not match a simple check.
+    """
+    version = ""
+    exe_path, output = _get_path_and_version_output(cmd, ["-h"])
+    if "Outputs a list of structural differences for each sequence" not in output:
+        msg = f"Executable exists at {exe_path} but does not seem to be from mummer"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)

--- a/tests/generate_fixtures/generate_target_anim_files.py
+++ b/tests/generate_fixtures/generate_target_anim_files.py
@@ -48,7 +48,7 @@ import subprocess
 from itertools import permutations
 from pathlib import Path
 
-from pyani_plus.tools import get_nucmer
+from pyani_plus.tools import get_delta_filter, get_nucmer
 
 # Paths to directories (eg, input sequences, delta and filter)
 INPUT_DIR = Path("../fixtures/sequences")
@@ -60,7 +60,8 @@ comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 
 nucmer = get_nucmer()
-print(f"Using nucmer {nucmer.version} at {nucmer.exe_path}")
+delta_filter = get_delta_filter()
+print(f"Using nucmer {nucmer.version} at {nucmer.exe_path}")  # noqa: T201
 
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
@@ -80,7 +81,7 @@ for genomes in comparisons:
     # pipe from within the call to stdout
     with (FILTER_DIR / (stem + ".filter")).open("w") as ofh:
         subprocess.run(
-            ["delta-filter", "-1", DELTA_DIR / (stem + ".delta")],  # noqa: S607
+            [delta_filter.exe_path, "-1", DELTA_DIR / (stem + ".delta")],
             check=True,
             stdout=ofh,
         )

--- a/tests/generate_fixtures/generate_target_anim_files.py
+++ b/tests/generate_fixtures/generate_target_anim_files.py
@@ -48,6 +48,8 @@ import subprocess
 from itertools import permutations
 from pathlib import Path
 
+from pyani_plus.tools import get_nucmer
+
 # Paths to directories (eg, input sequences, delta and filter)
 INPUT_DIR = Path("../fixtures/sequences")
 DELTA_DIR = Path("../fixtures/anim/targets/delta")
@@ -57,11 +59,14 @@ FILTER_DIR = Path("../fixtures/anim/targets/filter")
 comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 
+nucmer = get_nucmer()
+print(f"Using nucmer {nucmer.version} at {nucmer.exe_path}")
+
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
     subprocess.run(
-        [  # noqa: S607
-            "nucmer",
+        [
+            nucmer.exe_path,
             "-p",
             DELTA_DIR / stem,
             "--mum",

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -52,6 +52,8 @@ import subprocess
 from itertools import permutations
 from pathlib import Path
 
+from pyani_plus.tools import get_nucmer
+
 # Paths to directories (eg. input sequences, outputs for delta, filter...)
 INPUT_DIR = Path("../fixtures/sequences")
 DELTA_DIR = Path("../fixtures/dnadiff/targets/delta")
@@ -63,11 +65,14 @@ SHOW_COORDS_DIR = Path("../fixtures/dnadiff/targets/show_coords")
 comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 
+nucmer = get_nucmer()
+print(f"Using nucmer {nucmer.version} at {nucmer.exe_path}")
+
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
     subprocess.run(
-        [  # noqa: S607
-            "nucmer",
+        [
+            nucmer.exe_path,
             "-p",
             DELTA_DIR / stem,
             "--maxmatch",

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -52,7 +52,12 @@ import subprocess
 from itertools import permutations
 from pathlib import Path
 
-from pyani_plus.tools import get_nucmer
+from pyani_plus.tools import (
+    get_delta_filter,
+    get_nucmer,
+    get_show_coords,
+    get_show_diff,
+)
 
 # Paths to directories (eg. input sequences, outputs for delta, filter...)
 INPUT_DIR = Path("../fixtures/sequences")
@@ -66,7 +71,10 @@ comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 
 nucmer = get_nucmer()
-print(f"Using nucmer {nucmer.version} at {nucmer.exe_path}")
+delta_filter = get_delta_filter()
+show_coords = get_show_coords()
+show_diff = get_show_diff()
+print(f"Using nucmer {nucmer.version} at {nucmer.exe_path}")  # noqa: T201
 
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
@@ -86,21 +94,21 @@ for genomes in comparisons:
     # pipe from within the call to stdout
     with (FILTER_DIR / (stem + ".filter")).open("w") as ofh:
         subprocess.run(
-            ["delta-filter", "-m", DELTA_DIR / (stem + ".delta")],  # noqa: S607
+            [delta_filter.exe_path, "-m", DELTA_DIR / (stem + ".delta")],
             check=True,
             stdout=ofh,
         )
 
     with (SHOW_DIFF_DIR / (stem + ".rdiff")).open("w") as ofh:
         subprocess.run(
-            ["show-diff", "-rH", FILTER_DIR / (stem + ".filter")],  # noqa: S607
+            [show_diff.exe_path, "-rH", FILTER_DIR / (stem + ".filter")],
             check=True,
             stdout=ofh,
         )
 
     with (SHOW_COORDS_DIR / (stem + ".mcoords")).open("w") as ofh:
         subprocess.run(
-            ["show-coords", FILTER_DIR / (stem + ".filter")],  # noqa: S607
+            [show_coords.exe_path, FILTER_DIR / (stem + ".filter")],
             check=True,
             stdout=ofh,
         )

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -45,6 +45,8 @@ import subprocess
 from itertools import permutations
 from pathlib import Path
 
+from pyani_plus.tools import get_fastani
+
 # Parameters (eg, input sequences, fastANI outputs, k-mer sizes...)
 INPUT_DIR = Path("../fixtures/sequences")
 FASTANI_DIR = Path("../fixtures/fastani/targets")
@@ -56,11 +58,14 @@ MIN_FRAC = 0.2
 comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 
+fastani = get_fastani()
+print(f"Using fastANI {fastani.version} at {fastani.exe_path}")
+
 for genomes in comparisons:
     stem = "_vs_".join(genomes)
     subprocess.run(
-        [  # noqa: S607
-            "fastANI",
+        [
+            fastani.exe_path,
             "-q",
             inputs[genomes[0]],
             "-r",

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -59,7 +59,7 @@ comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
 
 fastani = get_fastani()
-print(f"Using fastANI {fastani.version} at {fastani.exe_path}")
+print(f"Using fastANI {fastani.version} at {fastani.exe_path}")  # noqa: T201
 
 for genomes in comparisons:
     stem = "_vs_".join(genomes)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -97,6 +97,30 @@ def test_fake_nucmer() -> None:
         tools.get_nucmer(cmd)
 
 
+def test_fake_delta_filter() -> None:
+    """Confirm simple delta-filter output parsing works."""
+    cmd = Path("tests/fixtures/tools/just_one")  # no numerical output
+    msg = f"Executable exists at {cmd.resolve()} but does not seem to be from mummer"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_delta_filter(cmd)
+
+
+def test_fake_show_coords() -> None:
+    """Confirm simple show-coords output parsing works."""
+    cmd = Path("tests/fixtures/tools/just_one")  # no numerical output
+    msg = f"Executable exists at {cmd.resolve()} but does not seem to be from mummer"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_show_coords(cmd)
+
+
+def test_fake_show_diff() -> None:
+    """Confirm simple show-diff output parsing works."""
+    cmd = Path("tests/fixtures/tools/just_one")  # no numerical output
+    msg = f"Executable exists at {cmd.resolve()} but does not seem to be from mummer"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_show_diff(cmd)
+
+
 def test_find_blastn() -> None:
     """Confirm can find NCBI blastn if on $PATH and determine its version."""
     # At the time of writing this dependency is NOT installed for CI testing
@@ -123,3 +147,27 @@ def test_find_nucmer() -> None:
     info = tools.get_nucmer()
     assert info.exe_path.parts[-1] == "nucmer"
     assert info.version.startswith("3.")
+
+
+def test_find_delta_filter() -> None:
+    """Confirm can find mummer delta-filter on $PATH."""
+    # At the time of writing this dependency is installed for CI testing
+    info = tools.get_delta_filter()
+    assert info.exe_path.parts[-1] == "delta-filter"
+    assert info.version == ""
+
+
+def test_find_show_coords() -> None:
+    """Confirm can find mummer show-coords on $PATH."""
+    # At the time of writing this dependency is installed for CI testing
+    info = tools.get_show_coords()
+    assert info.exe_path.parts[-1] == "show-coords"
+    assert info.version == ""
+
+
+def test_find_show_diff() -> None:
+    """Confirm can find mummer show-diff on $PATH."""
+    # At the time of writing this dependency is installed for CI testing
+    info = tools.get_show_diff()
+    assert info.exe_path.parts[-1] == "show-diff"
+    assert info.version == ""


### PR DESCRIPTION
Continues work towards #32, building on the work merged in #65, by adding functions for the mummer scripts, and now uses all these functions in the fixture generator scripts.

This extracts the non-workflow commits from the WIP on #67, and applies the feedback from there (e.g. using ``print(...)`` with ``# noqa: T201`` in the generator scripts), and gets the test coverage up to full.

This allows us to remove the ``# noqa: S607`` in the generator scripts.