### PR TITLE
update snakemake version in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ biopython
 intervaltree
 moreutils>=0.67
 perl-ipc-run
-snakemake>=8.12
+snakemake>=8.24
 rich
 sqlalchemy>=2.0
 typer>=0.12


### PR DESCRIPTION
After some changes have been implemented, I found out that it broke few things on my side returing the followowing errors:

```bash
ImportError while importing test module '/Users/angelikakiepas/Desktop/pyani-plus/tests/test_anim.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/anaconda3/envs/pyani_plus_dev_2/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_anim.py:35: in <module>
    from pyani_plus import db_orm, private_cli, tools, utils
pyani_plus/private_cli.py:37: in <module>
    from pyani_plus.public_cli import (
pyani_plus/public_cli.py:52: in <module>
    from pyani_plus.snakemake import snakemake_scheduler
pyani_plus/snakemake/snakemake_scheduler.py:28: in <module>
    from snakemake.settings.types import OutputSettings, Quietness
E   ModuleNotFoundError: No module named 'snakemake.settings.types'; 'snakemake.settings' is not a package
```
I realised that the installed `snakemake` version was 8.12, which was the minimum required based on `requirements.txt`. After installing `snakemake v8.24`, the issue was resolved. I have now updated the minimum version in `requirements.txt` to prevent potential issues for end-users.