### PR TITLE
Catch empty nucmer file explicitly

### DIFF
--- a/pyani_plus/methods/method_anim.py
+++ b/pyani_plus/methods/method_anim.py
@@ -132,7 +132,12 @@ def parse_delta(filename: Path) -> tuple[int, int, float, int]:
     aligned_bases = 0  # Hold a count of aligned bases for each sequence
     weighted_identical_bases = 0  # Hold a count of weighted identical bases
 
-    for line in [_.strip().split() for _ in filename.open("r").readlines()]:
+    # Ideally we wouldn't read the whole file into memory at once...
+    lines = [_.strip().split() for _ in filename.open("r").readlines()]
+    if not lines:
+        msg = f"Empty delta file from nucmer, {filename}"
+        raise ValueError(msg)
+    for line in lines:
         if line[0] == "NUCMER":  # Skip headers
             continue
         # Lines starting with ">" indicate which sequences are aligned

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -153,6 +153,9 @@ def test_delta_parsing(anim_nucmer_targets_filter_indir: Path) -> None:
         222,
     )
 
+    with pytest.raises(ValueError, match="Empty delta file from nucmer, /dev/null"):
+        method_anim.parse_delta(Path("/dev/null"))
+
 
 def test_aligned_bases_count(aligned_regions: dict) -> None:
     """Check only aligned bases in non-overlapping regions are counted."""


### PR DESCRIPTION
Without this we got a divide-by-zero when calculating the average percentage identity. We need a test case with a real nucmer delta file giving no alignment...

[Spotted while working on something else which appears to have accidentally triggered empty delta files. In future work we will want a test case which really does have no alignment, and at that point handle the divide-by-zero situation explicitly]

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
