### PR TITLE
Test duplicate FASTA stems are caught by snakemake_scheduler

### DIFF
--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -60,7 +60,9 @@ def check_input_stems(indir: str) -> dict[str, Path]:
         duplicates = [
             item for item in stems if stems.count(item) > 1 and item in set(stems)
         ]
-        msg = f"Duplicated stems found for {list(set(duplicates))}. Please investigate."
+        msg = (
+            f"Duplicated stems found for {sorted(set(duplicates))}. Please investigate."
+        )
         raise ValueError(msg)
 
     return input_files


### PR DESCRIPTION
Should bring the test coverage reported by CodeCov up to 100% by testing the three lines of ``check_input_stems`` dealing with duplicate input sequence filename stems.