### PR TITLE
Make DB logging API stricter; rename add_comparison -> db_comparison etc

### DIFF
--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -101,26 +101,14 @@ def test_missing_db(tmp_path: str, input_genomes_tiny: Path, anib_blastn: Path) 
     tmp_db = Path(tmp_path) / "new.sqlite"
     assert not tmp_db.is_file()
 
-    with pytest.raises(SystemExit, match="does not exist, but not using --create-db"):
+    with pytest.raises(SystemExit, match="does not exist"):
         log_anib(
             database=tmp_db,
             # These are for the comparison table
             query_fasta=input_genomes_tiny / "MGV-GENOME-0264574.fas",
             subject_fasta=input_genomes_tiny / "MGV-GENOME-0266457.fna",
             blastn=anib_blastn / "MGV-GENOME-0264574_vs_MGV-GENOME-0266457.tsv",
-            create_db=False,
         )
-
-    # This should work:
-    log_anib(
-        database=tmp_db,
-        # These are for the comparison table
-        query_fasta=input_genomes_tiny / "MGV-GENOME-0264574.fas",
-        subject_fasta=input_genomes_tiny / "MGV-GENOME-0266457.fna",
-        blastn=anib_blastn / "MGV-GENOME-0264574_vs_MGV-GENOME-0266457.tsv",
-        create_db=True,
-    )
-    tmp_db.unlink()
 
 
 def test_bad_query_or_subject(

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -69,7 +69,6 @@ def test_bad_query_or_subject(
             fragsize=1000,
             kmersize=51,
             minmatch=0.9,
-            create_db=False,
         )
 
     with pytest.raises(
@@ -91,7 +90,6 @@ def test_bad_query_or_subject(
             fragsize=1000,
             kmersize=51,
             minmatch=0.9,
-            create_db=False,
         )
 
 
@@ -102,7 +100,7 @@ def test_missing_db(
     tmp_db = Path(tmp_path) / "new.sqlite"
     assert not tmp_db.is_file()
 
-    with pytest.raises(SystemExit, match="does not exist, but not using --create-db"):
+    with pytest.raises(SystemExit, match="does not exist"):
         log_fastani(
             database=tmp_db,
             # These are for the comparison table
@@ -114,21 +112,4 @@ def test_missing_db(
             fragsize=1000,
             kmersize=51,
             minmatch=0.9,
-            create_db=False,
         )
-
-    # This should work:
-    log_fastani(
-        database=tmp_db,
-        # These are for the comparison table
-        query_fasta=input_genomes_tiny / "MGV-GENOME-0264574.fas",
-        subject_fasta=input_genomes_tiny / "MGV-GENOME-0266457.fna",
-        fastani=fastani_targets_indir
-        / "MGV-GENOME-0264574_vs_MGV-GENOME-0266457.fastani",
-        # These are all for the configuration table:
-        fragsize=1000,
-        kmersize=51,
-        minmatch=0.9,
-        create_db=True,
-    )
-    tmp_db.unlink()


### PR DESCRIPTION
I want to change the command line and internal API to make adding dependent table rows more configurable. In particular currently adding a comparison will implicitly add the configuration and genome rows if not already there - which may be undesirable (e.g. mismatch between the intended configuration already in the DB, and what snakemake is trying to use instead which if wrong will not already exist). This was deliberate while bootstrapping the framework as I could use the log-comparison functionality in isolation, creating a new DB as needed.

With these changes ``log_comparison`` and the ``log_<method>`` functions like ``log_fastani`` will now REQUIRE that the database exists and contains the configuration and genomes already.

This ensures our snakemake workflows WILL FAIL if they are trying to write to a non-existent configuration due to an error in propagating the configuration settings.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
