### PR TITLE
add fixtures for dnadiff method (expected results)

### DIFF
--- a/pyani_plus/tools.py
+++ b/pyani_plus/tools.py
@@ -289,3 +289,31 @@ def get_show_diff(cmd: str | Path = "show-diff") -> ExternalToolData:
         raise RuntimeError(msg)
 
     return ExternalToolData(exe_path, version)
+
+
+def get_dnadiff(cmd: str | Path = "dnadiff") -> ExternalToolData:
+    """Return dnadiff and version as a named tuple.
+
+    We expect the tool to behave as follows:
+
+    .. code-block:: bash
+
+        $ dnadiff -V
+            dnadiff
+            DNAdiff version 1.3
+
+    Here the function would return the binary path and "1.3" as the version.
+
+    Raises a RuntimeError if the command cannot be found, run, or if the
+    version cannot be inferred - this likely indicates a dramatically
+    different version of the tool with different behaviour.
+    """
+    exe_path, output = _get_path_and_version_output(cmd, ["-V"])
+
+    match = re.search(r"(?<=version\s)[0-9\.]*", output)
+    version = match.group().strip() if match else None
+    if not version:
+        msg = f"Executable exists at {exe_path} but could not retrieve version"
+        raise RuntimeError(msg)
+
+    return ExternalToolData(exe_path, version)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,12 @@ def fastani_targets_indir() -> Path:
 
 
 @pytest.fixture
+def dnadiff_reports_dir() -> Path:
+    """Directory containing dnadiff report files."""
+    return FIXTUREPATH / "dnadiff" / "targets" / "dnadiff_reports"
+
+
+@pytest.fixture
 def dnadiff_nucmer_targets_filter_indir() -> Path:
     """Directory containing MUMmer filter snakemake reference files."""
     return FIXTUREPATH / "dnadiff" / "targets" / "filter"

--- a/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0264574_vs_MGV-GENOME-0266457.report
+++ b/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0264574_vs_MGV-GENOME-0266457.report
@@ -1,0 +1,87 @@
+/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0264574.fas /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0266457.fna
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                    1
+AlignedSeqs               1(100.00%)           1(100.00%)
+UnalignedSeqs               0(0.00%)             0(0.00%)
+
+[Bases]
+TotalBases                     39253                39594
+AlignedBases           39169(99.79%)        39176(98.94%)
+UnalignedBases             84(0.21%)           418(1.06%)
+
+[Alignments]
+1-to-1                             2                    2
+TotalLength                    59174                59187
+AvgLength                   29587.00             29593.50
+AvgIdentity                    99.63                99.63
+
+M-to-M                             2                    2
+TotalLength                    59174                59187
+AvgLength                   29587.00             29593.50
+AvgIdentity                    99.63                99.63
+
+[Feature Estimates]
+Breakpoints                        3                    3
+Relocations                        0                    0
+Translocations                     0                    0
+Inversions                         0                    0
+
+Insertions                         2                    1
+InsertionSum                      90                  418
+InsertionAvg                   45.00               418.00
+
+TandemIns                          1                    0
+TandemInsSum                       6                    0
+TandemInsAvg                    6.00                 0.00
+
+[SNPs]
+TotalSNPs                        207                  207
+CT                        38(18.36%)           26(12.56%)
+CA                          5(2.42%)             7(3.38%)
+CG                          2(0.97%)             1(0.48%)
+GT                         12(5.80%)             7(3.38%)
+GA                        40(19.32%)           44(21.26%)
+GC                          1(0.48%)             2(0.97%)
+TA                          9(4.35%)            16(7.73%)
+TC                        26(12.56%)           38(18.36%)
+TG                          7(3.38%)            12(5.80%)
+AT                         16(7.73%)             9(4.35%)
+AG                        44(21.26%)           40(19.32%)
+AC                          7(3.38%)             5(2.42%)
+
+TotalGSNPs                        48                   48
+CG                          0(0.00%)             0(0.00%)
+CT                         6(12.50%)            7(14.58%)
+CA                          1(2.08%)             1(2.08%)
+GT                          2(4.17%)             4(8.33%)
+GA                        13(27.08%)           12(25.00%)
+GC                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             2(4.17%)
+TG                          4(8.33%)             2(4.17%)
+TC                         7(14.58%)            6(12.50%)
+AT                          2(4.17%)             0(0.00%)
+AC                          1(2.08%)             1(2.08%)
+AG                        12(25.00%)           13(27.08%)
+
+TotalIndels                        1                    1
+C.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)           1(100.00%)
+A.                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.T                        1(100.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       1                    1
+C.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)           1(100.00%)
+A.                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.T                        1(100.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)

