### PR TITLE
Assorted fixes for testing matrix comparisons

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -172,9 +172,11 @@ def log_run(  # noqa: PLR0913
             md5 = file_md5sum(filename)
             genomes.append(db_orm.add_genome(session, filename, md5))
 
-    run_id = db_orm.add_run(
+    run = db_orm.add_run(
         session, config, cmdline, status, name, date=None, genomes=genomes
-    ).run_id
+    )
+    run.cache_comparisons()
+    run_id = run.run_id
 
     session.commit()
     session.close()

--- a/tests/snakemake/__init__.py
+++ b/tests/snakemake/__init__.py
@@ -68,6 +68,7 @@ def compare_matrices(database_path: Path, matrices_path: Path) -> None:
     * ``matrix_identity.tsv``
     * ``matrix_sim_errors.tsv``
 
+    If any of the files are missing, the comparison is skipped.
     """
     session = db_orm.connect_to_db(database_path)
     run = session.query(db_orm.Run).one()
@@ -75,10 +76,15 @@ def compare_matrices(database_path: Path, matrices_path: Path) -> None:
     if run.identities is None:
         run.cache_comparisons()
 
-    compare_matrix(run.identities, matrices_path / "matrix_identity.tsv")
-    if False:
-        # These don't yet work for fastANI
+    assert matrices_path.is_dir()
+
+    if (matrices_path / "matrix_identity.tsv").is_file():
+        compare_matrix(run.identities, matrices_path / "matrix_identity.tsv")
+    if (matrices_path / "matrix_aln_lengths.tsv").is_file():
         compare_matrix(run.aln_length, matrices_path / "matrix_aln_lengths.tsv")
-        compare_matrix(run.sim_errors, matrices_path / "matrix_sim_errors.tsv")
+    if (matrices_path / "matrix_coverage.tsv").is_file():
         compare_matrix(run.cov_query, matrices_path / "matrix_coverage.tsv")
+    if (matrices_path / "matrix_hadamard.tsv").is_file():
         compare_matrix(run.hadamard, matrices_path / "matrix_hadamard.tsv")
+    if (matrices_path / "matrix_sim_errors.tsv").is_file():
+        compare_matrix(run.sim_errors, matrices_path / "matrix_sim_errors.tsv")

--- a/tests/snakemake/__init__.py
+++ b/tests/snakemake/__init__.py
@@ -51,6 +51,11 @@ def compare_matrix(matrix_df: pd.DataFrame, matrix_path: Path) -> None:
         .sort_index(axis=1)
     )
     assert list(matrix_df.columns) == list(expected_df.columns)
+    if not expected_df.dtypes.equals(matrix_df.dtypes):
+        # This happens with some old pyANI output using floats for ints
+        # Cast both to float
+        expected_df = expected_df.astype(float)
+        matrix_df = matrix_df.astype(float)
     pd.testing.assert_frame_equal(matrix_df, expected_df, obj=matrix_path.stem)
 
 

--- a/tests/snakemake/__init__.py
+++ b/tests/snakemake/__init__.py
@@ -78,9 +78,7 @@ def compare_matrices(database_path: Path, matrices_path: Path) -> None:
     session = db_orm.connect_to_db(database_path)
     run = session.query(db_orm.Run).one()
 
-    if run.identities is None:
-        run.cache_comparisons()
-
+    assert run.identities is not None
     assert matrices_path.is_dir()
 
     if (matrices_path / "matrix_identity.tsv").is_file():

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -33,11 +33,12 @@ from pathlib import Path
 
 import pytest
 
+from pyani_plus import db_orm
 from pyani_plus.private_cli import log_configuration, log_genome, log_run
 from pyani_plus.snakemake import snakemake_scheduler
 from pyani_plus.tools import get_fastani
 
-from . import compare_matrices
+from . import compare_matrix
 
 
 @pytest.fixture
@@ -151,7 +152,10 @@ def test_snakemake_rule_fastani(  # noqa: PLR0913
         minmatch=config_fastani_args["minFrac"],
         create_db=False,
     )
-    compare_matrices(db, fastani_matrices)
+    # Will want to do this, compare_matrices(db, fastani_matrices), but for now:
+    session = db_orm.connect_to_db(db)
+    run = session.query(db_orm.Run).one()
+    compare_matrix(run.identities, fastani_matrices / "matrix_identity.tsv")
 
 
 def test_snakemake_duplicate_stems(


### PR DESCRIPTION
This is work from the ANIb and fastANI matrix testing (issues #102 and #104).

The helper function will now test all available matrices (which we want to do generally), but this currently breaks with fastANI - so that is disabled in the short term.