### PR TITLE
Test ANIb matrices - Issue 102

### DIFF
--- a/pyani_plus/methods/method_anib.py
+++ b/pyani_plus/methods/method_anib.py
@@ -63,9 +63,6 @@ def fragment_fasta_files(
         if not isinstance(filename, Path):
             msg = f"Expected a Path object in list of FASTA files, got {filename!r}"
             raise TypeError(msg)
-        if not filename.is_file():
-            msg = f"Cannot fragment {filename!s}, file not found"
-            raise ValueError(msg)
         frag_filename = outdir / (filename.stem + "-fragments.fna")
         with filename.open() as in_handle, frag_filename.open("w") as out_handle:
             count = 0
@@ -79,5 +76,8 @@ def fragment_fasta_files(
                     for i in range(0, len(fragment), 60):
                         out_handle.write(fragment[i : i + 60] + "\n")
                     index += fragsize
+        if not count:
+            msg = f"No sequences found in {filename}"
+            raise ValueError(msg)
         fragmented_files.append(frag_filename)
     return fragmented_files

--- a/pyani_plus/methods/method_anib.py
+++ b/pyani_plus/methods/method_anib.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 FRAGSIZE = 1020  # Default ANIb fragment size
+MIN_COVERAGE = 0.7
+MIN_IDENTITY = 0.3
 
 # We do NOT use the standard 12 columns, but a custom 15 cols as per old pyANI
 # std = qaccver saccver pident length mismatch gapopen qstart qend sstart send evalue bitscore
@@ -81,3 +83,87 @@ def fragment_fasta_files(
             raise ValueError(msg)
         fragmented_files.append(frag_filename)
     return fragmented_files
+
+
+def parse_blastn_file(blastn: Path) -> tuple[float, int, int]:
+    """Extract the ANI etc from a blastn output file using the ANIb method.
+
+    Parses the BLAST tabular output file, taking only rows with a query coverage
+    over 70% and percentage identity over 30%, and deduplicating.
+
+    Returns mean percentage identity of all BLAST alignments passing thresholds
+    (treated as zero rather than NaN if there are no accepted alignments), the
+    total alignment length, and total similarity errors (mismatches and gaps).
+
+    >>> fname = (
+    ...     "tests/fixtures/anib/blastn/MGV-GENOME-0264574_vs_MGV-GENOME-0266457.tsv"
+    ... )
+    >>> identity, length, sim_errors = parse_blastn_file(Path(fname))
+    >>> print(
+    ...     f"Identity {100*identity:0.1f}% over length {length} with {sim_errors} errors"
+    ... )
+    Identity 99.5% over length 39169 with 215 errors
+
+    We expect 100% identity for a self comparison (but this is not always true):
+
+    >>> fname = (
+    ...     "tests/fixtures/anib/blastn/MGV-GENOME-0264574_vs_MGV-GENOME-0264574.tsv"
+    ... )
+    >>> identity, length, sim_errors = parse_blastn_file(Path(fname))
+    >>> print(
+    ...     f"Identity {100*identity:0.1f}% over length {length} with {sim_errors} errors"
+    ... )
+    Identity 100.0% over length 39253 with 0 errors
+    """
+    total_aln_length = 0
+    total_sim_errors = 0
+    all_pid: list[float] = []
+
+    prev_query = ""
+    with blastn.open() as handle:
+        for line in handle:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) != len(BLAST_COLUMNS):
+                msg = (
+                    f"Found {len(fields)} columns in {blastn}, not {len(BLAST_COLUMNS)}"
+                )
+                raise ValueError(msg)
+            if not fields[0].startswith("frag"):
+                msg = (
+                    f"BLAST output should be using fragmented queries, not {fields[0]}"
+                )
+                raise ValueError(msg)
+            values = dict(zip(BLAST_COLUMNS, fields, strict=False))
+            blast_alnlen = int(values["length"])
+            blast_gaps = int(values["gaps"])
+            ani_alnlen = blast_alnlen - blast_gaps
+            blast_mismatch = int(values["mismatch"])
+            ani_alnids = ani_alnlen - blast_mismatch
+            ani_query_coverage = ani_alnlen / int(values["qlen"])
+            # Can't use float(values["pident"])/100, this is relative to alignment length
+            ani_pid = ani_alnids / int(values["qlen"])
+
+            # Now apply filters - should these be parameters?
+            # And if there are multiple hits for this query, take first (best) one
+            if (
+                ani_query_coverage > MIN_COVERAGE
+                and ani_pid > MIN_IDENTITY
+                and prev_query != fields[0]
+            ):
+                total_aln_length += ani_alnlen
+                total_sim_errors += blast_mismatch + blast_gaps
+                # Not using ani_pid but BLAST's pident - see note below:
+                all_pid.append(float(values["pident"]) / 100)
+                prev_query = fields[0]  # to detect multiple hits for a query
+    # NOTE: Could warn about empty BLAST file using if prev_query is None:
+
+    # NOTE: We report the mean of blastn's pident for concordance with JSpecies
+    # Despite this, the concordance is not exact. Manual inspection during
+    # the original pyANI development indicated that a handful of fragments
+    # are differentially filtered out in JSpecies and here. This is often
+    # on the basis of rounding differences (e.g. coverage being close to 70%).
+    return (
+        sum(all_pid) / len(all_pid) if all_pid else 0,
+        total_aln_length,
+        total_sim_errors,
+    )

--- a/pyani_plus/workflows/snakemake_anib.smk
+++ b/pyani_plus/workflows/snakemake_anib.smk
@@ -68,7 +68,9 @@ rule blastdb:
 # For ANIb query the fragments FASTA from genomeA against a BLAST DB of genomeB.
 rule blastn:
     params:
+        db=config["db"],
         blastn=config["blastn"],
+        fragLen=config["fragLen"],
         indir=config["indir"],
         outdir=config["outdir"],
     input:
@@ -84,5 +86,9 @@ rule blastn:
             -db {wildcards.outdir}/{wildcards.genomeB} -out {output} -task blastn \
             -outfmt '6 qseqid sseqid length mismatch pident nident qlen slen \
                      qstart qend sstart send positive ppos gaps' \
-            -xdrop_gap_final 150 -dust no -evalue 1e-15 -max_target_seqs 1
+            -xdrop_gap_final 150 -dust no -evalue 1e-15 -max_target_seqs 1 &&
+        .pyani-plus-private-cli log-anib --database {params.db} \
+            --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
+            --blastn {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.tsv \
+            --fragsize {params.fragLen}
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,12 @@ def anib_targets_blastn(
 
 
 @pytest.fixture
+def dir_anib_results() -> Path:
+    """Directory containing pyani v0.3 ANIb matrices."""
+    return FIXTUREPATH / "anib" / "matrices"
+
+
+@pytest.fixture
 def anim_nucmer_targets_filter_indir() -> Path:
     """Directory containing MUMmer filter snakemake reference files."""
     return FIXTUREPATH / "anim" / "targets" / "filter"

--- a/tests/snakemake/test_snakemake_anib_workflow.py
+++ b/tests/snakemake/test_snakemake_anib_workflow.py
@@ -53,7 +53,7 @@ def config_anib_args(
     small set of input genomes as arguments.
     """
     return {
-        "db": Path(tmp_path) / "db.slqite",
+        "db": Path(tmp_path) / "db.sqlite",
         "blastn": get_blastn().exe_path,
         "makeblastdb": get_makeblastdb().exe_path,
         "outdir": anib_targets_outdir,

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -1,0 +1,48 @@
+# The MIT License
+#
+# Copyright (c) 2024 University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Tests for the ANIb implementation.
+
+These tests are intended to be run from the repository root using:
+
+pytest -v
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pyani_plus.methods import method_anib
+
+
+def test_bad_path(tmp_path: str) -> None:
+    """Confirm giving an empty path etc fails."""
+    with pytest.raises(
+        FileNotFoundError, match="No such file or directory: '/does/not/exist'"
+    ):
+        method_anib.fragment_fasta_files([Path("/does/not/exist")], Path(tmp_path))
+
+
+def test_empty_path(tmp_path: str) -> None:
+    """Confirm giving an empty path etc fails."""
+    with pytest.raises(ValueError, match="No sequences found in /dev/null"):
+        method_anib.fragment_fasta_files([Path("/dev/null")], Path(tmp_path))
+    # Note it is valid to have an empty BLASTN TSV file (there are no headers)

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -402,7 +402,7 @@ def test_fragment_fasta_bad_args(tmp_path: str, input_genomes_tiny: Path) -> Non
         private_cli.fragment_fasta(fasta, outdir=Path("/does/not/exist"))
 
     with pytest.raises(
-        ValueError, match="Cannot fragment /does/not/exist.fasta, file not found"
+        FileNotFoundError, match="No such file or directory: '/does/not/exist.fasta'"
     ):
         private_cli.fragment_fasta([Path("/does/not/exist.fasta")], out_dir)
 


### PR DESCRIPTION
This would close issue #102.

Adds parsing of the BLASTN TSV output files following the approach in pyani branch version_0_2 (although rewritten to parse the file line by line, rather than loading it all into memory using pandas).

Adds a private command line function to log the ANIb output to the database, and calls this from snakemake.

Validates all the matrices match those from pyani v0.2 (added earlier in #108).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
