### PR TITLE
Typer CLI polish

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -545,7 +545,7 @@ def log_anib(
     return 0
 
 
-@app.command()
+@app.command(rich_help_panel="Method specific logging")
 def log_dnadiff(
     database: REQ_ARG_TYPE_DATABASE,
     # These are for the comparison table

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -50,13 +50,34 @@ app = typer.Typer(
 )
 
 REQ_ARG_TYPE_FASTA_FILES = Annotated[
-    list[Path], typer.Argument(help="Path(s) to FASTA file(s)", show_default=False)
+    list[Path],
+    typer.Argument(
+        help="Path(s) to FASTA file(s)",
+        show_default=False,
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+    ),
 ]
 REQ_ARG_TYPE_QUERY_FASTA = Annotated[
-    Path, typer.Option(help="Path to query FASTA file", show_default=False)
+    Path,
+    typer.Option(
+        help="Path to query FASTA file",
+        show_default=False,
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+    ),
 ]
 REQ_ARG_TYPE_SUBJECT_FASTA = Annotated[
-    Path, typer.Option(help="Path to subject FASTA file", show_default=False)
+    Path,
+    typer.Option(
+        help="Path to subject FASTA file",
+        show_default=False,
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+    ),
 ]
 REQ_ARG_TYPE_METHOD = Annotated[
     str, typer.Option(help="Method, e.g. ANIm", show_default=False)

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -73,7 +73,9 @@ REQ_ARG_TYPE_VERSION = Annotated[
 NONE_ARG_TYPE_FRAGSIZE = Annotated[
     int | None,
     typer.Option(
-        help="Comparison method fragment size", rich_help_panel="Method parameters"
+        help="Comparison method fragment size",
+        rich_help_panel="Method parameters",
+        min=1,
     ),
 ]
 NONE_ARG_TYPE_MAXMATCH = Annotated[
@@ -82,13 +84,16 @@ NONE_ARG_TYPE_MAXMATCH = Annotated[
 NONE_ARG_TYPE_KMERSIZE = Annotated[
     int | None,
     typer.Option(
-        help="Comparison method k-mer size", rich_help_panel="Method parameters"
+        help="Comparison method k-mer size", rich_help_panel="Method parameters", min=1
     ),
 ]
 NONE_ARG_TYPE_MINMATCH = Annotated[
     float | None,
     typer.Option(
-        help="Comparison method min-match", rich_help_panel="Method parameters"
+        help="Comparison method min-match",
+        rich_help_panel="Method parameters",
+        min=0.0,
+        max=1.0,
     ),
 ]
 

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -76,19 +76,25 @@ REQ_ARG_TYPE_FASTA_DIR = Annotated[
 OPT_ARG_TYPE_FRAGSIZE = Annotated[
     int,
     typer.Option(
-        help="Comparison method fragment size", rich_help_panel="Method parameters"
+        help="Comparison method fragment size",
+        rich_help_panel="Method parameters",
+        min=1,
     ),
 ]
+# fastANI has maximum (and default) k-mer size 16
 OPT_ARG_TYPE_KMERSIZE = Annotated[
     int,
     typer.Option(
-        help="Comparison method k-mer size", rich_help_panel="Method parameters"
+        help="Comparison method k-mer size", rich_help_panel="Method parameters", min=1
     ),
 ]
 OPT_ARG_TYPE_MINMATCH = Annotated[
     float,
     typer.Option(
-        help="Comparison method min-match", rich_help_panel="Method parameters"
+        help="Comparison method min-match",
+        rich_help_panel="Method parameters",
+        min=0.0,
+        max=1.0,
     ),
 ]
 OPT_ARG_TYPE_CREATE_DB = Annotated[

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -56,13 +56,26 @@ FASTA_EXTENSIONS = {".fasta", ".fas", ".fna"}  # define more centrally?
 
 # Reused required command line arguments (which have no default)
 REQ_ARG_TYPE_DATABASE = Annotated[
-    Path, typer.Option(help="Path to pyANI-plus SQLite3 database", show_default=False)
+    Path,
+    typer.Option(
+        help="Path to pyANI-plus SQLite3 database",
+        show_default=False,
+        dir_okay=False,
+        file_okay=True,
+    ),
 ]
 REQ_ARG_TYPE_RUN_NAME = Annotated[
     str, typer.Option(help="Run name", show_default=False)
 ]
 REQ_ARG_TYPE_OUTDIR = Annotated[
-    Path, typer.Option(help="Output directory", show_default=False)
+    Path,
+    typer.Option(
+        help="Output directory",
+        show_default=False,
+        exists=True,
+        dir_okay=True,
+        file_okay=False,
+    ),
 ]
 REQ_ARG_TYPE_FASTA_DIR = Annotated[
     Path,

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -92,7 +92,8 @@ OPT_ARG_TYPE_MINMATCH = Annotated[
     ),
 ]
 OPT_ARG_TYPE_CREATE_DB = Annotated[
-    bool, typer.Option(help="Create database if does not exist")
+    # Listing name(s) explicitly to avoid automatic matching --no-create-db
+    bool, typer.Option("--create-db", help="Create database if does not exist")
 ]
 
 progress_columns = [


### PR DESCRIPTION
Assorted improvements to the ``typer`` based CLI, mostly based on readying more of the documentation at https://typer.tiangolo.com/ but also moving ``log-dnadiff`` into the "Method specific logging" section for the private CLI help.

Example output showing bounds on the parameters:

```console
$ pyani-plus fastani -h
                                                                                  
 Usage: pyani-plus fastani [OPTIONS] FASTA                                        
                                                                                  
 Execute fastANI calculations, logged to a pyANI-plus SQLite3 database.           
                                                                                  
╭─ Arguments ────────────────────────────────────────────────────────────────────╮
│ *    fasta      PATH  Directory of FASTA files (extensions .fas, .fasta, .fna) │
│                       [required]                                               │
╰────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ──────────────────────────────────────────────────────────────────────╮
│ *  --database           FILE  Path to pyANI-plus SQLite3 database [required]   │
│ *  --name               TEXT  Run name [required]                              │
│    --create-db                Create database if does not exist                │
│    --help       -h            Show this message and exit.                      │
╰────────────────────────────────────────────────────────────────────────────────╯
╭─ Method parameters ────────────────────────────────────────────────────────────╮
│ --fragsize        INTEGER RANGE [x>=1]       Comparison method fragment size   │
│                                              [default: 3000]                   │
│ --kmersize        INTEGER RANGE [x>=1]       Comparison method k-mer size      │
│                                              [default: 16]                     │
│ --minmatch        FLOAT RANGE [0.0<=x<=1.0]  Comparison method min-match       │
│                                              [default: 0.2]                    │
╰────────────────────────────────────────────────────────────────────────────────╯
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