--- a/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0264574_vs_OP073605.report
+++ b/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0264574_vs_OP073605.report
@@ -1,0 +1,87 @@
+/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0264574.fas /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/OP073605.fasta
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                    1
+AlignedSeqs               1(100.00%)           1(100.00%)
+UnalignedSeqs               0(0.00%)             0(0.00%)
+
+[Bases]
+TotalBases                     39253                57793
+AlignedBases           39147(99.73%)        39150(67.74%)
+UnalignedBases            106(0.27%)        18643(32.26%)
+
+[Alignments]
+1-to-1                             1                    1
+TotalLength                    39147                39150
+AvgLength                   39147.00             39150.00
+AvgIdentity                    99.93                99.93
+
+M-to-M                             1                    1
+TotalLength                    39147                39150
+AvgLength                   39147.00             39150.00
+AvgIdentity                    99.93                99.93
+
+[Feature Estimates]
+Breakpoints                        1                    1
+Relocations                        0                    0
+Translocations                     0                    0
+Inversions                         0                    0
+
+Insertions                         1                    1
+InsertionSum                     106                18643
+InsertionAvg                  106.00             18643.00
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                         24                   24
+AC                          0(0.00%)             1(4.17%)
+AG                         5(20.83%)            3(12.50%)
+AT                          2(8.33%)             0(0.00%)
+GC                          0(0.00%)             2(8.33%)
+GA                         3(12.50%)            5(20.83%)
+GT                         4(16.67%)             2(8.33%)
+TC                          2(8.33%)            3(12.50%)
+TA                          0(0.00%)             2(8.33%)
+TG                          2(8.33%)            4(16.67%)
+CT                         3(12.50%)             2(8.33%)
+CA                          1(4.17%)             0(0.00%)
+CG                          2(8.33%)             0(0.00%)
+
+TotalGSNPs                         7                    7
+CA                          0(0.00%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+CT                         3(42.86%)            2(28.57%)
+GC                          0(0.00%)             0(0.00%)
+GA                         1(14.29%)            1(14.29%)
+GT                          0(0.00%)             0(0.00%)
+AC                          0(0.00%)             0(0.00%)
+AG                         1(14.29%)            1(14.29%)
+AT                          0(0.00%)             0(0.00%)
+TC                         2(28.57%)            3(42.86%)
+TA                          0(0.00%)             0(0.00%)
+TG                          0(0.00%)             0(0.00%)
+
+TotalIndels                        3                    3
+A.                          0(0.00%)            1(33.33%)
+G.                          0(0.00%)            1(33.33%)
+T.                          0(0.00%)            1(33.33%)
+C.                          0(0.00%)             0(0.00%)
+.G                         1(33.33%)             0(0.00%)
+.A                         1(33.33%)             0(0.00%)
+.T                         1(33.33%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       1                    1
+C.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)           1(100.00%)
+.T                        1(100.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)

--- a/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0266457_vs_MGV-GENOME-0264574.report
+++ b/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0266457_vs_MGV-GENOME-0264574.report
@@ -1,0 +1,87 @@
+/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0266457.fna /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0264574.fas
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                    1
+AlignedSeqs               1(100.00%)           1(100.00%)
+UnalignedSeqs               0(0.00%)             0(0.00%)
+
+[Bases]
+TotalBases                     39594                39253
+AlignedBases           39176(98.94%)        39169(99.79%)
+UnalignedBases            418(1.06%)            84(0.21%)
+
+[Alignments]
+1-to-1                             2                    2
+TotalLength                    59187                59174
+AvgLength                   29593.50             29587.00
+AvgIdentity                    99.63                99.63
+
+M-to-M                             2                    2
+TotalLength                    59187                59174
+AvgLength                   29593.50             29587.00
+AvgIdentity                    99.63                99.63
+
+[Feature Estimates]
+Breakpoints                        3                    3
+Relocations                        0                    0
+Translocations                     0                    0
+Inversions                         0                    0
+
+Insertions                         1                    2
+InsertionSum                     418                   90
+InsertionAvg                  418.00                45.00
+
+TandemIns                          0                    1
+TandemInsSum                       0                    6
+TandemInsAvg                    0.00                 6.00
+
+[SNPs]
+TotalSNPs                        207                  207
+TC                        38(18.36%)           26(12.56%)
+TG                         12(5.80%)             7(3.38%)
+TA                         16(7.73%)             9(4.35%)
+CA                          7(3.38%)             5(2.42%)
+CG                          1(0.48%)             2(0.97%)
+CT                        26(12.56%)           38(18.36%)
+AG                        40(19.32%)           44(21.26%)
+AC                          5(2.42%)             7(3.38%)
+AT                          9(4.35%)            16(7.73%)
+GC                          2(0.97%)             1(0.48%)
+GA                        44(21.26%)           40(19.32%)
+GT                          7(3.38%)            12(5.80%)
+
+TotalGSNPs                        48                   48
+TC                         6(12.50%)            7(14.58%)
+TA                          2(4.17%)             0(0.00%)
+TG                          2(4.17%)             4(8.33%)
+AG                        13(27.08%)           12(25.00%)
+AC                          1(2.08%)             1(2.08%)
+AT                          0(0.00%)             2(4.17%)
+GT                          4(8.33%)             2(4.17%)
+GA                        12(25.00%)           13(27.08%)
+GC                          0(0.00%)             0(0.00%)
+CA                          1(2.08%)             1(2.08%)
+CG                          0(0.00%)             0(0.00%)
+CT                         7(14.58%)            6(12.50%)
+
+TotalIndels                        1                    1
+T.                        1(100.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)           1(100.00%)
+
+TotalGIndels                       1                    1
+T.                        1(100.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)           1(100.00%)

--- a/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0266457_vs_OP073605.report
+++ b/tests/fixtures/dnadiff/targets/dnadiff_reports/MGV-GENOME-0266457_vs_OP073605.report
@@ -1,0 +1,87 @@
+/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0266457.fna /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/OP073605.fasta
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                    1
+AlignedSeqs               1(100.00%)           1(100.00%)
+UnalignedSeqs               0(0.00%)             0(0.00%)
+
+[Bases]
+TotalBases                     39594                57793
+AlignedBases           39572(99.94%)        39568(68.47%)
+UnalignedBases             22(0.06%)        18225(31.53%)
+
+[Alignments]
+1-to-1                             1                    1
+TotalLength                    39572                39568
+AvgLength                   39572.00             39568.00
+AvgIdentity                    99.46                99.46
+
+M-to-M                             1                    1
+TotalLength                    39572                39568
+AvgLength                   39572.00             39568.00
+AvgIdentity                    99.46                99.46
+
+[Feature Estimates]
+Breakpoints                        1                    1
+Relocations                        0                    0
+Translocations                     0                    0
+Inversions                         0                    0
+
+Insertions                         1                    1
+InsertionSum                      22                18225
+InsertionAvg                   22.00             18225.00
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                        206                  206
+TA                         16(7.77%)            10(4.85%)
+TC                        36(17.48%)           26(12.62%)
+TG                         10(4.85%)             8(3.88%)
+CT                        26(12.62%)           36(17.48%)
+CA                          7(3.40%)             4(1.94%)
+CG                          2(0.97%)             2(0.97%)
+AC                          4(1.94%)             7(3.40%)
+AT                         10(4.85%)            16(7.77%)
+AG                        42(20.39%)           43(20.87%)
+GC                          2(0.97%)             2(0.97%)
+GT                          8(3.88%)            10(4.85%)
+GA                        43(20.87%)           42(20.39%)
+
+TotalGSNPs                        49                   49
+GA                        12(24.49%)           14(28.57%)
+GT                          4(8.16%)             2(4.08%)
+GC                          0(0.00%)             0(0.00%)
+AG                        14(28.57%)           12(24.49%)
+AC                          1(2.04%)             1(2.04%)
+AT                          0(0.00%)             2(4.08%)
+TC                         5(10.20%)            8(16.33%)
+TA                          2(4.08%)             0(0.00%)
+TG                          2(4.08%)             4(8.16%)
+CT                         8(16.33%)            5(10.20%)
+CA                          1(2.04%)             1(2.04%)
+CG                          0(0.00%)             0(0.00%)
+
+TotalIndels                        6                    6
+T.                          0(0.00%)             0(0.00%)
+C.                         1(16.67%)             0(0.00%)
+A.                         2(33.33%)             0(0.00%)
+G.                         2(33.33%)            1(16.67%)
+.G                         1(16.67%)            2(33.33%)
+.A                          0(0.00%)            2(33.33%)
+.C                          0(0.00%)            1(16.67%)
+.T                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       0                    0
+G.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)

