### PR TITLE
Use the ORM config names consistently

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -285,16 +285,21 @@ def run_method(  # noqa: PLR0913
     fasta: Path,
     target_extension: str,
     tool: tools.ExternalToolData,
-    fragsize: int | None,
-    maxmatch: bool | None,
-    kmersize: int | None,
-    minmatch: float | None,
-    params: dict[str, object],
+    binaries: dict[str, Path],
+    *,
+    fragsize: int | None = None,
+    maxmatch: bool | None = None,
+    kmersize: int | None = None,
+    minmatch: float | None = None,
 ) -> int:
     """Run the snakemake workflow for given method and log run to database."""
     fasta_names = check_fasta(fasta)
-
     workflow_name = f"snakemake_{method.lower()}.smk"
+    params: dict[str, object] = {k: str(v) for k, v in binaries.items()}
+    params["fragsize"] = fragsize
+    params["maxmatch"] = maxmatch
+    params["kmersize"] = kmersize
+    params["minmatch"] = minmatch
 
     # We should have caught all the obvious failures above,
     # including missing inputs or missing external tools.
@@ -398,12 +403,10 @@ def anim(
 
     target_extension = ".filter"
     tool = tools.get_nucmer()
-    params = {
+    binaries = {
         "nucmer": tool.exe_path,
         "delta_filter": tools.get_delta_filter().exe_path,
-        "mode": "mum",
     }
-    fragsize = maxmatch = kmersize = minmatch = None
     return run_method(
         database,
         name,
@@ -411,11 +414,7 @@ def anim(
         fasta,
         target_extension,
         tool,
-        fragsize,
-        maxmatch,
-        kmersize,
-        minmatch,
-        params,
+        binaries,
     )
 
 
@@ -436,13 +435,12 @@ def dnadiff(
     # We don't actually call the tool dnadiff (which has its own version),
     # rather we call nucmer, delta-filter, show-diff and show-coords from MUMmer
     tool = tools.get_nucmer()
-    params: dict[str, object] = {
+    binaries = {
         "nucmer": tool.exe_path,
         "delta_filter": tools.get_delta_filter().exe_path,
         "show_diff": tools.get_show_diff().exe_path,
         "show_coords": tools.get_show_coords().exe_path,
     }
-    fragsize = maxmatch = kmersize = minmatch = None
     return run_method(
         database,
         name,
@@ -450,11 +448,7 @@ def dnadiff(
         fasta,
         target_extension,
         tool,
-        fragsize,
-        maxmatch,
-        kmersize,
-        minmatch,
-        params,
+        binaries,
     )
 
 
@@ -479,12 +473,10 @@ def anib(
     if tool.version != alt.version:
         msg = f"ERROR: blastn {tool.version} vs makeblastdb {alt.version}"
         sys.exit(msg)
-    params = {
+    binaries = {
         "blastn": tool.exe_path,
         "makeblastdb": alt.exe_path,
-        "fragLen": fragsize,
     }
-    maxmatch = kmersize = minmatch = None
     return run_method(
         database,
         name,
@@ -492,11 +484,8 @@ def anib(
         fasta,
         target_extension,
         tool,
-        fragsize,
-        maxmatch,
-        kmersize,
-        minmatch,
-        params,
+        binaries,
+        fragsize=fragsize,
     )
 
 
@@ -519,13 +508,9 @@ def fastani(  # noqa: PLR0913
 
     target_extension = ".fastani"
     tool = tools.get_fastani()
-    params = {
+    binaries = {
         "fastani": tool.exe_path,
-        "fragLen": fragsize,
-        "kmerSize": kmersize,
-        "minFrac": minmatch,
     }
-    maxmatch = None
     return run_method(
         database,
         name,
@@ -533,11 +518,10 @@ def fastani(  # noqa: PLR0913
         fasta,
         target_extension,
         tool,
-        fragsize,
-        maxmatch,
-        kmersize,
-        minmatch,
-        params,
+        binaries,
+        fragsize=fragsize,
+        kmersize=kmersize,
+        minmatch=minmatch,
     )
 
 

--- a/pyani_plus/workflows/snakemake_anib.smk
+++ b/pyani_plus/workflows/snakemake_anib.smk
@@ -37,7 +37,7 @@ def get_genomeB(wildcards):
 # Should we put use fragment size in the filename?
 rule fragment:
     params:
-        fragLen=config["fragLen"],
+        fragsize=config["fragsize"],
         indir=config["indir"],
         outdir=config["outdir"],
     input:
@@ -45,7 +45,7 @@ rule fragment:
     output:
         "{outdir}/{genomeA}-fragments.fna",
     shell:
-        "chronic .pyani-plus-private-cli fragment-fasta --outdir {wildcards.outdir} --fragsize {params.fragLen} {input.genomeA}"
+        "chronic .pyani-plus-private-cli fragment-fasta --outdir {wildcards.outdir} --fragsize {params.fragsize} {input.genomeA}"
 
 
 # The nucleotide database of the FASTA file is used for the ANIb reference.
@@ -70,7 +70,7 @@ rule blastn:
     params:
         db=config["db"],
         blastn=config["blastn"],
-        fragLen=config["fragLen"],
+        fragsize=config["fragsize"],
         indir=config["indir"],
         outdir=config["outdir"],
     input:
@@ -90,5 +90,5 @@ rule blastn:
         chronic .pyani-plus-private-cli log-anib --database {params.db} \
             --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
             --blastn {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.tsv \
-            --fragsize {params.fragLen}
+            --fragsize {params.fragsize}
         """

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -38,9 +38,9 @@ rule fastani:
         db=config["db"],
         fastani=config["fastani"],
         indir=config["indir"],
-        fragLen=config["fragLen"],
-        kmerSize=config["kmerSize"],
-        minFrac=config["minFrac"],
+        fragsize=config["fragsize"],
+        kmersize=config["kmersize"],
+        minmatch=config["minmatch"],
     input:
         genomeA=get_genomeA,
         genomeB=get_genomeB,
@@ -50,9 +50,9 @@ rule fastani:
         """
         chronic {params.fastani} -q {input.genomeA} -r {input.genomeB} \
             -o {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani \
-            --fragLen {params.fragLen} -k {params.kmerSize} --minFraction {params.minFrac} &&
+            --fragLen {params.fragsize} -k {params.kmersize} --minFraction {params.minmatch} &&
         chronic .pyani-plus-private-cli log-fastani --database {params.db} \
             --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
             --fastani {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.fastani \
-            --fragsize {params.fragLen} --kmersize {params.kmerSize} --minmatch {params.minFrac}
+            --fragsize {params.fragsize} --kmersize {params.kmersize} --minmatch {params.minmatch}
         """

--- a/tests/snakemake/test_snakemake_anib_workflow.py
+++ b/tests/snakemake/test_snakemake_anib_workflow.py
@@ -59,7 +59,7 @@ def config_anib_args(
         "outdir": anib_targets_outdir,
         "indir": input_genomes_tiny,
         "cores": snakemake_cores,
-        "fragLen": "1020",
+        "fragsize": "1020",
     }
 
 
@@ -145,7 +145,7 @@ def test_snakemake_rule_blastn(  # noqa: PLR0913
         method="ANIb",
         program=blastn_tool.exe_path.stem,
         version=blastn_tool.version,
-        fragsize=config_anib_args["fragLen"],
+        fragsize=config_anib_args["fragsize"],
         create_db=True,
     )
     # Record the FASTA files in the genomes table _before_ call snakemake
@@ -175,7 +175,7 @@ def test_snakemake_rule_blastn(  # noqa: PLR0913
         method="ANIb",
         program=blastn_tool.exe_path.stem,
         version=blastn_tool.version,
-        fragsize=config_anib_args["fragLen"],
+        fragsize=config_anib_args["fragsize"],
         kmersize=None,
         minmatch=None,
         create_db=False,

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -54,9 +54,9 @@ def config_fastani_args(
         "outdir": fastani_targets_outdir,
         "indir": str(input_genomes_tiny),
         "cores": snakemake_cores,
-        "fragLen": 3000,
-        "kmerSize": 16,
-        "minFrac": 0.2,
+        "fragsize": 3000,
+        "kmersize": 16,
+        "minmatch": 0.2,
     }
 
 
@@ -111,9 +111,9 @@ def test_snakemake_rule_fastani(  # noqa: PLR0913
         method="fastANI",
         program=fastani_tool.exe_path.stem,
         version=fastani_tool.version,
-        fragsize=config_fastani_args["fragLen"],
-        kmersize=config_fastani_args["kmerSize"],
-        minmatch=config_fastani_args["minFrac"],
+        fragsize=config_fastani_args["fragsize"],
+        kmersize=config_fastani_args["kmersize"],
+        minmatch=config_fastani_args["minmatch"],
         create_db=True,
     )
     # Record the FASTA files in the genomes table _before_ call snakemake
@@ -144,9 +144,9 @@ def test_snakemake_rule_fastani(  # noqa: PLR0913
         method="fastANI",
         program=fastani_tool.exe_path.stem,
         version=fastani_tool.version,
-        fragsize=config_fastani_args["fragLen"],
-        kmersize=config_fastani_args["kmerSize"],
-        minmatch=config_fastani_args["minFrac"],
+        fragsize=config_fastani_args["fragsize"],
+        kmersize=config_fastani_args["kmersize"],
+        minmatch=config_fastani_args["minmatch"],
         create_db=False,
     )
     compare_matrices(db, fastani_matrices)


### PR DESCRIPTION
This is work in aid of the resume functionality planned for #154, where it helped to have all the methods use the same variable names for k-mer length, fragment size, etc.

They are now standardized on the names used in our database.

These can then be passed to snakemake centrally rather than making the parameter/config dict separately for each method.