### PR TITLE
Single conda install under GitHub Actions

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -43,14 +43,8 @@ jobs:
       - name: Install pip
         run: python -m pip install --upgrade pip
 
-      - name: Install Development Requirements
-        run: conda install --file requirements-dev.txt -y
-
       - name: Install Requirements
-        run: conda install --file requirements.txt -y
-
-      - name: Install third-party tools
-        run: conda install --file requirements-thirdparty-linux.txt -y
+        run: conda install -y --file requirements.txt --file requirements-dev.txt --file requirements-thirdparty-linux.txt -y
 
       - name: Install pyani-plus
         run: pip install -e .

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Check Miniconda Installation
         run: |
+          conda config --remove channels defaults
           conda info
           conda list
 

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Check Miniconda Installation
         run: |
+          conda config --remove channels defaults
           conda info
           conda list
 

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -43,14 +43,8 @@ jobs:
       - name: Install pip
         run: python -m pip install --upgrade pip
 
-      - name: Install Development Requirements
-        run: conda install --file requirements-dev.txt -y
-
       - name: Install Requirements
-        run: conda install --file requirements.txt -y
-
-      - name: Install third-party tools
-        run: conda install --file requirements-thirdparty-macos.txt -y
+        run: conda install -y --file requirements.txt --file requirements-dev.txt --file requirements-thirdparty-macos.txt
 
       - name: Install pyani-plus
         run: pip install -e .


### PR DESCRIPTION
This is hopefully faster than the current three separate calls to conda install, but certainly makes the dependency installation time easier to see at a glance.

It also forcibly removes the default channel (which shouldn't be there as trying to use miniforge - but appears to be an issue with conda-incubator/setup-miniconda - I couldn't find an exact match on their issue tracker).