### PR TITLE
config boolean maxmatch to string mode; use in ANIm

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -143,7 +143,7 @@ class Configuration(Base):
             "program",
             "version",
             "fragsize",
-            "maxmatch",
+            "mode",
             "kmersize",
             "minmatch",
         ),
@@ -170,7 +170,7 @@ class Configuration(Base):
     program: Mapped[str] = mapped_column()
     version: Mapped[str] = mapped_column()
     fragsize: Mapped[int | None] = mapped_column()  # in fastANI this is fragLength
-    maxmatch: Mapped[bool | None] = mapped_column()  # in fastANi this is Null
+    mode: Mapped[str | None] = mapped_column()  # this is "mum" or "maxmatch" in ANIm
     kmersize: Mapped[int | None] = mapped_column()
     minmatch: Mapped[float | None] = mapped_column()
 
@@ -179,7 +179,7 @@ class Configuration(Base):
         return (
             f"Configuration(configuration_id={self.configuration_id},"
             f" program={self.program!r}, version={self.version!r},"
-            f" fragsize={self.fragsize}, maxmatch={self.maxmatch},"
+            f" fragsize={self.fragsize}, mode={self.mode!r},"
             f" kmersize={self.kmersize}, minmatch={self.minmatch})"
         )
 
@@ -246,7 +246,7 @@ class Comparison(Base):
         return (
             f"Query: {self.query_hash}, Subject: {self.subject_hash}, "
             f"%ID={self.identity}, ({self.configuration.program} {self.configuration.version}), "
-            f"FragSize: {self.configuration.fragsize}, MaxMatch: {self.configuration.maxmatch}, "
+            f"FragSize: {self.configuration.fragsize}, Mode: {self.configuration.mode}, "
             f"KmerSize: {self.configuration.kmersize}, MinMatch: {self.configuration.minmatch}"
         )
 
