### PR TITLE
Use explicit SQL naming for indices, constraints, etc

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -36,6 +36,7 @@ import pandas as pd
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 from sqlalchemy import (
     ForeignKey,
+    MetaData,
     UniqueConstraint,
     create_engine,
     insert,
@@ -59,6 +60,19 @@ class Base(DeclarativeBase):
     See the SQLAlchemy 2.0 documentation. This is expected to be
     compatible with type checkers like mypy.
     """
+
+    # The DB schema migration tool alembic recommends naming all the
+    # constraints explicitly to facilitate reproducible changes. See
+    # https://alembic.sqlalchemy.org/en/latest/naming.html
+    metadata = MetaData(
+        naming_convention={
+            "ix": "ix_%(column_0_label)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
+            "ck": "ck_%(table_name)s_`%(constraint_name)s`",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        }
+    )
 
 
 class RunGenomeAssociation(Base):


### PR DESCRIPTION
The DB schema migration tool alembic recommends naming all the constraints explicitly to facilitate reproducible changes. See https://alembic.sqlalchemy.org/en/latest/naming.html

This will help with using alembic, see #171 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
