### PR TITLE
Use 3 viruses instead of 4 bacteria in all tests

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -585,10 +585,10 @@ def add_genome(session: Session, fasta_filename: Path | str, md5: str) -> Genome
 
     >>> session = connect_to_db(":memory:")
     >>> from pyani_plus.utils import file_md5sum
-    >>> fasta = "tests/fixtures/sequences/NC_002696.fasta"
+    >>> fasta = "tests/fixtures/viral_example/OP073605.fasta"
     >>> genome = add_genome(session, fasta, file_md5sum(fasta))
     >>> genome.genome_hash
-    'f19cb07198a41a4406a22b2f57a6b5e7'
+    '5584c7029328dc48d33f95f0a78f7e57'
 
     Note this calls session.commit() explicitly to try to reduce locking contention,
     and makes some efforts to cope gracefully with competing processes also trying

--- a/pyani_plus/utils.py
+++ b/pyani_plus/utils.py
@@ -33,13 +33,13 @@ def file_md5sum(filename: Path | str) -> str:
     Behaves like the command line tool ``md5sum``, giving a 32 character
     hexadecimal representation of the MD5 checksum of the file contents::
 
-        $ md5sum tests/fixtures/sequences/NC_002696.fasta
-        f19cb07198a41a4406a22b2f57a6b5e7  tests/fixtures/sequences/NC_002696.fasta
+        $ md5sum tests/fixtures/viral_example/OP073605.fasta
+        5584c7029328dc48d33f95f0a78f7e57  tests/fixtures/viral_example/OP073605.fasta
 
     In Python:
 