--- a/tests/fixtures/dnadiff/targets/dnadiff_reports/OP073605_vs_MGV-GENOME-0264574.report
+++ b/tests/fixtures/dnadiff/targets/dnadiff_reports/OP073605_vs_MGV-GENOME-0264574.report
@@ -1,0 +1,87 @@
+/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/OP073605.fasta /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0264574.fas
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                    1
+AlignedSeqs               1(100.00%)           1(100.00%)
+UnalignedSeqs               0(0.00%)             0(0.00%)
+
+[Bases]
+TotalBases                     57793                39253
+AlignedBases           39150(67.74%)        39147(99.73%)
+UnalignedBases         18643(32.26%)           106(0.27%)
+
+[Alignments]
+1-to-1                             1                    1
+TotalLength                    39150                39147
+AvgLength                   39150.00             39147.00
+AvgIdentity                    99.93                99.93
+
+M-to-M                             1                    1
+TotalLength                    39150                39147
+AvgLength                   39150.00             39147.00
+AvgIdentity                    99.93                99.93
+
+[Feature Estimates]
+Breakpoints                        1                    1
+Relocations                        0                    0
+Translocations                     0                    0
+Inversions                         0                    0
+
+Insertions                         1                    1
+InsertionSum                   18643                  106
+InsertionAvg                18643.00               106.00
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                         24                   24
+CT                         5(20.83%)            3(12.50%)
+CA                          2(8.33%)            4(16.67%)
+CG                          2(8.33%)             0(0.00%)
+GC                          0(0.00%)             2(8.33%)
+GT                          0(0.00%)             1(4.17%)
+GA                          2(8.33%)            3(12.50%)
+TC                         3(12.50%)            5(20.83%)
+TG                          1(4.17%)             0(0.00%)
+TA                          0(0.00%)             2(8.33%)
+AG                         3(12.50%)             2(8.33%)
+AC                         4(16.67%)             2(8.33%)
+AT                          2(8.33%)             0(0.00%)
+
+TotalGSNPs                         7                    7
+AC                          0(0.00%)             0(0.00%)
+AG                         3(42.86%)            2(28.57%)
+AT                          0(0.00%)             0(0.00%)
+TC                         1(14.29%)            1(14.29%)
+TG                          0(0.00%)             0(0.00%)
+TA                          0(0.00%)             0(0.00%)
+CA                          0(0.00%)             0(0.00%)
+CT                         1(14.29%)            1(14.29%)
+CG                          0(0.00%)             0(0.00%)
+GT                          0(0.00%)             0(0.00%)
+GA                         2(28.57%)            3(42.86%)
+GC                          0(0.00%)             0(0.00%)
+
+TotalIndels                        3                    3
+C.                         1(33.33%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+T.                         1(33.33%)             0(0.00%)
+A.                         1(33.33%)             0(0.00%)
+.A                          0(0.00%)            1(33.33%)
+.T                          0(0.00%)            1(33.33%)
+.C                          0(0.00%)            1(33.33%)
+.G                          0(0.00%)             0(0.00%)
+
+TotalGIndels                       1                    1
+A.                        1(100.00%)             0(0.00%)
+T.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)           1(100.00%)
+.G                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)

