### PR TITLE
Standardise copyright headers in Python files

### DIFF
--- a/pyani_plus/__init__.py
+++ b/pyani_plus/__init__.py
@@ -1,3 +1,39 @@
+# Copyright (c) 2024-present University of Strathclyde
+# Author: Leighton Pritchard
+#
+# Contact:
+# leighton.pritchard@strath.ac.uk
+#
+# Leighton Pritchard,
+# Strathclyde Institute for Pharmacy and Biomedical Sciences,
+# Cathedral Street,
+# Glasgow,
+# G4 0RE
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# Copyright (c) 2024-present University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 """pyANI-plus.
 
 This is ``pyANI-plus``, an application and Python module for whole-genome

--- a/pyani_plus/snakemake/__init__.py
+++ b/pyani_plus/snakemake/__init__.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2019-
+# Copyright (c) 2019-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -1,4 +1,4 @@
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Peter Cock
 #
 # Contact:
@@ -15,7 +15,7 @@
 #
 # The MIT License
 #
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/workflows/__init__.py
+++ b/pyani_plus/workflows/__init__.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2019-
+# Copyright (c) 2019-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:
@@ -15,7 +15,7 @@
 #
 # The MIT License
 #
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/generate_fixtures/__init__.py
+++ b/tests/generate_fixtures/__init__.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/generate_fixtures/generate_target_anim_files.py
+++ b/tests/generate_fixtures/generate_target_anim_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/snakemake/__init__.py
+++ b/tests/snakemake/__init__.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/snakemake/conftest.py
+++ b/tests/snakemake/conftest.py
@@ -1,4 +1,4 @@
-# (c) The University of Strathclude 2024-present
+# (c) The University of Strathclyde 2024-present
 # Author: Peter Cock
 #
 # Contact:
@@ -15,7 +15,7 @@
 #
 # The MIT License
 #
-# (c) The University of Strathclude 2024-present
+# (c) The University of Strathclyde 2024-present
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/conftest.py
+++ b/tests/snakemake/conftest.py
@@ -1,4 +1,4 @@
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Peter Cock
 #
 # Contact:
@@ -15,7 +15,7 @@
 #
 # The MIT License
 #
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/test_scheduler.py
+++ b/tests/snakemake/test_scheduler.py
@@ -1,3 +1,39 @@
+# Copyright (c) 2024-present University of Strathclyde
+# Author: Peter Cock
+#
+# Contact:
+# peter.cock@strath.ac.uk
+#
+# Peter Cock,
+# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
+# The University of Strathclyde
+# 161 Cathedral Street
+# Glasgow
+# G4 0RE
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# Copyright (c) 2024-present University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Tests for the pyani_plus/snakemake/snakemake_scheduler.py module.
 
 These tests are intended to be run from the repository root using:

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -1,4 +1,4 @@
-# (c) University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Leighton Pritchard
 #
 # Contact:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,39 @@
+# (c) The University of Strathclyde 2024-present
+# Author: Peter Cock
+#
+# Contact:
+# peter.cock@strath.ac.uk
+#
+# Peter Cock,
+# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
+# The University of Strathclyde
+# 161 Cathedral Street
+# Glasgow
+# G4 0RE
+# Scotland,
+# UK
+#
+# The MIT License
+#
+# (c) The University of Strathclyde 2024-present
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 """Tests for the pyani_plus/tools.py module.
 
 These tests are intended to be run from the repository root using:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,4 @@
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 # Author: Peter Cock
 #
 # Contact:
@@ -15,7 +15,7 @@
 #
 # The MIT License
 #
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024-present University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I realised some of the Python files were missing a copyright and license block, and there were inconsistencies in the others.

There is scope for a pre-commit hook to enforce this in future.