### PR TITLE
Simpler copyright and license headers, with pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,14 @@ repos:
     - id: mypy
       # equivalent to "files" in .mypy.ini
       files: '^(pyani_plus|tests)/'
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.5
+  hooks:
+    - id: insert-license
+      name: Check MIT license
+      files: \.(py|sh|smk)$
+      args:
+        - "--license-filepath=LICENSE"
+        - "--use-current-year"
+        - "--detect-license-in-X-top-lines=20"
+        - "--no-extra-eol"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2024-present University of Strathclyde
+Copyright (c) 2024 University of Strathclyde
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/__init__.py
+++ b/pyani_plus/__init__.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/pyani_plus/__init__.py
+++ b/pyani_plus/__init__.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/snakemake/__init__.py
+++ b/pyani_plus/snakemake/__init__.py
@@ -14,7 +14,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/pyani_plus/snakemake/snakemake_scheduler.py
+++ b/pyani_plus/snakemake/snakemake_scheduler.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/utils.py
+++ b/pyani_plus/utils.py
@@ -1,21 +1,6 @@
-# (c) The University of Strathclyde 2024-present
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/workflows/__init__.py
+++ b/pyani_plus/workflows/__init__.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2019-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G1 1XQ
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/pyani_plus/workflows/__init__.py
+++ b/pyani_plus/workflows/__init__.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -1,17 +1,3 @@
-# (c) University of Strathclyde 2024-present
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/workflows/snakemake_dnadiff.smk
+++ b/pyani_plus/workflows/snakemake_dnadiff.smk
@@ -1,3 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2024-present University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 from pyani_plus.snakemake import snakemake_scheduler
 
 indir_files = snakemake_scheduler.check_input_stems(config["indir"])

--- a/pyani_plus/workflows/snakemake_dnadiff.smk
+++ b/pyani_plus/workflows/snakemake_dnadiff.smk
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -1,3 +1,24 @@
+# The MIT License
+#
+# Copyright (c) 2024-present University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 from pyani_plus.snakemake import snakemake_scheduler
 
 indir_files = snakemake_scheduler.check_input_stems(config["indir"])

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/generate_fixtures/__init__.py
+++ b/tests/generate_fixtures/__init__.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/generate_fixtures/__init__.py
+++ b/tests/generate_fixtures/__init__.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/generate_fixtures/generate_target_anim_files.py
+++ b/tests/generate_fixtures/generate_target_anim_files.py
@@ -2,7 +2,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/generate_fixtures/generate_target_anim_files.py
+++ b/tests/generate_fixtures/generate_target_anim_files.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -2,7 +2,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -2,7 +2,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -1,19 +1,5 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/__init__.py
+++ b/tests/snakemake/__init__.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/__init__.py
+++ b/tests/snakemake/__init__.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/conftest.py
+++ b/tests/snakemake/conftest.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/conftest.py
+++ b/tests/snakemake/conftest.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/test_scheduler.py
+++ b/tests/snakemake/test_scheduler.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/test_scheduler.py
+++ b/tests/snakemake/test_scheduler.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Leighton Pritchard
-#
-# Contact:
-# leighton.pritchard@strath.ac.uk
-#
-# Leighton Pritchard,
-# Strathclyde Institute for Pharmacy and Biomedical Sciences,
-# Cathedral Street,
-# Glasgow,
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,18 +1,3 @@
-# Copyright (c) 2024-present University of Strathclyde
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
 # Copyright (c) 2024-present University of Strathclyde

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,6 @@
 # The MIT License
 #
-# Copyright (c) 2024-present University of Strathclyde
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,21 +1,6 @@
-# (c) The University of Strathclyde 2024-present
-# Author: Peter Cock
-#
-# Contact:
-# peter.cock@strath.ac.uk
-#
-# Peter Cock,
-# Strathclyde Institute of Pharmaceutical and Biomedical Sciences
-# The University of Strathclyde
-# 161 Cathedral Street
-# Glasgow
-# G4 0RE
-# Scotland,
-# UK
-#
 # The MIT License
 #
-# (c) The University of Strathclyde 2024-present
+# Copyright (c) 2024 University of Strathclyde
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Follows on from #74 based on our discussion.

This will work for now, but automatically checking matches when there are multiple lines of copyright holders will potentially be a problem. One simple solution is to use something like "Copyright (c) 2024 University of Strathclyde & external contributors" with additional comments above/below the standard block if needed.