### PR TITLE
Update requirements.txt (sql version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 biopython
 snakemake>=8.12
-sqlalchemy
+sqlalchemy>=2.0
 typer>=0.12


### PR DESCRIPTION
I accidentally discovered that the version of `SQLAlchemy` may be important for `pyani-plus` to work as expected.

When switching from working on my MacStudio to my laptop, I installed `SQLAlchemy v1.4` instead of `v2.0`, which resulted in errors for some tests (see below). In this PR, I'm proposing that slalchemy version is pinned in `requirements. txt`. 