### PR TITLE
Avoid implicit os.fork() on Linux; improve comparison progress bar

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -177,13 +177,7 @@ def run_snakemake_with_progress_bar(  # noqa: PLR0913
     working_directory: Path,
     interval: float = 0.5,
 ) -> None:
-    """Run snakemake with a progress bar.
-
-    Currently this works by monitoring the filesystem for the appearance of
-    the output files, while snakemake runs in a subprocess. This is not ideal,
-    and ideally we would use some kind of callbacks from snakemake - perhaps
-    using their logging mechanism.
-    """
+    """Run snakemake with a progress bar."""
     runner = snakemake_scheduler.SnakemakeRunner(workflow_name)
     # All rest replaces one line, runner.run_workflow(targets, params, workdir=working_directory)
 


### PR DESCRIPTION
This is to close #146 (avoid implicit ``os.fork()`` on Linux), but expanded to improve the progress-bar usage.

As of Python 3.8 onwards, the default on macOS ("Darwin") is "spawn"

As of Python 3.12, the default of "fork" on Linux triggers a deprecation warning. As of Python 3.14 on Linux the default will be "forkserver".

This changes our code to explicitly use "spawn" on macOS or "forkserver" otherwise.

For the progress bar, testing with SLURM on the Linux HPC revealed a problem with the initial thread setup. Originally I updated the progress bar on the main thread, with the single 'black-box' function call to snakemake on a child thread. That worked, but when snakemake failed we didn't get to see the traceback.

Furthermore, I fear the initial solution of monitoring the file system for the appearance of the target files will scale badly. This has now been changed to monitor progress via the database, and we can use the sqlite PRAGMA data_version to make this efficient.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
