### PR TITLE
helper functions in db_orm.py for importing data

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -136,7 +136,7 @@ class Configuration(Base):
     AND the run configuration.
     """
 
-    __tablename__ = "configuration"
+    __tablename__ = "configurations"
 
     __table_args__ = (
         UniqueConstraint(
@@ -211,7 +211,7 @@ class Comparison(Base):
     subject: Mapped[Genome] = relationship(Genome, foreign_keys=[subject_hash])
 
     configuration_id: Mapped[int] = mapped_column(
-        ForeignKey("configuration.configuration_id"), nullable=False
+        ForeignKey("configurations.configuration_id"), nullable=False
     )
     configuration: Mapped[Configuration] = relationship(
         Configuration, foreign_keys=[configuration_id]
@@ -295,7 +295,7 @@ class Run(Base):
     run_id: Mapped[int] = mapped_column(primary_key=True)
 
     configuration_id: Mapped[int] = mapped_column(
-        ForeignKey("configuration.configuration_id"), nullable=False
+        ForeignKey("configurations.configuration_id"), nullable=False
     )
     configuration: Mapped[Configuration] = relationship(
         Configuration, foreign_keys=[configuration_id]

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -634,6 +634,32 @@ def add_genome(session: Session, fasta_filename: Path | str, md5: str) -> Genome
     raise IntegrityError(msg)
 
 
+def add_run(  # noqa: PLR0913
+    session: Session,
+    configuration: Configuration,
+    cmdline: str,
+    status: str,
+    name: str,
+    date: datetime.datetime | None = None,
+    genomes: list[Genome] | None = None,
+) -> Run:
+    """Add and return a new run table entry.
+
+    Will make a near-duplicate if there is a match there already!
+    """
+    run = Run(
+        configuration_id=configuration.configuration_id,
+        cmdline=cmdline,
+        status=status,
+        name=name,
+        date=date if date else datetime.datetime.now(tz=datetime.UTC),
+        genomes=genomes if genomes else [],
+    )
+    session.add(run)
+    session.commit()
+    return run
+
+
 def add_comparison(  # noqa: PLR0913
     session: Session,
     configuration_id: int,

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -493,11 +493,16 @@ def connect_to_db(dbpath: Path | str, *, echo: bool = False) -> Session:
 
     >>> session = connect_to_db("/tmp/pyani-plus-example.sqlite", echo=True)
     20...
+
+    Will accept the special SQLite3 value of ":memory:" for an in-memory
+    database:
+
+    >>> session = connect_to_db(":memory:")
     """
     # Note with echo=True, the output starts yyyy-mm-dd and sadly
     # using just ... is interpreted as a continuation of the >>>
     # prompt rather than saying any output is fine with ELLIPSIS mode.
-    engine = create_engine(url=f"sqlite:///{dbpath}", echo=echo)
+    engine = create_engine(url=f"sqlite:///{dbpath!s}", echo=echo)
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)()
 

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -27,11 +27,13 @@ Python objects.
 """
 
 import datetime
+import platform
 from io import StringIO
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from Bio.SeqIO.FastaIO import SimpleFastaParser
 from sqlalchemy import (
     ForeignKey,
     UniqueConstraint,
@@ -486,7 +488,7 @@ class Run(Base):
         )
 
 
-def connect_to_db(dbpath: Path, *, echo: bool = False) -> Session:
+def connect_to_db(dbpath: Path | str, *, echo: bool = False) -> Session:
     """Create/connect to existing DB, and return session bound to it.
 
     >>> session = connect_to_db("/tmp/pyani-plus-example.sqlite", echo=True)