--- a/tests/fixtures/dnadiff/targets/dnadiff_reports/OP073605_vs_MGV-GENOME-0266457.report
+++ b/tests/fixtures/dnadiff/targets/dnadiff_reports/OP073605_vs_MGV-GENOME-0266457.report
@@ -1,0 +1,87 @@
+/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/OP073605.fasta /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0266457.fna
+NUCMER
+
+                               [REF]                [QRY]
+[Sequences]
+TotalSeqs                          1                    1
+AlignedSeqs               1(100.00%)           1(100.00%)
+UnalignedSeqs               0(0.00%)             0(0.00%)
+
+[Bases]
+TotalBases                     57793                39594
+AlignedBases           39568(68.47%)        39572(99.94%)
+UnalignedBases         18225(31.53%)            22(0.06%)
+
+[Alignments]
+1-to-1                             1                    1
+TotalLength                    39568                39572
+AvgLength                   39568.00             39572.00
+AvgIdentity                    99.46                99.46
+
+M-to-M                             1                    1
+TotalLength                    39568                39572
+AvgLength                   39568.00             39572.00
+AvgIdentity                    99.46                99.46
+
+[Feature Estimates]
+Breakpoints                        1                    1
+Relocations                        0                    0
+Translocations                     0                    0
+Inversions                         0                    0
+
+Insertions                         1                    1
+InsertionSum                   18225                   22
+InsertionAvg                18225.00                22.00
+
+TandemIns                          0                    0
+TandemInsSum                       0                    0
+TandemInsAvg                    0.00                 0.00
+
+[SNPs]
+TotalSNPs                        206                  206
+GT                          4(1.94%)             7(3.40%)
+GA                        36(17.48%)           26(12.62%)
+GC                          2(0.97%)             2(0.97%)
+AT                         10(4.85%)            16(7.77%)
+AG                        26(12.62%)           36(17.48%)
+AC                          8(3.88%)            10(4.85%)
+TC                        43(20.87%)           42(20.39%)
+TG                          7(3.40%)             4(1.94%)
+TA                         16(7.77%)            10(4.85%)
+CG                          2(0.97%)             2(0.97%)
+CA                         10(4.85%)             8(3.88%)
+CT                        42(20.39%)           43(20.87%)
+
+TotalGSNPs                        49                   49
+TC                        12(24.49%)           14(28.57%)
+TA                          2(4.08%)             0(0.00%)
+TG                          1(2.04%)             1(2.04%)
+AC                          4(8.16%)             2(4.08%)
+AG                         8(16.33%)            5(10.20%)
+AT                          0(0.00%)             2(4.08%)
+GA                         5(10.20%)            8(16.33%)
+GT                          1(2.04%)             1(2.04%)
+GC                          0(0.00%)             0(0.00%)
+CG                          0(0.00%)             0(0.00%)
+CA                          2(4.08%)             4(8.16%)
+CT                        14(28.57%)           12(24.49%)
+
+TotalIndels                        6                    6
+G.                          0(0.00%)            1(16.67%)
+A.                          0(0.00%)             0(0.00%)
+T.                          0(0.00%)            2(33.33%)
+C.                         1(16.67%)            2(33.33%)
+.A                          0(0.00%)             0(0.00%)
+.T                         2(33.33%)             0(0.00%)
+.G                         1(16.67%)             0(0.00%)
+.C                         2(33.33%)            1(16.67%)
+
+TotalGIndels                       0                    0
+T.                          0(0.00%)             0(0.00%)
+A.                          0(0.00%)             0(0.00%)
+G.                          0(0.00%)             0(0.00%)
+C.                          0(0.00%)             0(0.00%)
+.T                          0(0.00%)             0(0.00%)
+.A                          0(0.00%)             0(0.00%)
+.G                          0(0.00%)             0(0.00%)
+.C                          0(0.00%)             0(0.00%)

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -42,6 +42,7 @@ sequences in the query too.
 # Imports
 import shutil
 import subprocess
