### PR TITLE
Use rich.table for the list-runs output

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -569,7 +569,7 @@ def list_runs(
         conf = run.configuration
         n = run.genomes.count()
         done = run.comparisons().count()
-        comparison_summary = f"{done}/{n**2}={n}x{n}"
+        comparison_summary = f"{done}/{n**2}={n}²"
         if done == 0:
             comparison_summary = Text(comparison_summary, style="red")
         elif done != n**2:


### PR DESCRIPTION
This replaces the current main branch placeholder output for the ``list-runs`` command, which is/was as follows - using 3 lines per run but including the program and version (which this change drops):

```console
$ pyani-plus list-runs --database x.db
Database x.db contains 11 runs
Run-ID 1, '4B'
  4 genomes; date 2024-10-17 20:47:06.977657; status Done
  Method fastANI; program fastANI 1.33
Run-ID 2, '4B'
  4 genomes; date 2024-10-17 20:47:52.903618; status Done
  Method fastANI; program fastANI 1.33
Run-ID 3, '4B'
  4 genomes; date 2024-10-17 20:48:07.212665; status Done
  Method ANIb; program blastn 2.16.0+
Run-ID 4, '4B'
  4 genomes; date 2024-10-17 20:53:18.633298; status Done
  Method ANIb; program blastn 2.16.0+
Run-ID 5, '4B'
  4 genomes; date 2024-10-18 08:07:43.242812; status Done
  Method ANIb; program blastn 2.16.0+
Run-ID 6, '4B'
  4 genomes; date 2024-10-18 08:07:53.195594; status Setup
  Method ANIm; program nucmer 3.1
Run-ID 7, '4B'
  3 genomes; date 2024-10-18 08:19:11.761123; status Setup
  Method ANIm; program nucmer 3.1
Run-ID 8, '4B'
  3 genomes; date 2024-10-18 08:22:49.174134; status Done
  Method ANIm; program nucmer 3.1
Run-ID 9, '4B'
  4 genomes; date 2024-10-18 08:59:39.823543; status Done
  Method ANIm; program nucmer 3.1
Run-ID 10, 'Three little viruses'
  3 genomes; date 2024-10-25 11:45:00.722929; status Setup
  Method ANIb; program blastn 2.16.0+
Run-ID 11, 'Assorted Pectobacterium from RefSeq'
  871 genomes; date 2024-10-25 12:02:18.024587; status Setup
  Method fastANI; program fastANI 1.33
```

Sample output using the SF mono font in the macOS terminal:

<img width="1719" alt="Screenshot 2024-10-25 at 14 39 31" src="https://github.com/user-attachments/assets/e0df8c58-aec0-4af2-8e8a-5e853193a3d4">

As plain text:

```console
$ pyani-plus list-runs --database x.db
                           11 analysis runs in x.db                           
┏━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
┃ ID ┃ Date       ┃ Method  ┃ Comparisons      ┃ Status ┃ Name               ┃
┡━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
│  1 │ 2024-10-17 │ fastANI │        15/16=4x4 │ Done   │ 4B                 │
│  2 │ 2024-10-17 │ fastANI │        15/16=4x4 │ Done   │ 4B                 │
│  3 │ 2024-10-17 │ ANIb    │        16/16=4x4 │ Done   │ 4B                 │
│  4 │ 2024-10-17 │ ANIb    │        16/16=4x4 │ Done   │ 4B                 │
│  5 │ 2024-10-18 │ ANIb    │        16/16=4x4 │ Done   │ 4B                 │
│  6 │ 2024-10-18 │ ANIm    │        16/16=4x4 │ Setup  │ 4B                 │
│  7 │ 2024-10-18 │ ANIm    │          9/9=3x3 │ Setup  │ 4B                 │
│  8 │ 2024-10-18 │ ANIm    │          9/9=3x3 │ Done   │ 4B                 │
│  9 │ 2024-10-18 │ ANIm    │        16/16=4x4 │ Done   │ 4B                 │
│ 10 │ 2024-10-25 │ ANIb    │          0/9=3x3 │ Setup  │ Three little       │
│    │            │         │                  │        │ viruses            │
│ 11 │ 2024-10-25 │ fastANI │ 0/758641=871x871 │ Setup  │ Assorted           │
│    │            │         │                  │        │ Pectobacterium     │
│    │            │         │                  │        │ from RefSeq        │
└────┴────────────┴─────────┴──────────────────┴────────┴────────────────────┘
```

This behaves OK when there is not enough width:

```console
$ pyani-plus list-runs --database x.db
                 11 analysis runs in x.db                  
┏━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┓
┃ ID ┃ Date   ┃ Meth… ┃ Comparisons      ┃ Status ┃ Name  ┃
┡━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━┩
│  1 │ 2024-… │ fast… │        15/16=4x4 │ Done   │ 4B    │
│  2 │ 2024-… │ fast… │        15/16=4x4 │ Done   │ 4B    │
│  3 │ 2024-… │ ANIb  │        16/16=4x4 │ Done   │ 4B    │
│  4 │ 2024-… │ ANIb  │        16/16=4x4 │ Done   │ 4B    │
│  5 │ 2024-… │ ANIb  │        16/16=4x4 │ Done   │ 4B    │
│  6 │ 2024-… │ ANIm  │        16/16=4x4 │ Setup  │ 4B    │
│  7 │ 2024-… │ ANIm  │          9/9=3x3 │ Setup  │ 4B    │
│  8 │ 2024-… │ ANIm  │          9/9=3x3 │ Done   │ 4B    │
│  9 │ 2024-… │ ANIm  │        16/16=4x4 │ Done   │ 4B    │
│ 10 │ 2024-… │ ANIb  │          0/9=3x3 │ Setup  │ Three │
│    │        │       │                  │        │ litt… │
│    │        │       │                  │        │ viru… │
│ 11 │ 2024-… │ fast… │ 0/758641=871x871 │ Setup  │ Asso… │
│    │        │       │                  │        │ Pect… │
│    │        │       │                  │        │ from  │
│    │        │       │                  │        │ RefS… │
└────┴────────┴───────┴──────────────────┴────────┴───────┘
```

This includes a "Comparisons" column showing done/total=n*n, where "done" is the number of comparisons recorded for that run, total is the number expected, equal to n-squared for n genomes. This is colour coded, red if done is zero, yellow when done != total, and green for done=total.

If we want to include more columns, we can select different table styles, including without the vertical lines.

We may want to offer a choice of output format. Legacy pyani offered tab separated, Excel, html. Might be useful to offer Markdown table output?

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