@@ -519,7 +519,7 @@ def db_configuration(  # noqa: PLR0913
     program: str,
     version: str,
     fragsize: int | None = None,
-    maxmatch: bool | None = None,
+    mode: str | None = None,
     kmersize: int | None = None,
     minmatch: float | None = None,
     *,
@@ -565,7 +565,7 @@ def db_configuration(  # noqa: PLR0913
         .where(Configuration.program == program)
         .where(Configuration.version == version)
         .where(Configuration.fragsize == fragsize)
-        .where(Configuration.maxmatch == maxmatch)
+        .where(Configuration.mode == mode)
         .where(Configuration.kmersize == kmersize)
         .where(Configuration.minmatch == minmatch)
         .one_or_none()
@@ -579,7 +579,7 @@ def db_configuration(  # noqa: PLR0913
             program=program,
             version=version,
             fragsize=fragsize,
-            maxmatch=maxmatch,
+            mode=mode,
             kmersize=kmersize,
             minmatch=minmatch,
         )

--- a/pyani_plus/methods/method_anim.py
+++ b/pyani_plus/methods/method_anim.py
@@ -41,9 +41,20 @@ percentage (of whole genome) for each pairwise comparison.
 """
 
 from collections import defaultdict
+from enum import Enum
 from pathlib import Path
 
 import intervaltree  # type: ignore  # noqa: PGH003
+
+
+class EnumModeANIm(str, Enum):
+    """Enum for the --mode command line argument passed to ANIm."""
+
+    mum = "mum"  # default
+    maxmatch = "maxmatch"
+
+
+MODE = EnumModeANIm.mum  # constant for CLI default
 
 
 def get_aligned_bases_count(aligned_regions: dict) -> int:

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -35,6 +35,7 @@ from rich.progress import track
 from pyani_plus import db_orm, tools
 from pyani_plus.methods import method_anib, method_anim, method_dnadiff, method_fastani
 from pyani_plus.public_cli import (
+    OPT_ARG_TYPE_ANIM_MODE,
     OPT_ARG_TYPE_CREATE_DB,
     OPT_ARG_TYPE_FRAGSIZE,
     OPT_ARG_TYPE_KMERSIZE,
@@ -99,8 +100,11 @@ NONE_ARG_TYPE_FRAGSIZE = Annotated[
         min=1,
     ),
 ]
-NONE_ARG_TYPE_MAXMATCH = Annotated[
-    bool | None, typer.Option(help="Comparison method max-match")
+NONE_ARG_TYPE_MODE = Annotated[
+    str | None,
+    typer.Option(
+        help="Comparison method specific mode", rich_help_panel="Method parameters"
+    ),
 ]
 NONE_ARG_TYPE_KMERSIZE = Annotated[
     int | None,
@@ -127,7 +131,7 @@ def log_configuration(  # noqa: PLR0913
     version: REQ_ARG_TYPE_VERSION,
     *,
     fragsize: NONE_ARG_TYPE_FRAGSIZE = None,
-    maxmatch: NONE_ARG_TYPE_MAXMATCH = None,
+    mode: NONE_ARG_TYPE_MODE = None,
     kmersize: NONE_ARG_TYPE_KMERSIZE = None,
     minmatch: NONE_ARG_TYPE_MINMATCH = None,
     create_db: OPT_ARG_TYPE_CREATE_DB = False,
@@ -148,7 +152,7 @@ def log_configuration(  # noqa: PLR0913
         program=program,
         version=version,
         fragsize=fragsize,
-        maxmatch=maxmatch,
+        mode=mode,
         kmersize=kmersize,
         minmatch=minmatch,
         create=True,
@@ -205,7 +209,7 @@ def log_run(  # noqa: PLR0913
     version: REQ_ARG_TYPE_VERSION,
     *,
     fragsize: NONE_ARG_TYPE_FRAGSIZE = None,
-    maxmatch: NONE_ARG_TYPE_MAXMATCH = None,
+    mode: NONE_ARG_TYPE_MODE = None,
     kmersize: NONE_ARG_TYPE_KMERSIZE = None,
     minmatch: NONE_ARG_TYPE_MINMATCH = None,
     create_db: OPT_ARG_TYPE_CREATE_DB = False,
@@ -230,7 +234,7 @@ def log_run(  # noqa: PLR0913
         program=program,
         version=version,
         fragsize=fragsize,
-        maxmatch=maxmatch,
+        mode=mode,
         kmersize=kmersize,
         minmatch=minmatch,
         create=True,
@@ -280,7 +284,7 @@ def log_comparison(  # noqa: PLR0913
     version: REQ_ARG_TYPE_VERSION,
     *,
     fragsize: NONE_ARG_TYPE_FRAGSIZE = None,
-    maxmatch: NONE_ARG_TYPE_MAXMATCH = None,
+    mode: NONE_ARG_TYPE_MODE = None,
     kmersize: NONE_ARG_TYPE_KMERSIZE = None,
     minmatch: NONE_ARG_TYPE_MINMATCH = None,
     # Optional comparison table entries
@@ -302,7 +306,7 @@ def log_comparison(  # noqa: PLR0913
         program=program,
         version=version,
         fragsize=fragsize,
-        maxmatch=maxmatch,
+        mode=mode,
         kmersize=kmersize,
         minmatch=minmatch,
         create=False,
@@ -331,7 +335,7 @@ def log_comparison(  # noqa: PLR0913
 
 
 # Ought we switch the command line arguments here to match fastANI naming?
-# Note this omits maxmatch
+# Note this omits mode
 @app.command(rich_help_panel="Method specific logging")
 def log_fastani(  # noqa: PLR0913
     database: REQ_ARG_TYPE_DATABASE,
@@ -397,7 +401,6 @@ def log_fastani(  # noqa: PLR0913
         program=fastani_tool.exe_path.stem,
         version=fastani_tool.version,
         fragsize=fragsize,  # aka --fragLen
-        maxmatch=None,
         kmersize=kmersize,  # aka --k
         minmatch=minmatch,  # aka --minFraction
         create=False,
@@ -457,7 +460,8 @@ def log_anim(
             exists=True,
         ),
     ],
-    # Don't use any of fragsize, maxmatch, kmersize, minmatch (configuration table entries)
+    # Don't use any of fragsize, kmersize, minmatch (configuration table entries)
+    mode: OPT_ARG_TYPE_ANIM_MODE = method_anim.MODE,
 ) -> int:
     """Log single ANIm pairwise comparison (with nucmer) to database.
 
@@ -493,10 +497,7 @@ def log_anim(
         method="ANIm",
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,
-        fragsize=None,
-        maxmatch=None,
-        kmersize=None,
-        minmatch=None,
+        mode=mode,
         create=False,
     )
 
@@ -523,7 +524,7 @@ def log_anim(
     return 0
 
 
-# Note this omits kmersize, minmatch, maxmatch
+# Note this omits kmersize, minmatch, mode
 @app.command(rich_help_panel="Method specific logging")
 def log_anib(
     database: REQ_ARG_TYPE_DATABASE,
@@ -574,9 +575,6 @@ def log_anib(
         program=blastn_tool.exe_path.stem,
         version=blastn_tool.version,
         fragsize=fragsize,
-        maxmatch=None,
-        kmersize=None,
-        minmatch=None,
         create=False,
     )
 
@@ -679,10 +677,6 @@ def log_dnadiff(
         method="dnadiff",
         program=tool.exe_path.stem,
         version=tool.version,
-        fragsize=None,
-        maxmatch=None,
-        kmersize=None,
-        minmatch=None,
         create=False,
     )
 

--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -37,9 +37,11 @@ def get_genomeB(wildcards):
 # NOTE: We do not need to construct forward and reverse comparisons within this
 # rule. This is done in the context of pyani_plus by specifying target files in
 # the calling code
+# Here mode will be "mum" (default) or "maxmatch", meaning nucmer --mum etc.
 rule delta:
     params:
         nucmer=config["nucmer"],
+        mode=config["mode"],
         indir=config["indir"],
         outdir=config["outdir"],
     input:
@@ -48,7 +50,7 @@ rule delta:
     output:
         "{outdir}/{genomeA}_vs_{genomeB}.delta",
     shell:
-        "chronic {params.nucmer} -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --mum {input.genomeB} {input.genomeA}"
+        "chronic {params.nucmer} -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} --{params.mode} {input.genomeB} {input.genomeA}"
 
 
 # The filter rule runs delta-filter wrapper for nucmer
@@ -57,6 +59,7 @@ rule delta:
 rule filter:
     params:
         db=config["db"],
+        mode=config["mode"],
         delta_filter=config["delta_filter"],
         outdir=config["outdir"],
     input:
@@ -73,5 +76,6 @@ rule filter:
              > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter &&
         chronic .pyani-plus-private-cli log-anim --database {params.db} \
             --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
-            --deltafilter {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter
+            --deltafilter {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter \
+            --mode {params.mode}
         """

--- a/tests/snakemake/test_snakemake_anib_workflow.py
+++ b/tests/snakemake/test_snakemake_anib_workflow.py
@@ -196,8 +196,6 @@ def test_snakemake_rule_blastn(  # noqa: PLR0913
         program=blastn_tool.exe_path.stem,
         version=blastn_tool.version,
         fragsize=config_anib_args["fragsize"],
-        kmersize=None,
-        minmatch=None,
         create_db=False,
     )
     compare_matrices(db, dir_anib_results)

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -60,6 +60,7 @@ def config_anim_args(
         "delta_filter": get_delta_filter().exe_path,
         # "outdir": ... is dynamic
         "indir": input_genomes_tiny,
+        "mode": "mum",
         "cores": snakemake_cores,
     }
 
@@ -117,10 +118,7 @@ def test_snakemake_rule_filter(  # noqa: PLR0913
         method="ANIm",
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,
-        fragsize=None,
-        maxmatch=None,
-        kmersize=None,
-        minmatch=None,
+        mode=config_anim_args["mode"],
         create_db=True,
     )
     # Record the FASTA files in the genomes table _before_ call snakemake
@@ -161,10 +159,7 @@ def test_snakemake_rule_filter(  # noqa: PLR0913
         method="ANIm",
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,
-        fragsize=None,
-        maxmatch=None,
-        kmersize=None,
-        minmatch=None,
+        mode=config_anim_args["mode"],
         create_db=False,
     )
     compare_matrices(db, dir_anim_results)

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -219,7 +219,7 @@ def test_snakemake_rule_show_diff_and_coords(  # noqa: PLR0913
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,  # used as a proxy for MUMmer suite
         fragsize=None,
-        maxmatch=None,
+        mode=None,
         kmersize=None,
         minmatch=None,
         create_db=True,
@@ -263,7 +263,7 @@ def test_snakemake_rule_show_diff_and_coords(  # noqa: PLR0913
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,
         fragsize=None,
-        maxmatch=None,
+        mode=None,
         kmersize=None,
         minmatch=None,
         create_db=False,
@@ -304,7 +304,7 @@ def test_snakemake_rule_show_coords(  # noqa: PLR0913
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,  # used as a proxy for MUMer suite
         fragsize=None,
-        maxmatch=None,
+        mode=None,
         kmersize=None,
         minmatch=None,
         create_db=True,
@@ -347,7 +347,7 @@ def test_snakemake_rule_show_coords(  # noqa: PLR0913
         program=nucmer_tool.exe_path.stem,
         version=nucmer_tool.version,  # used as a proxy for MUMmer suite
         fragsize=None,
-        maxmatch=None,
+        mode=None,
         kmersize=None,
         minmatch=None,
         create_db=False,

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -235,6 +235,7 @@ def test_logging_anim(
         method="ANIm",
         program=tool.exe_path.stem,
         version=tool.version,
+        mode=method_anim.MODE,
         create_db=True,
     )
     private_cli.log_genome(

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -66,7 +66,7 @@ def test_make_and_populate_comparisons(tmp_path: str) -> None:
         program="guestimate",
         version="v0.1.2beta3",
         fragsize=100,
-        maxmatch=True,
+        mode="RNG",
         kmersize=17,
         minmatch=0.3,
     )
@@ -74,7 +74,7 @@ def test_make_and_populate_comparisons(tmp_path: str) -> None:
     assert repr(config) == (
         "Configuration(configuration_id=None,"
         " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=100, maxmatch=True, kmersize=17, minmatch=0.3)"
+        " fragsize=100, mode='RNG', kmersize=17, minmatch=0.3)"
     )
     session.add(config)
     assert config.configuration_id is None
@@ -135,7 +135,7 @@ def test_make_and_populate_comparisons(tmp_path: str) -> None:
         assert str(comparison) == (
             f"Query: {comparison.query_hash}, Subject: {comparison.subject_hash},"
             " %ID=0.96, (guestimate v0.1.2beta3), "
-            "FragSize: 100, MaxMatch: True, KmerSize: 17, MinMatch: 0.3"
+            "FragSize: 100, Mode: RNG, KmerSize: 17, MinMatch: 0.3"
         )
 
         # Check the configuration object attribute:
@@ -192,7 +192,7 @@ def test_make_and_populate_runs(tmp_path: str) -> None:
     assert repr(config) == (
         "Configuration(configuration_id=None,"
         " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=1000, maxmatch=None, kmersize=31, minmatch=None)"
+        " fragsize=1000, mode=None, kmersize=31, minmatch=None)"
     )
     session.add(config)
     assert config.configuration_id is None
@@ -280,7 +280,7 @@ def test_make_and_populate_mock_example(tmp_path: str) -> None:
     assert repr(config) == (
         "Configuration(configuration_id=None,"
         " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=1000, maxmatch=None, kmersize=31, minmatch=None)"
+        " fragsize=1000, mode=None, kmersize=31, minmatch=None)"
     )
     session.add(config)
     session.commit()
@@ -495,7 +495,7 @@ def test_add_config(tmp_path: str) -> None:
     assert repr(config) == (
         "Configuration(configuration_id=1,"
         " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=100, maxmatch=None, kmersize=17, minmatch=None)"
+        " fragsize=100, mode=None, kmersize=17, minmatch=None)"
     )
 
     # Trying to add the exact same values should return the existing entry:
@@ -550,7 +550,7 @@ def test_helper_functions(tmp_path: str, input_genomes_tiny: Path) -> None:
     assert repr(config) == (
         "Configuration(configuration_id=1,"
         " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=1000, maxmatch=None, kmersize=31, minmatch=None)"
+        " fragsize=1000, mode=None, kmersize=31, minmatch=None)"
     )
 
     hashes = {}


### PR DESCRIPTION
Closes #164 by replacing the optional boolean ``maxmatch`` in the database with an optional string ``mode``, and uses this with ANIm (default "mum", alternative mode "maxmatch").

```console
$ pyani-plus anim --help
                                                                              
 Usage: pyani-plus anim [OPTIONS] FASTA                                       
                                                                              
 Execute ANIm calculations, logged to a pyANI-plus SQLite3 database.          
                                                                              
╭─ Arguments ────────────────────────────────────────────────────────────────╮
│ *    fasta      PATH  Directory of FASTA files (extensions .fas, .fasta,   │
│                       .fna)                                                │
│                       [required]                                           │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ Options ──────────────────────────────────────────────────────────────────╮
│ *  --database           FILE  Path to pyANI-plus SQLite3 database          │
│                               [required]                                   │
│ *  --name               TEXT  Run name [required]                          │
│    --create-db                Create database if does not exist            │
│    --help       -h            Show this message and exit.                  │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ Method parameters ────────────────────────────────────────────────────────╮
│ --mode        [mum|maxmatch]  Nucmer mode for ANIm [default: mum]          │
╰────────────────────────────────────────────────────────────────────────────╯
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [x] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
