### PR TITLE
Enable doctests within pytest framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ fixtures:
 
 # Run tests
 # When the tests complete, the coverage output will be opened in a browser
+# See also pyproject.toml setting addopts which adds --doctest-modules etc
 test:
 	@python -m pytest -n auto --cov-report=html --cov=pyani_plus -v tests/ && open htmlcov/index.html
 

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -233,8 +233,12 @@ class Comparison(Base):
 def connect_to_db(dbpath: Path, *, echo: bool = False) -> Session:
     """Create/connect to existing DB, and return session bound to it.
 
-    >>> session = connect_to_db("/tmp/example.sqlite", echo=True)
+    >>> session = connect_to_db("/tmp/pyani-plus-example.sqlite", echo=True)
+    20...
     """
+    # Note with echo=True, the output starts yyyy-mm-dd and sadly
+    # using just ... is interpreted as a continuation of the >>>
+    # prompt rather than saying any output is fine with ELLIPSIS mode.
     engine = create_engine(url=f"sqlite:///{dbpath}", echo=echo)
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "pyani-plus"
 version = "0.0.1"
@@ -19,6 +15,13 @@ classifiers = [
 ]
 dependencies = ["snakemake", "sqlalchemy"]
 
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["pyani_plus"]
+
 [tool.ruff.lint]
 select = ["ALL"]
 pycodestyle.max-line-length = 120
@@ -27,8 +30,14 @@ ignore = ["ANN101", "ANN102", "COM812", "D203", "D213", "S603"]
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]
 
-[tool.setuptools.packages.find]
-include = ["pyani_plus"]
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = ["--doctest-modules"]
+testpaths = [
+    "tests",
+    "pyani_plus",
+]
+doctest_optionflags = ["ELLIPSIS"]
 
 [project.urls]
 Homepage = "https://github.com/pyani-plus/pyani-plus"


### PR DESCRIPTION
Currently these isn't much scope for using doctests, beyond some minimal examples in the ORM perhaps - currently most of the other code needs input directories or calls external tools.

However, this seems useful in the medium term.