-        >>> file_md5sum("tests/fixtures/sequences/NC_002696.fasta")
-        'f19cb07198a41a4406a22b2f57a6b5e7'
+        >>> file_md5sum("tests/fixtures/viral_example/OP073605.fasta")
+        '5584c7029328dc48d33f95f0a78f7e57'
 
     This is used in pyANI-plus on input FASTA format sequence files, to give a
     fingerprint of the file contents allowing us to cache and reused comparison

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,12 +244,6 @@ def dnadiff_targets_showcoords(dnadiff_targets_showcoords_outdir: Path) -> list[
 
 
 @pytest.fixture
-def input_genomes_small() -> Path:
-    """Path to small set of four bacterial input genomes."""
-    return FIXTUREPATH / "sequences"
-
-
-@pytest.fixture
 def input_genomes_tiny() -> Path:
     """Path to small set of two viral input genomes."""
     return FIXTUREPATH / "viral_example"

--- a/tests/fixtures/fastani/targets/MGV-GENOME-0264574_vs_MGV-GENOME-0266457.fastani
+++ b/tests/fixtures/fastani/targets/MGV-GENOME-0264574_vs_MGV-GENOME-0266457.fastani
@@ -1,0 +1,1 @@
+../fixtures/viral_example/MGV-GENOME-0264574.fas	../fixtures/viral_example/MGV-GENOME-0266457.fna	99.5014	12	13

--- a/tests/fixtures/fastani/targets/MGV-GENOME-0264574_vs_OP073605.fastani
+++ b/tests/fixtures/fastani/targets/MGV-GENOME-0264574_vs_OP073605.fastani
@@ -1,0 +1,1 @@
+../fixtures/viral_example/MGV-GENOME-0264574.fas	../fixtures/viral_example/OP073605.fasta	99.9386	13	13

--- a/tests/fixtures/fastani/targets/MGV-GENOME-0266457_vs_MGV-GENOME-0264574.fastani
+++ b/tests/fixtures/fastani/targets/MGV-GENOME-0266457_vs_MGV-GENOME-0264574.fastani
@@ -1,0 +1,1 @@
+../fixtures/viral_example/MGV-GENOME-0266457.fna	../fixtures/viral_example/MGV-GENOME-0264574.fas	99.5247	13	13

--- a/tests/fixtures/fastani/targets/MGV-GENOME-0266457_vs_OP073605.fastani
+++ b/tests/fixtures/fastani/targets/MGV-GENOME-0266457_vs_OP073605.fastani
@@ -1,0 +1,1 @@
+../fixtures/viral_example/MGV-GENOME-0266457.fna	../fixtures/viral_example/OP073605.fasta	99.5129	13	13

--- a/tests/fixtures/fastani/targets/NC_002696_vs_NC_010338.fastani
+++ b/tests/fixtures/fastani/targets/NC_002696_vs_NC_010338.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_002696.fasta	../fixtures/sequences/NC_010338.fna	82.8552	889	1338

--- a/tests/fixtures/fastani/targets/NC_002696_vs_NC_011916.fastani
+++ b/tests/fixtures/fastani/targets/NC_002696_vs_NC_011916.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_002696.fasta	../fixtures/sequences/NC_011916.fas	99.9965	1338	1338

--- a/tests/fixtures/fastani/targets/NC_002696_vs_NC_014100.fastani
+++ b/tests/fixtures/fastani/targets/NC_002696_vs_NC_014100.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_002696.fasta	../fixtures/sequences/NC_014100.fna	85.9835	1007	1338

--- a/tests/fixtures/fastani/targets/NC_010338_vs_NC_002696.fastani
+++ b/tests/fixtures/fastani/targets/NC_010338_vs_NC_002696.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_010338.fna	../fixtures/sequences/NC_002696.fasta	82.9124	877	1825

--- a/tests/fixtures/fastani/targets/NC_010338_vs_NC_011916.fastani
+++ b/tests/fixtures/fastani/targets/NC_010338_vs_NC_011916.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_010338.fna	../fixtures/sequences/NC_011916.fas	82.9359	887	1825

--- a/tests/fixtures/fastani/targets/NC_010338_vs_NC_014100.fastani
+++ b/tests/fixtures/fastani/targets/NC_010338_vs_NC_014100.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_010338.fna	../fixtures/sequences/NC_014100.fna	83.001	978	1825

--- a/tests/fixtures/fastani/targets/NC_011916_vs_NC_002696.fastani
+++ b/tests/fixtures/fastani/targets/NC_011916_vs_NC_002696.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_011916.fas	../fixtures/sequences/NC_002696.fasta	99.9946	1337	1347

--- a/tests/fixtures/fastani/targets/NC_011916_vs_NC_010338.fastani
+++ b/tests/fixtures/fastani/targets/NC_011916_vs_NC_010338.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_011916.fas	../fixtures/sequences/NC_010338.fna	82.7818	899	1347

--- a/tests/fixtures/fastani/targets/NC_011916_vs_NC_014100.fastani
+++ b/tests/fixtures/fastani/targets/NC_011916_vs_NC_014100.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_011916.fas	../fixtures/sequences/NC_014100.fna	85.9928	1001	1347

--- a/tests/fixtures/fastani/targets/NC_014100_vs_NC_002696.fastani
+++ b/tests/fixtures/fastani/targets/NC_014100_vs_NC_002696.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_014100.fna	../fixtures/sequences/NC_002696.fasta	86.1137	998	1551

--- a/tests/fixtures/fastani/targets/NC_014100_vs_NC_010338.fastani
+++ b/tests/fixtures/fastani/targets/NC_014100_vs_NC_010338.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_014100.fna	../fixtures/sequences/NC_010338.fna	83.0029	978	1551

--- a/tests/fixtures/fastani/targets/NC_014100_vs_NC_011916.fastani
+++ b/tests/fixtures/fastani/targets/NC_014100_vs_NC_011916.fastani
@@ -1,1 +1,0 @@
-../fixtures/sequences/NC_014100.fna	../fixtures/sequences/NC_011916.fas	86.0574	1000	1551

--- a/tests/fixtures/fastani/targets/OP073605_vs_MGV-GENOME-0264574.fastani
+++ b/tests/fixtures/fastani/targets/OP073605_vs_MGV-GENOME-0264574.fastani
@@ -1,0 +1,1 @@
+../fixtures/viral_example/OP073605.fasta	../fixtures/viral_example/MGV-GENOME-0264574.fas	99.8333	13	19

--- a/tests/fixtures/fastani/targets/OP073605_vs_MGV-GENOME-0266457.fastani
+++ b/tests/fixtures/fastani/targets/OP073605_vs_MGV-GENOME-0266457.fastani
@@ -1,0 +1,1 @@
+../fixtures/viral_example/OP073605.fasta	../fixtures/viral_example/MGV-GENOME-0266457.fna	99.4912	13	19

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from pyani_plus.tools import get_fastani
 
 # Parameters (eg, input sequences, fastANI outputs, k-mer sizes...)
-INPUT_DIR = Path("../fixtures/sequences")
+INPUT_DIR = Path("../fixtures/viral_example")
 FASTANI_DIR = Path("../fixtures/fastani/targets")
 FRAG_LEN = 3000
 KMER_SIZE = 16
@@ -48,7 +48,7 @@ MIN_FRAC = 0.2
 
 # Running comparisons
 comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*")], 2)
-inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*")}
+inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*.f*")}
 
 fastani = get_fastani()
 print(f"Using fastANI {fastani.version} at {fastani.exe_path}")  # noqa: T201

--- a/tests/snakemake/test_scheduler.py
+++ b/tests/snakemake/test_scheduler.py
@@ -36,27 +36,26 @@ from pyani_plus.snakemake import snakemake_scheduler
 
 
 def test_input_stems(
-    input_genomes_small: Path,
+    input_genomes_tiny: Path,
 ) -> None:
     """Verify expected stem:filename mapping from FASTA directory."""
-    mapping = snakemake_scheduler.check_input_stems(str(input_genomes_small))
+    mapping = snakemake_scheduler.check_input_stems(str(input_genomes_tiny))
     assert mapping == {
-        "NC_002696": input_genomes_small / "NC_002696.fasta",
-        "NC_010338": input_genomes_small / "NC_010338.fna",
-        "NC_011916": input_genomes_small / "NC_011916.fas",
-        "NC_014100": input_genomes_small / "NC_014100.fna",
+        "MGV-GENOME-0264574": input_genomes_tiny / "MGV-GENOME-0264574.fas",
+        "MGV-GENOME-0266457": input_genomes_tiny / "MGV-GENOME-0266457.fna",
+        "OP073605": input_genomes_tiny / "OP073605.fasta",
     }
 
 
 def test_duplicate_stems(
-    input_genomes_small: Path,
+    input_genomes_tiny: Path,
     tmp_path: str,
 ) -> None:
     """Verify expected error message with duplicated FASTA stems."""
     dup_input_dir = Path(tmp_path) / "duplicated_stems"
     dup_input_dir.mkdir()
     stems = set()
-    for sequence in input_genomes_small.glob("*.f*"):
+    for sequence in input_genomes_tiny.glob("*.f*"):
         # For every input FASTA file, make two versions - XXX.fasta and XXX.fna
         os.symlink(sequence, dup_input_dir / (sequence.stem + ".fasta"))
         os.symlink(sequence, dup_input_dir / (sequence.stem + ".fna"))

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -41,7 +41,7 @@ from pyani_plus.tools import get_fastani
 @pytest.fixture
 def config_fastani_args(
     fastani_targets_outdir: Path,
-    input_genomes_small: Path,
+    input_genomes_tiny: Path,
     snakemake_cores: int,
     tmp_path: str,
 ) -> dict:
@@ -50,7 +50,7 @@ def config_fastani_args(
         "db": Path(tmp_path) / "db.slqite",
         "fastani": get_fastani().exe_path,
         "outdir": fastani_targets_outdir,
-        "indir": str(input_genomes_small),
+        "indir": str(input_genomes_tiny),
         "cores": snakemake_cores,
         "fragLen": 3000,
         "kmerSize": 16,


### PR DESCRIPTION
Following work and discussion on #98, this adjusts the remaining test cases to use the 3 viruses (fixture name ``input_genomes_tiny``) rather than the original 4 bacteria (fixture name ``input_genomes_small``).

Most of the changes here are updating the fastANI test (replacing the expected intermediate files).

This does not (yet) actually delete the four bacteria at ``tests/fixtures/sequences/`` which we may want to use later on - perhaps for a worked example, or as part of a "long" test?

Bonus: On my old Intel macOS machine the tests now take 7 to 10s, down from 12 to 15s.