### PR TITLE
Implement Fixture cleanup in `generate_fixture` scipt - Fixes #114

### DIFF
--- a/tests/generate_fixtures/generate_anib_blast_files.py
+++ b/tests/generate_fixtures/generate_anib_blast_files.py
@@ -47,6 +47,12 @@ QUERY_DIR = Path("../fixtures/anib/fragments")
 NJS_DIR = Path("../fixtures/anib/blastdb")
 BLASTN_DIR = Path("../fixtures/anib/blastn")
 
+# Remove pre-existing fixtures before regenerating new ones.
+# This is to help with if and when we change the
+# example sequences being used.
+for file in NJS_DIR.glob("*.njs"):
+    file.unlink()
+
 blastn = get_blastn()
 makeblastdb = get_makeblastdb()
 if blastn.version != makeblastdb.version:

--- a/tests/generate_fixtures/generate_anib_fragment_files.py
+++ b/tests/generate_fixtures/generate_anib_fragment_files.py
@@ -40,6 +40,12 @@ INPUT_DIR = Path("../fixtures/viral_example")
 FRAG_DIR = Path("../fixtures/anib/fragments")
 FRAGSIZE = 1020  # Default ANIb fragment size
 
+# Remove pre-existing fixtures before regenerating new ones.
+# This is to help with if and when we change the
+# example sequences being used.
+for file in FRAG_DIR.glob("*.fna"):
+    file.unlink()
+
 # Note flexible on input *.fna vs *.fa vs *.fasta, but fixed on output
 for fasta in INPUT_DIR.glob("*.f*"):
     output = FRAG_DIR / (fasta.stem + "-fragments.fna")

--- a/tests/generate_fixtures/generate_pyani_anim_matrices.sh
+++ b/tests/generate_fixtures/generate_pyani_anim_matrices.sh
@@ -27,6 +27,14 @@ pyani --version
 # Abort if not matched (via set -e above)
 pyani --version 2>&1 | grep "pyani version: 0\.3\." > /dev/null
 
+# Remove pre-existing fixtures before regenerating new ones.
+# This is to help with if and when we change the
+# example sequences being used.
+echo "Removing pre-existing fixtures..."
+for file in ../fixtures/anim/matrices/*.tsv; do
+    rm "$file"
+done
+
 # Make a temp subdir
 mkdir tmp_pyani_anim
 cd tmp_pyani_anim

--- a/tests/generate_fixtures/generate_pyani_fastani_matrices.sh
+++ b/tests/generate_fixtures/generate_pyani_fastani_matrices.sh
@@ -25,12 +25,20 @@ set -euo pipefail
 echo "This is intended to be used with pyANI v0.3, we have:"
 pyani --version
 
+# Remove pre-existing fixtures before regenerating new ones.
+# This is to help with if and when we change the
+# example sequences being used.
+echo "Removing pre-existing fixtures..."
+for file in ../fixtures/fastani/matrices/*.tsv; do
+    rm "$file"
+done
+
 # Make a temp subdir
 mkdir tmp_pyani_fastani
 cd tmp_pyani_fastani
 
 echo "Creating pyANI database"
-pyani createdb
+pyani createdb --force
 
 echo "Setting up input genomes"
 for FASTA in ../../../tests/fixtures/viral_example/*.f*; do

--- a/tests/generate_fixtures/generate_target_fastani_files.py
+++ b/tests/generate_fixtures/generate_target_fastani_files.py
@@ -46,6 +46,12 @@ FRAG_LEN = 3000
 KMER_SIZE = 16
 MIN_FRAC = 0.2
 
+# Remove pre-existing fixtures before regenerating new ones.
+# This is to help with if and when we change the
+# example sequences being used.
+for file in FASTANI_DIR.glob("*.fastani"):
+    file.unlink()
+
 # Running comparisons
 inputs = {_.stem: _ for _ in Path(INPUT_DIR).glob("*.f*")}
 comparisons = product(inputs, inputs)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -115,7 +115,7 @@ def test_fake_fastani() -> None:
 
 
 def test_fake_nucmer() -> None:
-    """Confirm simple fastani version parsing works."""
+    """Confirm simple nucmer version parsing works."""
     info = tools.get_nucmer("tests/fixtures/tools/just_one")  # parsed like mummer v4
     assert info.exe_path == Path("tests/fixtures/tools/just_one").resolve()
     assert info.version == "1.0.0"


### PR DESCRIPTION
As mentioned in #114 and #110, whenever we want to rerun the scripts for generating fixtures, it will be worth it to delete the pre-existing fixtures. This might not be necessary if the input sets remain the same, but it will be handy if we decide to change the test sets.

This PR introduces the changes for fixture generation process by ensuring we remove pre-existing fixtures first.