+import tempfile
 from itertools import permutations
 from pathlib import Path
 
@@ -59,14 +60,7 @@ DELTA_DIR = Path("../fixtures/dnadiff/targets/delta")
 FILTER_DIR = Path("../fixtures/dnadiff/targets/filter")
 SHOW_DIFF_DIR = Path("../fixtures/dnadiff/targets/show_diff")
 SHOW_COORDS_DIR = Path("../fixtures/dnadiff/targets/show_coords")
-
-# dnadiff generates many files; since we only need `.report` files,
-# we will save all files to a temporary location, move the report files
-# to a specific directory, and remove the rest.
-Path("temp_dnadiff").mkdir(parents=True, exist_ok=True)
-
 DNADIFF_DIR = Path("../fixtures/dnadiff/targets/dnadiff_reports")
-DNADIFF_TEMP_DIR = Path("temp_dnadiff")
 
 # Running comparisons
 comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*.f*")], 2)
@@ -127,22 +121,15 @@ for genomes in comparisons:
             check=True,
             stdout=ofh,
         )
-
-    subprocess.run(
-        [
-            dnadiff.exe_path,
-            "-p",
-            DNADIFF_TEMP_DIR / stem,
-            inputs[genomes[0]],
-            inputs[genomes[1]],
-        ],
-        check=True,
-    )
-
-# Move `.report` files
-for file in DNADIFF_TEMP_DIR.glob("*.report"):
-    file.rename(DNADIFF_DIR / file.name)
-
-# remove dnadiff temporary directory
-if DNADIFF_TEMP_DIR.exists() and DNADIFF_TEMP_DIR.is_dir():
-    shutil.rmtree(DNADIFF_TEMP_DIR)
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.run(
+            [
+                dnadiff.exe_path,
+                "-p",
+                tmp + "/" + stem,
+                inputs[genomes[0]],
+                inputs[genomes[1]],
+            ],
+            check=True,
+        )
+        shutil.move(tmp + "/" + stem + ".report", DNADIFF_DIR / (stem + ".report"))

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -67,6 +67,8 @@ comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*.f*")], 2)
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*.f*")}
 
 # Cleanup