@@ -498,3 +500,102 @@ def connect_to_db(dbpath: Path, *, echo: bool = False) -> Session:
     engine = create_engine(url=f"sqlite:///{dbpath}", echo=echo)
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine)()
+
+
+def add_genome(session: Session, fasta_filename: Path | str, md5: str) -> bool:
+    """Add a FASTA file to the genomes table if not already there.
+
+    Assumes and trusts the MD5 checksum given matches.
+
+    Returns true if the genome was added (but note session.commit() does not
+    get called here), false if already there:
+
+    >>> session = connect_to_db(":memory:")
+    >>> from pyani_plus.utils import file_md5sum
+    >>> fasta = "tests/fixtures/sequences/NC_002696.fasta"
+    >>> add_genome(session, fasta, file_md5sum(fasta))
+    True
+    >>> add_genome(session, fasta, file_md5sum(fasta))  # already there
+    False
+    """
+    if session.query(Genome).where(Genome.genome_hash == md5).count():
+        return False
+
+    length = 0
+    description = None
+    with Path(fasta_filename).open() as handle:
+        for title, seq in SimpleFastaParser(handle):
+            length += len(seq)
+            if description is None:
+                description = title  # Just use first entry
+    genome = Genome(
+        genome_hash=md5,
+        path=str(fasta_filename),
+        length=length,
+        description=description,
+    )
+    session.add(genome)
+    return True
+
+
+def add_comparison(  # noqa: PLR0913
+    session: Session,
+    configuration_id: int,
+    query_hash: str,
+    subject_hash: str,
+    identity: float,
+    aln_length: int,
+    sim_errors: int | None = None,
+    cov_query: float | None = None,
+    cov_subject: float | None = None,
+    uname: platform.uname_result | None = None,
+) -> bool:
+    """Add a comparison to the comparison table if not already there.
+
+    This assumes the configuration and both the query and subject are already in
+    the linked tables. If not, addition will fail with an integrity error:
+
+    >>> session = connect_to_db(":memory:")
+    >>> add_comparison(session, 1, "abcd", "cdef", 0.99, 12345)
+    True
+    >>> add_comparison(session, 1, "abcd", "cdef", 0.98, 12340)  # Already there
+    False
+
+    By default the uname values for the current platform are used (i.e. this assumes
+    the computed values were computed locally on the same machine).
+
+    Returns true if the comparison was added (but note session.commit() does not
+    get called here), false if already there. This will NOT alter a pre-existing
+    entry even if there are differences (e.g. expected like operating system, or
+    unexpected like percentage identity).
+    """
+    if (
+        session.query(Comparison)
+        .where(Comparison.configuration_id == configuration_id)
+        .where(Comparison.query_hash == query_hash)
+        .where(Comparison.subject_hash == subject_hash)
+        .count()
+    ):
+        # We could sanity check the entry there matches... that might reveal
+        # a cross-platform difference, or a change to historical behaviour?
+        return False
+
+    if uname is None:
+        # This function caches the return value, so repeat calls are fast:
+        uname = platform.uname()
+
+    comp = Comparison(
+        configuration_id=configuration_id,
+        query_hash=query_hash,
+        subject_hash=subject_hash,
+        identity=identity,
+        aln_length=aln_length,
+        sim_errors=sim_errors,
+        cov_query=cov_query,
+        cov_subject=cov_subject,
+        uname_system=uname.system,
+        uname_release=uname.release,
+        uname_machine=uname.machine,
+    )
+    session.add(comp)
+    return True

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -570,7 +570,9 @@ def add_genome(session: Session, fasta_filename: Path | str, md5: str) -> Genome
     >>> session = connect_to_db(":memory:")
     >>> from pyani_plus.utils import file_md5sum
     >>> fasta = "tests/fixtures/sequences/NC_002696.fasta"
-    >>> add_genome(session, fasta, file_md5sum(fasta))
+    >>> genome = add_genome(session, fasta, file_md5sum(fasta))
+    >>> genome.genome_hash
+    'f19cb07198a41a4406a22b2f57a6b5e7'
     """
     genome = session.query(Genome).where(Genome.genome_hash == md5).one_or_none()
     if genome is not None:
@@ -611,7 +613,9 @@ def add_comparison(  # noqa: PLR0913
     the linked tables. If not, addition will fail with an integrity error:
 
     >>> session = connect_to_db(":memory:")
-    >>> add_comparison(session, 1, "abcd", "cdef", 0.99, 12345)
+    >>> comp = add_comparison(session, 1, "abcd", "cdef", 0.99, 12345)
+    >>> comp.identity
+    0.99
 
     By default the uname values for the current platform are used (i.e. this assumes
     the computed values were computed locally on the same machine).

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -48,10 +48,7 @@ def log_genome(
     Any pre-existing duplicate FASTA entries are left as is.
     """
     print(f"Logging to {database}")  # noqa: T201
-    db = Path(database)
-    if not db.is_file():
-        sys.exit(f"ERROR - Database {db} does not exist")
-    session = db_orm.connect_to_db(db)
+    session = db_orm.connect_to_db(database)
 
     file_total = 0
     if fasta:
@@ -101,10 +98,7 @@ def log_comparison(  # noqa: PLR0913
 ) -> int:
     """Log a single pyANI-plus pairwise comparison to the database."""
     print(f"Logging to {database}")  # noqa: T201
