### PR TITLE
Default --name in public CLI

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -43,7 +43,6 @@ from pyani_plus.public_cli import (
     REQ_ARG_TYPE_DATABASE,
     REQ_ARG_TYPE_FASTA_DIR,
     REQ_ARG_TYPE_OUTDIR,
-    REQ_ARG_TYPE_RUN_NAME,
 )
 from pyani_plus.utils import check_fasta, file_md5sum
 
@@ -54,6 +53,9 @@ app = typer.Typer(
 OPT_ARG_TYPE_QUIET = Annotated[
     # Listing name(s) explicitly to avoid automatic matching --no-quiet
     bool, typer.Option("--quiet", help="Suppress any output except if fails")
+]
+REQ_ARG_TYPE_RUN_NAME = Annotated[
+    str, typer.Option(help="Run name", show_default=False)
 ]
 REQ_ARG_TYPE_FASTA_FILES = Annotated[
     list[Path],

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -56,9 +56,6 @@ REQ_ARG_TYPE_DATABASE = Annotated[
         file_okay=True,
     ),
 ]
-REQ_ARG_TYPE_RUN_NAME = Annotated[
-    str, typer.Option(help="Run name", show_default=False)
-]
 REQ_ARG_TYPE_OUTDIR = Annotated[
     Path,
     typer.Option(
@@ -78,6 +75,13 @@ REQ_ARG_TYPE_FASTA_DIR = Annotated[
 ]
 
 # Reused optional command line arguments (defined with a default):
+OPT_ARG_TYPE_RUN_NAME = Annotated[
+    # Using None to mean the dynamic default value here:
+    str | None,
+    typer.Option(
+        help="Run name. Default is 'N genomes using METHOD'.", show_default=False
+    ),
+]
 OPT_ARG_TYPE_FRAGSIZE = Annotated[
     int,
     typer.Option(
@@ -125,7 +129,7 @@ app = typer.Typer(
 def start_and_run_method(  # noqa: PLR0913
     executor: ToolExecutor,
     database: Path,
-    name: str,
+    name: str | None,
     method: str,
     fasta: Path,
     target_extension: str,
@@ -182,7 +186,7 @@ def start_and_run_method(  # noqa: PLR0913
         cmdline=" ".join(sys.argv),
         fasta_directory=fasta,
         status="Initialising",
-        name=name,
+        name=f"{len(filename_to_md5)} genomes using {method}" if name is None else name,
         date=None,
         fasta_to_hash=filename_to_md5,
     )
@@ -291,9 +295,9 @@ def run_method(  # noqa: PLR0913
 def anim(  # noqa: PLR0913
     fasta: REQ_ARG_TYPE_FASTA_DIR,
     database: REQ_ARG_TYPE_DATABASE,
-    # These are for the run table:
-    name: REQ_ARG_TYPE_RUN_NAME,
     *,
+    # These are for the run table:
+    name: OPT_ARG_TYPE_RUN_NAME = None,
     # Does not use fragsize, kmersize, or minmatch
     # The mode here is not optional - must pick one!
     mode: OPT_ARG_TYPE_ANIM_MODE = method_anim.MODE,
@@ -326,9 +330,9 @@ def anim(  # noqa: PLR0913
 def dnadiff(
     fasta: REQ_ARG_TYPE_FASTA_DIR,
     database: REQ_ARG_TYPE_DATABASE,
-    # These are for the run table:
-    name: REQ_ARG_TYPE_RUN_NAME,
     *,
+    # These are for the run table:
+    name: OPT_ARG_TYPE_RUN_NAME = None,
     # Does not use fragsize, mode, kmersize, or minmatch
     create_db: OPT_ARG_TYPE_CREATE_DB = False,
     executor: OPT_ARG_TYPE_EXECUTOR = ToolExecutor.local,
@@ -363,10 +367,10 @@ def anib(  # noqa: PLR0913
     fasta: REQ_ARG_TYPE_FASTA_DIR,
     database: REQ_ARG_TYPE_DATABASE,
     # These are for the run table:
-    name: REQ_ARG_TYPE_RUN_NAME,
+    *,
+    name: OPT_ARG_TYPE_RUN_NAME = None,
     # These are all for the configuration table:
     fragsize: OPT_ARG_TYPE_FRAGSIZE = method_anib.FRAGSIZE,
-    *,
     # Does not use mode, kmersize, or minmatch
     create_db: OPT_ARG_TYPE_CREATE_DB = False,
     executor: OPT_ARG_TYPE_EXECUTOR = ToolExecutor.local,
@@ -401,9 +405,9 @@ def anib(  # noqa: PLR0913
 def fastani(  # noqa: PLR0913
     fasta: REQ_ARG_TYPE_FASTA_DIR,
     database: REQ_ARG_TYPE_DATABASE,
-    # These are for the run table:
-    name: REQ_ARG_TYPE_RUN_NAME,
     *,
+    # These are for the run table:
+    name: OPT_ARG_TYPE_RUN_NAME = None,
     # These are all for the configuration table:
     fragsize: OPT_ARG_TYPE_FRAGSIZE = method_fastani.FRAG_LEN,
     # Does not use mode

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -297,9 +297,8 @@ def test_dnadiff(
     """Check dnadiff run (default settings)."""
     out = Path(tmp_path)
     tmp_db = out / "example.sqlite"
-    public_cli.dnadiff(
-        database=tmp_db, fasta=input_genomes_tiny, name="Test Run", create_db=True
-    )
+    # Leaving out name, so can check the default worked
+    public_cli.dnadiff(database=tmp_db, fasta=input_genomes_tiny, create_db=True)
     public_cli.export_run(database=tmp_db, outdir=out)
     # Fuzzy, 0.9963 from dnadiff tool != 0.9962661747 from our code
     compare_matrix_files(
@@ -307,6 +306,10 @@ def test_dnadiff(
         out / "dnadiff_identity.tsv",
         atol=5e-5,
     )
+    session = db_orm.connect_to_db(tmp_db)
+    run = session.query(db_orm.Run).one()
+    assert run.name == "3 genomes using dnadiff"
+    session.close()
 
 
 def test_anib(tmp_path: str, input_genomes_tiny: Path, dir_anib_results: Path) -> None:


### PR DESCRIPTION
Making the ``--name`` option at the command line optional with a reasonable default seems to be a small usability improvement - provided the default is sensible?

Because the default must be dynamic, we can't give it directly in the CLI help (as a dark green ``[default: ...]`` entry). Rather we set the default to ``None`` and fill this at runtime based on the other options.

Currently the default is "{N} genomes using {METHOD}", without attempting to record anything further like the date or any (non-default) method parameters. We could do that though?

```
$ pyani-plus fastani --help
                                                                              
 Usage: pyani-plus fastani [OPTIONS] FASTA                                    
                                                                              
 Execute fastANI calculations, logged to a pyANI-plus SQLite3 database.       
                                                                              
╭─ Arguments ────────────────────────────────────────────────────────────────╮
│ *    fasta      PATH  Directory of FASTA files (extensions .fas, .fasta,   │
│                       .fna)                                                │
│                       [required]                                           │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ Options ──────────────────────────────────────────────────────────────────╮
│ *  --database           FILE           Path to pyANI-plus SQLite3 database │
│                                        [required]                          │
│    --name               TEXT           Run name. Default is 'N genomes     │
│                                        using METHOD'.                      │
│    --create-db                         Create database if does not exist   │
│    --executor           [local|slurm]  How should the internal tools be    │
│                                        run?                                │
│                                        [default: local]                    │
│    --help       -h                     Show this message and exit.         │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ Method parameters ────────────────────────────────────────────────────────╮
│ --fragsize        INTEGER RANGE [x>=1]       Comparison method fragment    │
│                                              size                          │
│                                              [default: 3000]               │
│ --kmersize        INTEGER RANGE [x>=1]       Comparison method k-mer size  │
│                                              [default: 16]                 │
│ --minmatch        FLOAT RANGE [0.0<=x<=1.0]  Comparison method min-match   │
│                                              [default: 0.2]                │
╰────────────────────────────────────────────────────────────────────────────╯
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