+# This is to help with if and when we change the
+# example sequences being used.
 for file in DELTA_DIR.glob("*.delta"):
     file.unlink()
 for file in FILTER_DIR.glob("*.filter"):

--- a/tests/generate_fixtures/generate_target_dnadiff_files.py
+++ b/tests/generate_fixtures/generate_target_dnadiff_files.py
@@ -63,10 +63,10 @@ SHOW_COORDS_DIR = Path("../fixtures/dnadiff/targets/show_coords")
 # dnadiff generates many files; since we only need `.report` files,
 # we will save all files to a temporary location, move the report files
 # to a specific directory, and remove the rest.
-Path("./temp_dnadiff").mkdir(parents=True, exist_ok=True)
+Path("temp_dnadiff").mkdir(parents=True, exist_ok=True)
 
 DNADIFF_DIR = Path("../fixtures/dnadiff/targets/dnadiff_reports")
-DNADIFF_TEMP_DIR = Path("./temp_dnadiff")
+DNADIFF_TEMP_DIR = Path("temp_dnadiff")
 
 # Running comparisons
 comparisons = permutations([_.stem for _ in Path(INPUT_DIR).glob("*.f*")], 2)
@@ -144,4 +144,5 @@ for file in DNADIFF_TEMP_DIR.glob("*.report"):
     file.rename(DNADIFF_DIR / file.name)
 
 # remove dnadiff temporary directory