-    db = Path(database)
-    if not db.is_file():
-        sys.exit(f"ERROR - Database {db} does not exist")
-    session = db_orm.connect_to_db(db)
+    session = db_orm.connect_to_db(database)
 
     config = db_orm.add_configuration(
         session, method, program, version, fragsize, maxmatch, kmersize, minmatch
@@ -206,10 +200,7 @@ def log_fastani(  # noqa: PLR0913
         )
 
     print(f"Logging to {database}")  # noqa: T201
-    db = Path(database)
-    if not db.is_file():
-        sys.exit(f"ERROR - Database {db} does not exist")
-    session = db_orm.connect_to_db(db)
+    session = db_orm.connect_to_db(database)
 
     config = db_orm.add_configuration(
         session,

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -39,6 +39,45 @@ app = typer.Typer()
 
 
 @app.command()
+def log_configuration(  # noqa: PLR0913
+    database: Annotated[str, typer.Option(help="Path to pyANI-plus SQLite3 database")],
+    method: Annotated[str, typer.Option(help="Method, e.g. ANIm")],
+    program: Annotated[str, typer.Option(help="Program, e.g. nucmer")],
+    version: Annotated[str, typer.Option(help="Program version, e.g. 3.1")],
+    fragsize: Annotated[
+        int | None, typer.Option(help="Optional method fragment size")
+    ] = None,
+    maxmatch: Annotated[
+        bool | None, typer.Option(help="Comparison method max-match")
+    ] = None,
+    kmersize: Annotated[
+        int | None, typer.Option(help="Comparison method k-mer size")
+    ] = None,
+    minmatch: Annotated[
+        float | None, typer.Option(help="Comparison method min-match")
+    ] = None,
+) -> int:
+    """Log this as a known configuration in the database.
+
+    Any pre-existing configuration entry is left as is.
+    """
+    print(f"Logging to {database}")  # noqa: T201
+    session = db_orm.connect_to_db(database)
+    config = db_orm.add_configuration(
+        session, method, program, version, fragsize, maxmatch, kmersize, minmatch
+    )
+    if config.configuration_id is None:
+        sys.exit("Error with configuration table?")
+    session.commit()  # should be redundant
+    print(  # noqa: T201
+        f"Configuration identifier {config.configuration_id}"
+    )
+    session.close()
+
+    return 0
+
+
+@app.command()
 def log_genome(
     fasta: Annotated[list[str], typer.Argument(help="Path to FASTA file(s)")],
     database: Annotated[str, typer.Option(help="Path to pyANI-plus SQLite3 database")],

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -103,7 +103,6 @@ def log_comparison(  # noqa: PLR0913
     config = db_orm.add_configuration(
         session, method, program, version, fragsize, maxmatch, kmersize, minmatch
     )
-    session.commit()
     if config.configuration_id is None:
         sys.exit("Error with configuration table?")
 
@@ -211,7 +210,6 @@ def log_fastani(  # noqa: PLR0913
         kmersize=kmersize,  # aka --k
         minmatch=minmatch,  # aka --minFraction
     )
-    session.commit()
     if config.configuration_id is None:
         sys.exit("Error with configuration table?")
 
@@ -239,6 +237,7 @@ def log_fastani(  # noqa: PLR0913
         cov_query=cov_query,
         cov_subject=cov_subject,
     )
+
     session.commit()
     return 0
 

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -1,0 +1,159 @@
+# The MIT License
+#
+# Copyright (c) 2024 University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Implements the private command line interface (CLI) used internally.
+
+The commands defined here are intended to be used from within pyANI-plus via
+snakemake, for example from worker nodes, to log results to the database.
+"""
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.progress import track
+
+from pyani_plus import db_orm
+from pyani_plus.utils import file_md5sum
+
+app = typer.Typer()
+
+
+@app.command()
+def log_genome(
+    fasta: Annotated[list[str], typer.Argument(help="Path to FASTA file(s)")],
+    database: Annotated[str, typer.Option(help="Path to pyANI-plus SQLite3 database")],
+) -> int:
+    """For given FASTA file(s), compute their MD5 checksum, and log them in the database.
+
+    Any pre-existing duplicate FASTA entries are left as is.
+    """
+    print(f"Logging to {database}")  # noqa: T201
+    db = Path(database)
+    if not db.is_file():
+        sys.exit(f"ERROR - Database {db} does not exist")
+    session = db_orm.connect_to_db(db)
+
+    file_total = 0
+    file_skip = 0
+    if fasta:
+        for filename in track(fasta, description="Processing..."):
+            file_total += 1
+            md5 = file_md5sum(filename)
+            if not db_orm.add_genome(session, filename, md5):
+                file_skip += 1
+    session.commit()
+    session.close()
+    print(  # noqa: T201
+        f"Processed {file_total} FASTA files, skipped {file_skip}, recorded {file_total-file_skip}"
+    )
+
+    return 0
+
+
+@app.command()
+def log_comparison(  # noqa: PLR0913
+    database: Annotated[str, typer.Option(help="Path to pyANI-plus SQLite3 database")],
+    # These are for the comparison table
+    query_fasta: Annotated[str, typer.Option(help="Path to query FASTA file")],
+    subject_fasta: Annotated[str, typer.Option(help="Path to subject FASTA file")],
+    identity: Annotated[
+        float, typer.Option(help="Percent identity (float from 0 to 1)")
+    ],
+    aln_length: Annotated[int, typer.Option(help="Alignment length")],
+    # These are all for the configuration table:
+    method: Annotated[str, typer.Option(help="Comparison method")],
+    program: Annotated[str, typer.Option(help="Comparison program name")],
+    version: Annotated[str, typer.Option(help="Comparison program version")],
+    fragsize: Annotated[
+        str | None, typer.Option(help="Comparison method fragment size")
+    ] = None,
+    maxmatch: Annotated[
+        str | None, typer.Option(help="Comparison method max-match")
+    ] = None,
+    kmersize: Annotated[
+        str | None, typer.Option(help="Comparison method k-mer size")
+    ] = None,
+    minmatch: Annotated[
+        str | None, typer.Option(help="Comparison method min-match")
+    ] = None,
+) -> int:
+    """Log a single pyANI-plus pairwise comparison to the database."""
+    print(f"Logging to {database}")  # noqa: T201
+    db = Path(database)
+    if not db.is_file():
+        sys.exit(f"ERROR - Database {db} does not exist")
+    session = db_orm.connect_to_db(db)
+
+    config = (
+        session.query(db_orm.Configuration)
+        .where(db_orm.Configuration.method == method)
+        .where(db_orm.Configuration.program == program)
+        .where(db_orm.Configuration.version == version)
+        .where(db_orm.Configuration.fragsize == fragsize)
+        .where(db_orm.Configuration.maxmatch == maxmatch)
+        .where(db_orm.Configuration.kmersize == kmersize)
+        .where(db_orm.Configuration.minmatch == minmatch)
+        .one_or_none()
+    )
+    if config is None:
+        config = db_orm.Configuration(
+            method=method,
+            program=program,
+            version=version,
+            fragsize=fragsize,
+            maxmatch=maxmatch,
+            kmersize=kmersize,
+            minmatch=minmatch,
+        )
+        session.add(config)
+        session.commit()
+        print(f"Adding novel configuration {config.configuration_id} to database")  # noqa: T201
+    else:
+        print(f"Using pre-existing configuration {config.configuration_id} in database")  # noqa: T201
+
+    query_md5 = file_md5sum(query_fasta)
+    subject_md5 = file_md5sum(subject_fasta)
+
+    # Could log if the FASTA entries were new?
+    if db_orm.add_genome(session, query_fasta, query_md5):
+        print(f"Adding novel FASTA hash {query_md5} to database")  # noqa: T201
+    if db_orm.add_genome(session, subject_fasta, subject_md5):
+        print(f"Adding novel FASTA hash {subject_md5} to database")  # noqa: T201
+    new = db_orm.add_comparison(
+        session,
+        configuration_id=config.configuration_id,
+        query_hash=query_md5,
+        subject_hash=subject_md5,
+        identity=identity,
+        aln_length=aln_length,
+    )
+    session.commit()
+    if new:
+        print(f"{query_fasta} vs {subject_fasta} {method} logged")  # noqa: T201
+    else:
+        print(f"{query_fasta} vs {subject_fasta} {method} existed")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(app())

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -268,7 +268,7 @@ def parse_fastani_file(filename: Path) -> tuple[Path, Path, float, int, int]:
     We assume that all fastANI comparisons are pairwise: one query and
     one reference file. The fastANI file should contain a single line.
 
-    fsatANI *can* produce multi-line output, if a list of query/reference
+    fastANI *can* produce multi-line output, if a list of query/reference
     files is given to it.
     """
     with filename.open() as handle:

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -160,6 +160,8 @@ def parse_fastani_file(filename: Path) -> tuple[Path, Path, float, int, int]:
     )
 
 
+# Ought we switch the command line arguments here to match fastANI naming?
+# Note this omits maxmatch
 @app.command()
 def log_fastani(  # noqa: PLR0913
     database: Annotated[str, typer.Option(help="Path to pyANI-plus SQLite3 database")],
@@ -170,9 +172,6 @@ def log_fastani(  # noqa: PLR0913
     # These are all for the configuration table:
     fragsize: Annotated[
         int | None, typer.Option(help="Comparison method fragment size")
-    ] = None,
-    maxmatch: Annotated[
-        bool | None, typer.Option(help="Comparison method max-match")
     ] = None,
     kmersize: Annotated[
         int | None, typer.Option(help="Comparison method k-mer size")
@@ -207,10 +206,10 @@ def log_fastani(  # noqa: PLR0913
         method="fastANI",
         program=fastani_tool.exe_path.stem,
         version=fastani_tool.version,
-        fragsize=fragsize,
-        maxmatch=maxmatch,
-        kmersize=kmersize,
-        minmatch=minmatch,
+        fragsize=fragsize,  # aka --fragLen
+        maxmatch=None,
+        kmersize=kmersize,  # aka --k
+        minmatch=minmatch,  # aka --minFraction
     )
     session.commit()
     if config.configuration_id is None:

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -56,11 +56,18 @@ def log_configuration(  # noqa: PLR0913
     minmatch: Annotated[
         float | None, typer.Option(help="Comparison method min-match")
     ] = None,
+    create_db: Annotated[  # noqa: FBT002
+        bool, typer.Option(help="Create database if does not exist")
+    ] = False,
 ) -> int:
     """Log this as a known configuration in the database.
 
     Any pre-existing configuration entry is left as is.
     """
+    if database != ":memory:" and not create_db and not Path(database).is_file():
+        msg = f"ERROR: Database {database} does not exist, but not using --create-db"
+        sys.exit(msg)
+
     print(f"Logging to {database}")  # noqa: T201
     session = db_orm.connect_to_db(database)
     config = db_orm.add_configuration(
@@ -81,11 +88,18 @@ def log_configuration(  # noqa: PLR0913
 def log_genome(
     fasta: Annotated[list[str], typer.Argument(help="Path to FASTA file(s)")],
     database: Annotated[str, typer.Option(help="Path to pyANI-plus SQLite3 database")],
+    create_db: Annotated[  # noqa: FBT002
+        bool, typer.Option(help="Create database if does not exist")
+    ] = False,
 ) -> int:
     """For given FASTA file(s), compute their MD5 checksum, and log them in the database.
 
     Any pre-existing duplicate FASTA entries are left as is.
     """
+    if database != ":memory:" and not create_db and not Path(database).is_file():
+        msg = f"ERROR: Database {database} does not exist, but not using --create-db"
+        sys.exit(msg)
+
     print(f"Logging to {database}")  # noqa: T201
     session = db_orm.connect_to_db(database)
 
@@ -134,8 +148,15 @@ def log_comparison(  # noqa: PLR0913
     sim_errors: Annotated[int | None, typer.Option(help="Alignment length")] = None,
     cov_query: Annotated[float | None, typer.Option(help="Alignment length")] = None,
     cov_subject: Annotated[float | None, typer.Option(help="Alignment length")] = None,
+    create_db: Annotated[  # noqa: FBT002
+        bool, typer.Option(help="Create database if does not exist")
+    ] = False,
 ) -> int:
     """Log a single pyANI-plus pairwise comparison to the database."""
+    if database != ":memory:" and not create_db and not Path(database).is_file():
+        msg = f"ERROR: Database {database} does not exist, but not using --create-db"
+        sys.exit(msg)
+
     print(f"Logging to {database}")  # noqa: T201
     session = db_orm.connect_to_db(database)
 
@@ -217,6 +238,9 @@ def log_fastani(  # noqa: PLR0913
     minmatch: Annotated[
         float | None, typer.Option(help="Comparison method min-match")
     ] = None,
+    create_db: Annotated[  # noqa: FBT002
+        bool, typer.Option(help="Create database if does not exist")
+    ] = False,
 ) -> int:
     """Log a single pyANI-plus fastANI pairwise comparison to the database."""
     # Assuming this will match as expect this script to be called right
@@ -235,6 +259,10 @@ def log_fastani(  # noqa: PLR0913
         sys.exit(
             f"ERROR: Given --subject-fasta {subject_fasta} but query in fastANI file was {used_subject}"
         )
+
+    if database != ":memory:" and not create_db and not Path(database).is_file():
+        msg = f"ERROR: Database {database} does not exist, but not using --create-db"
+        sys.exit(msg)
 
     print(f"Logging to {database}")  # noqa: T201
     session = db_orm.connect_to_db(database)

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -46,5 +46,12 @@ rule fastani:
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.fastani",
     shell:
-        "{params.fastani} -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"
-        ".pyani-plus-private-cli log-fastani --database :memory: --query-fasta {input.genomeA} --subject-fasta {input.genomeB} --fastani {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragsize {params.fragLen} --kmersize {params.kmerSize} --minmatch {params.minFrac}"
+        """
+        {params.fastani} -q {input.genomeA} -r {input.genomeB} \
+            -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani \
+            --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac} &&
+        .pyani-plus-private-cli log-fastani --database workflow-test.sqlite \
+            --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
+            --fastani {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani \
+            --fragsize {params.fragLen} --kmersize {params.kmerSize} --minmatch {params.minFrac}
+        """

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -47,3 +47,4 @@ rule fastani:
         "{outdir}/{genomeA}_vs_{genomeB}.fastani",
     shell:
         "{params.fastani} -q {input.genomeA} -r {input.genomeB} -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac}"
+        ".pyani-plus-private-cli log-fastani --database :memory: --query-fasta {input.genomeA} --subject-fasta {input.genomeB} --fastani {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani --fragsize {params.fragLen} --kmersize {params.kmerSize} --minmatch {params.minFrac}"

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -35,6 +35,7 @@ def get_genomeB(wildcards):
 # The fastani rule runs fastANI
 rule fastani:
     params:
+        db=config["db"],
         fastani=config["fastani"],
         indir=config["indir"],
         fragLen=config["fragLen"],
@@ -50,7 +51,7 @@ rule fastani:
         {params.fastani} -q {input.genomeA} -r {input.genomeB} \
             -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani \
             --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac} &&
-        .pyani-plus-private-cli log-fastani --database workflow-test.sqlite \
+        .pyani-plus-private-cli log-fastani --database {params.db} \
             --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
             --fastani {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani \
             --fragsize {params.fragLen} --kmersize {params.kmerSize} --minmatch {params.minFrac}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ testpaths = [
 ]
 doctest_optionflags = ["ELLIPSIS"]
 
+[project.scripts]
+".pyani-plus-private-cli" = "pyani_plus.private_cli:app"
+
 [project.urls]
 Homepage = "https://github.com/pyani-plus/pyani-plus"
 Issues = "https://github.com/pyani-plus/pyani-plus/issues"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 biopython
 snakemake>=8.12
 sqlalchemy
+typer>=0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+biopython
 snakemake>=8.12
 sqlalchemy

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -43,9 +43,11 @@ def config_fastani_args(
     fastani_targets_outdir: Path,
     input_genomes_small: Path,
     snakemake_cores: int,
+    tmp_path: str,
 ) -> dict:
     """Return configuration settings for testing snakemake fastANI rule."""
     return {
+        "db": Path(tmp_path) / "db.slqite",
         "fastani": get_fastani().exe_path,
         "outdir": fastani_targets_outdir,
         "indir": str(input_genomes_small),
@@ -97,22 +99,26 @@ def test_snakemake_rule_fastani(
     fastani_tool = get_fastani()
 
     # Setup minimal test DB
+    db = config_fastani_args["db"]
+    assert not db.is_file()
     log_configuration(
-        database="workflow-test.sqlite",  # currently hard coded in workflow
+        database=db,
         method="fastANI",
         program=fastani_tool.exe_path.stem,
         version=fastani_tool.version,
         fragsize=config_fastani_args["fragLen"],
         kmersize=config_fastani_args["kmerSize"],
         minmatch=config_fastani_args["minFrac"],
+        create_db=True,
     )
     # Record the FASTA files in the genomes table _before_ call snakemake
     log_genome(
-        database="workflow-test.sqlite",  # currently hard coded in workflow
+        database=db,
         fasta=list(
             snakemake_scheduler.check_input_stems(config_fastani_args["indir"]).values()
         ),
     )
+    assert db.is_file()
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_fastani.smk")

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 import pytest
 
+from pyani_plus.private_cli import log_configuration
 from pyani_plus.snakemake import snakemake_scheduler
 from pyani_plus.tools import get_fastani
 
@@ -91,6 +92,20 @@ def test_snakemake_rule_fastani(
     """
     # Remove the output directory to force re-running the snakemake rule
     shutil.rmtree(fastani_targets_outdir, ignore_errors=True)
+
+    # Assuming this will match but worker nodes might have a different version
+    fastani_tool = get_fastani()
+
+    # Setup minimal test DB
+    log_configuration(
+        database="workflow-test.sqlite",  # currently hard coded in workflow
+        method="fastANI",
+        program=fastani_tool.exe_path.stem,
+        version=fastani_tool.version,
+        fragsize=config_fastani_args["fragLen"],
+        kmersize=config_fastani_args["kmerSize"],
+        minmatch=config_fastani_args["minFrac"],
+    )
 
     # Run snakemake wrapper
     runner = snakemake_scheduler.SnakemakeRunner("snakemake_fastani.smk")

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 import pytest
 
-from pyani_plus.private_cli import log_configuration
+from pyani_plus.private_cli import log_configuration, log_genome
 from pyani_plus.snakemake import snakemake_scheduler
 from pyani_plus.tools import get_fastani
 
@@ -105,6 +105,13 @@ def test_snakemake_rule_fastani(
         fragsize=config_fastani_args["fragLen"],
         kmersize=config_fastani_args["kmerSize"],
         minmatch=config_fastani_args["minFrac"],
+    )
+    # Record the FASTA files in the genomes table _before_ call snakemake
+    log_genome(
+        database="workflow-test.sqlite",  # currently hard coded in workflow
+        fasta=list(
+            snakemake_scheduler.check_input_stems(config_fastani_args["indir"]).values()
+        ),
     )
 
     # Run snakemake wrapper

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -466,7 +466,8 @@ def test_helper_functions(tmp_path: str, input_genomes_small: Path) -> None:
 
     session = db_orm.connect_to_db(tmp_db)
 
-    config = db_orm.Configuration(
+    config = db_orm.add_configuration(
+        session,
         method="guessing",
         program="guestimate",
         version="v0.1.2beta3",

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -475,12 +475,10 @@ def test_helper_functions(tmp_path: str, input_genomes_small: Path) -> None:
         kmersize=31,
     )
     assert repr(config) == (
-        "Configuration(configuration_id=None,"
+        "Configuration(configuration_id=1,"
         " program='guestimate', version='v0.1.2beta3',"
         " fragsize=1000, maxmatch=None, kmersize=31, minmatch=None)"
     )
-    session.add(config)
-    session.commit()
 
     hashes = {}
     for fasta in input_genomes_small.glob("*.f*"):
@@ -493,4 +491,3 @@ def test_helper_functions(tmp_path: str, input_genomes_small: Path) -> None:
             db_orm.add_comparison(
                 session, config.configuration_id, a, b, 1 if a == b else 0.99, 12345
             )
-    session.commit()

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -485,18 +485,12 @@ def test_helper_functions(tmp_path: str, input_genomes_small: Path) -> None:
     hashes = {}
     for fasta in input_genomes_small.glob("*.f*"):
         md5 = file_md5sum(fasta)
-        assert db_orm.add_genome(session, fasta, md5)
-        # Can't add this twice:
-        assert not db_orm.add_genome(session, fasta, md5)
+        db_orm.add_genome(session, fasta, md5)
         hashes[md5] = fasta
 
     for a in hashes:
         for b in hashes:
-            assert db_orm.add_comparison(
-                session, config.configuration_id, a, b, 1 if a == b else 0.99, 12345
-            )
-            # Can't add this twice:
-            assert not db_orm.add_comparison(
+            db_orm.add_comparison(
                 session, config.configuration_id, a, b, 1 if a == b else 0.99, 12345
             )
     session.commit()

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -1,0 +1,145 @@
+# The MIT License
+#
+# Copyright (c) 2024 University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Tests for the pyani_plus/db_orm.py module.
+
+These tests are intended to be run from the repository root using:
+
+pytest -v
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pyani_plus import private_cli
+
+
+def test_log_configuration(tmp_path: str) -> None:
+    """Confirm can create a new empty database via log-configuration."""
+    tmp_db = Path(tmp_path) / "new.sqlite"
+    assert not tmp_db.is_file()
+
+    with pytest.raises(SystemExit) as err:
+        private_cli.log_configuration(
+            tmp_db,
+            method="guessing",
+            program="guestimate",
+            version="0.1.2beta3",
+            fragsize=100,
+            kmersize=51,
+            create_db=False,
+        )
+    assert "does not exist, but not using --create-db" in str(err)
+
+    # This time create it
+    private_cli.log_configuration(
+        tmp_db,
+        method="guessing",
+        program="guestimate",
+        version="0.1.2beta3",
+        fragsize=100,
+        kmersize=51,
+        create_db=True,
+    )
+
+    # This time should already be a DB there
+    private_cli.log_configuration(
+        tmp_db,
+        method="guessing",
+        program="guestimate",
+        version="0.1.2beta3",
+        fragsize=75,
+        kmersize=31,
+        create_db=False,
+    )
+
+    tmp_db.unlink()
+
+
+def test_log_genome(tmp_path: str, input_genomes_small: Path) -> None:
+    """Confirm can create a new empty database via log-genome."""
+    tmp_db = Path(tmp_path) / "new.sqlite"
+    assert not tmp_db.is_file()
+
+    with pytest.raises(SystemExit) as err:
+        private_cli.log_genome(
+            database=tmp_db,
+            fasta=list(
+                input_genomes_small.glob("*.fasta")  # subset of folder
+            ),
+        )
+    assert "does not exist, but not using --create-db" in str(err)
+
+    # This time create it
+    private_cli.log_genome(
+        database=tmp_db,
+        fasta=list(
+            input_genomes_small.glob("*.fasta")  # subset of folder
+        ),
+        create_db=True,
+    )
+
+
+def test_log_comparison(tmp_path: str, input_genomes_small: Path) -> None:
+    """Confirm can create a mock DB using log-comparison etc."""
+    tmp_db = Path(tmp_path) / "new.sqlite"
+    assert not tmp_db.is_file()
+
+    private_cli.log_configuration(
+        tmp_db,
+        method="guessing",
+        program="guestimate",
+        version="0.1.2beta3",
+        fragsize=100,
+        kmersize=51,
+        create_db=True,
+    )
+
+    fasta = list(input_genomes_small.glob("*.fasta"))  # subset of folder
+    private_cli.log_genome(
+        database=tmp_db,
+        fasta=fasta,
+        create_db=False,
+    )
+
+    # Should at this point log the run
+
+    for query in fasta:
+        for subject in fasta:
+            private_cli.log_comparison(
+                database=tmp_db,
+                query_fasta=query,
+                subject_fasta=subject,
+                identity=1.0 if query == subject else 0.96,
+                aln_length=12345,
+                method="guessing",
+                program="guestimate",
+                version="0.1.2beta3",
+                fragsize=100,
+                kmersize=51,
+                sim_errors=1,
+                cov_query=0.98,
+                cov_subject=0.98,
+                create_db=False,
+            )
+
+    # Would next test updating the run matrices

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -114,14 +114,16 @@ def test_log_comparison(tmp_path: str, input_genomes_small: Path) -> None:
         create_db=True,
     )
 
-    fasta = list(input_genomes_small.glob("*.fasta"))  # subset of folder
+    fasta = list(input_genomes_small.glob("*.fna"))  # subset of folder (2)
     private_cli.log_genome(
         database=tmp_db,
         fasta=fasta,
         create_db=False,
     )
 
-    # Should at this point log the run
+    # Could at this point log the run with status=started (or similar),
+    # but will need a mechanism to return the run ID and use it to update
+    # the table row at the end...
 
     for query in fasta:
         for subject in fasta:
@@ -142,4 +144,22 @@ def test_log_comparison(tmp_path: str, input_genomes_small: Path) -> None:
                 create_db=False,
             )
 
-    # Would next test updating the run matrices
+    # Can now log the run with status=completed
+    # Or, if we already logged it with status=started, would need to update
+    # the existing run table entry with the cached matrices and completed status
+    private_cli.log_run(
+        database=tmp_db,
+        # Run
+        cmdline="pyani_plus run ...",
+        name="Guess Run",
+        status="Completed",
+        fasta=fasta,  # list
+        # Config
+        method="guessing",
+        program="guestimate",
+        version="0.1.2beta3",
+        fragsize=100,
+        kmersize=51,
+        # Misc
+        create_db=False,
+    )


### PR DESCRIPTION
Based on the https://github.com/widdowquinn/pyani/blob/master/pyani/pyani_orm.py approach with helper functions to record genomes and runs - although this starts simpler with the pre-run tables only.

See also #81 which may be able to use this.

--

Update: See later, this now has helper functions for loading data into all the defined tables, and matching CLI functions too (although we may not need all of the later).