-shutil.rmtree(DNADIFF_TEMP_DIR)
+if DNADIFF_TEMP_DIR.exists() and DNADIFF_TEMP_DIR.is_dir():
+    shutil.rmtree(DNADIFF_TEMP_DIR)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -154,6 +154,24 @@ def test_fake_show_diff() -> None:
         tools.get_show_diff(cmd)
 
 
+def test_fake_dnadiff() -> None:
+    """Confirm simple dnadiff version parsing works."""
+    info = tools.get_nucmer(
+        "tests/fixtures/tools/version_one"
+    )  # outputs "version 1.0.0"
+    assert info.exe_path == Path("tests/fixtures/tools/version_one").resolve()
+    assert info.version == "1.0.0"
+
+    info = tools.get_nucmer("tests/fixtures/tools/just_one")  # outputs "1.0.0"
+    assert info.exe_path == Path("tests/fixtures/tools/just_one").resolve()
+    assert info.version == "1.0.0"
+
+    cmd = Path("tests/fixtures/tools/cutting_edge")  # no numerical output
+    msg = f"Executable exists at {cmd.resolve()} but could not retrieve version"
+    with pytest.raises(RuntimeError, match=msg):
+        tools.get_dnadiff(cmd)
+
+
 def test_find_makeblastdb() -> None:
     """Confirm can find NCBI makeblastdb if on $PATH and determine its version."""
     # At the time of writing this dependency is NOT installed for CI testing
@@ -216,3 +234,11 @@ def test_find_show_diff() -> None:
     info = tools.get_show_diff()
     assert info.exe_path.parts[-1] == "show-diff"
     assert info.version == ""
+
+
+def test_find_dnadiff() -> None:
+    """Confirm can find dnadiff on $PATH."""
+    # At the time of writing this dependency is installed for CI testing
+    info = tools.get_dnadiff()
+    assert info.exe_path.parts[-1] == "dnadiff"
+    assert info.version.startswith("1.")


### PR DESCRIPTION
As stated in #17, we need to write a module that will parse the `dnadiff` output. I have been working on this in the `issue_17` branch, but the `main` branch has changed _slightly_ since then, and the working history on this matter might be hard to follow.

Similar to #96, I have decided to break this into smaller chunks and merge smaller changes into the `main` branch.

This PR introduces the following:

- Minor changes to `generate_target_dnadiff_files.py` to generate `.report` files, which have also been added to the repo. The content of the `.report` files contains information about the number of aligned bases, genome identity, etc., for pairwise comparisons, which will be used as a ground truth for testing the `dnadiff` method in `pyani_plus`. 

```bash
/Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0264574.fas /Users/angelikakiepas/Desktop/pyani-plus/tests/generate_fixtures/../fixtures/viral_example/MGV-GENOME-0266457.fna
NUCMER

                               [REF]                [QRY]
[Sequences]
TotalSeqs                          1                    1
AlignedSeqs               1 (100.00%)           1 (100.00%)
UnalignedSeqs               0 (0.00%)             0 (0.00%)

[Bases]
TotalBases                     39253                39594
AlignedBases           39169 (99.79%)        39176 (98.94%)
UnalignedBases             84 (0.21%)           418 (1.06%)
```
- I have added `get_dnadiff` to `tools.py`. Although `pyani-plus` will not need `dnadiff`, it was necessary for me to generate fixtures. We can always remove this if it’s not needed. 
- I have also added the directory with all `dnadiff` `.report` files to `conftest.py` fixtures.