### PR TITLE
Single snakemake rules for ANIm and dnadiff

### DIFF
--- a/pyani_plus/workflows/snakemake_anim.smk
+++ b/pyani_plus/workflows/snakemake_anim.smk
@@ -57,7 +57,8 @@ rule ANIm:
     shell:
         """
         {params.nucmer} -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} \
-            --{params.mode} {input.genomeB} {input.genomeA} > {output}.log 2>&1 &&
+            --{params.mode} {input.genomeB} {input.genomeA} \
+            > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}_nucmer.log 2>&1 &&
         {params.delta_filter} \
             -1 {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.delta \
              > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter &&

--- a/pyani_plus/workflows/snakemake_dnadiff.smk
+++ b/pyani_plus/workflows/snakemake_dnadiff.smk
@@ -32,14 +32,12 @@ def get_genomeB(wildcards):
     return indir_files[wildcards.genomeB]
 
 
-# The rule dnadiff runs nucmer, delta-filter, show-diff and show-coords wrappers to
+# The rule dnadiff runs nucmer, delta-filter, show-diff and show-coords wrappers
 # required to replicate the number of AlignedBases, identity and coverage reported
 # by dnadiff.
 # NOTE: We do not need to construct forward and reverse comparisons within this
 # rule. This is done in the context of pyani_plus by specifying target files in
 # the calling code.
-
-
 rule dnadiff:
     params:
         db=config["db"],
@@ -59,7 +57,7 @@ rule dnadiff:
     shell:
         """
         {params.nucmer} -p {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB} \
-            --maxmatch {input.genomeB} {input.genomeA} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.delta.log 2>&1 &&
+            --maxmatch {input.genomeB} {input.genomeA} > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}_nucmer.log 2>&1 &&
         {params.delta_filter} \
             -m {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.delta \
              > {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.filter &&

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,29 +199,9 @@ def dnadiff_nucmer_targets_filter_indir() -> Path:
 
 
 @pytest.fixture
-def dnadiff_nucmer_targets_filter_outdir(tmp_path: str) -> Path:
-    """Output directory for MUMmer filter snakemake tests.
-
-    This path indicates the location to which MUMmer should write
-    its output files during dnadiff testing
-    """
-    return Path(tmp_path).resolve() / "dnadiff_nucmer_filter_output"
-
-
-@pytest.fixture
 def dnadiff_nucmer_targets_delta_indir() -> Path:
     """Directory containing MUMmer delta snakemake reference files."""
     return FIXTUREPATH / "dnadiff" / "targets" / "delta"
-
-
-@pytest.fixture
-def dnadiff_nucmer_targets_delta_outdir(tmp_path: str) -> Path:
-    """Output directory for MUMmer filter snakemake tests.
-
-    This path indicates the location to which MUMmer should write
-    its output files during dnadiff testing
-    """
-    return Path(tmp_path).resolve() / "dnadiff_nucmer_delta_output"
 
 
 @pytest.fixture
@@ -231,35 +211,25 @@ def dnadiff_targets_showdiff_indir() -> Path:
 
 
 @pytest.fixture
-def dnadiff_targets_showdiff_outdir(tmp_path: str) -> Path:
-    """Output directory for MUMmer filter snakemake tests.
-
-    This path indicates the location to which dnadiff should write
-    its output files during dnadiff testing
-    """
-    return Path(tmp_path).resolve() / "dnadiff_show_diff_output"
-
-
-@pytest.fixture
 def dnadiff_targets_showcoords_indir() -> Path:
     """Directory containing snadiff show_diff snakemake reference files."""
     return FIXTUREPATH / "dnadiff" / "targets" / "show_coords"
 
 
 @pytest.fixture
-def dnadiff_targets_showcoords_outdir(tmp_path: str) -> Path:
+def dnadiff_targets_outdir(tmp_path: str) -> Path:
     """Output directory for MUMmer filter snakemake tests.
 
     This path indicates the location to which dnadiff should write
     its output files during dnadiff testing
     """
-    return Path(tmp_path).resolve() / "dnadiff_show_coords_output"
+    return Path(tmp_path).resolve() / "dnadiff_targets_output"
 
 
 @pytest.fixture
 def dnadiff_nucmer_targets_filter(
-    dnadiff_nucmer_targets_filter_outdir: Path,
-) -> list[str]:
+    dnadiff_targets_outdir: Path,
+) -> list[Path]:
     """Target filter files for dnadiff method tests.
 
     These are paths to the output files we want to generate using
@@ -268,13 +238,13 @@ def dnadiff_nucmer_targets_filter(
     values
     """
     reference_paths = (FIXTUREPATH / "dnadiff" / "targets" / "filter").glob("*.filter")
-    return [dnadiff_nucmer_targets_filter_outdir / _.name for _ in reference_paths]
+    return [dnadiff_targets_outdir / _.name for _ in reference_paths]
 
 
 @pytest.fixture
 def dnadiff_nucmer_targets_delta(
-    dnadiff_nucmer_targets_delta_outdir: Path,
-) -> list[str]:
+    dnadiff_targets_outdir: Path,
+) -> list[Path]:
     """Target delta files for dnadiff method tests.
 
     These are paths to the output files we want to generate using
@@ -282,11 +252,11 @@ def dnadiff_nucmer_targets_delta(
     could later be processed to obtain AlignedBases values
     """
     reference_paths = (FIXTUREPATH / "dnadiff" / "targets" / "delta").glob("*.delta")
-    return [dnadiff_nucmer_targets_delta_outdir / _.name for _ in reference_paths]
+    return [dnadiff_targets_outdir / _.name for _ in reference_paths]
 
 
 @pytest.fixture
-def dnadiff_targets_showdiff(dnadiff_targets_showdiff_outdir: Path) -> list[str]:
+def dnadiff_targets_showdiff(dnadiff_targets_outdir: Path) -> list[Path]:
     """Target qdiff files for dnadiff method tests.
 
     These are paths to the output files we want to generate using
@@ -296,11 +266,11 @@ def dnadiff_targets_showdiff(dnadiff_targets_showdiff_outdir: Path) -> list[str]
     reference_paths = (FIXTUREPATH / "dnadiff" / "targets" / "show_diff").glob(
         "*.qdiff",
     )
-    return [dnadiff_targets_showdiff_outdir / _.name for _ in reference_paths]
+    return [dnadiff_targets_outdir / _.name for _ in reference_paths]
 
 
 @pytest.fixture
-def dnadiff_targets_showcoords(dnadiff_targets_showcoords_outdir: Path) -> list[Path]:
+def dnadiff_targets_showcoords(dnadiff_targets_outdir: Path) -> list[Path]:
     """Target mcoords files for dnadiff method tests.
 
     These are paths to the output files we want to generate using
@@ -310,7 +280,7 @@ def dnadiff_targets_showcoords(dnadiff_targets_showcoords_outdir: Path) -> list[
     reference_paths = (FIXTUREPATH / "dnadiff" / "targets" / "show_coords").glob(
         "*.mcoords",
     )
-    return [dnadiff_targets_showcoords_outdir / _.name for _ in reference_paths]
+    return [dnadiff_targets_outdir / _.name for _ in reference_paths]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,8 @@ def dir_anim_results() -> Path:
 
 
 @pytest.fixture
-def anim_nucmer_targets_filter_outdir(tmp_path: str) -> Path:
-    """Output directory for MUMmer filter snakemake tests.
+def anim_targets_outdir(tmp_path: str) -> Path:
+    """Output directory for ANIm snakemake tests.
 
     This path indicates the location to which MUMmer should write
     its output files during ANIm testing
@@ -129,37 +129,27 @@ def anim_nucmer_targets_delta_indir() -> Path:
 
 
 @pytest.fixture
-def anim_nucmer_targets_delta_outdir(tmp_path: str) -> Path:
-    """Output directory for MUMmer delta snakemake tests.
-
-    This path indicates the location to which MUMmer should write
-    its output files during ANIm testing
-    """
-    return Path(tmp_path).resolve() / "nucmer_delta_output"
-
-
-@pytest.fixture
-def anim_nucmer_targets_filter(anim_nucmer_targets_filter_outdir: Path) -> list[str]:
-    """Target files for ANIm tests.
+def anim_nucmer_targets_filter(anim_targets_outdir: Path) -> list[Path]:
+    """Target delta-filter files for ANIm tests.
 
     These are paths to the output files we want to generate using
     nucmer for ANIm. We aim to ask MUMmer to generate a set of
     .filter files that could later be processed to obtain ANI values
     """
     reference_paths = (FIXTUREPATH / "anim" / "targets" / "filter").glob("*.filter")
-    return [anim_nucmer_targets_filter_outdir / _.name for _ in reference_paths]
+    return [anim_targets_outdir / _.name for _ in reference_paths]
 
 
 @pytest.fixture
-def anim_nucmer_targets_delta(anim_nucmer_targets_delta_outdir: Path) -> list[str]:
-    """Target files for ANIm tests.
+def anim_nucmer_targets_delta(anim_targets_outdir: Path) -> list[Path]:
+    """Target delta files for ANIm tests.
 
     These are paths to the output files we want to generate using
     nucmer for ANIm. We aim to generate a set of .delta files that
     could later be processed to obtain ANI values
     """
     reference_paths = (FIXTUREPATH / "anim" / "targets" / "delta").glob("*.delta")
-    return [anim_nucmer_targets_delta_outdir / _.name for _ in reference_paths]
+    return [anim_targets_outdir / _.name for _ in reference_paths]
 
 
 @pytest.fixture

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -85,7 +85,7 @@ def compare_files_with_skip(file1: Path, file2: Path, skip: int = 1) -> bool:
     return True
 
 
-def test_snakemake_rule_filter(  # noqa: PLR0913
+def test_snakemake_rule_ANIm(  # noqa: N802, PLR0913
     anim_nucmer_targets_filter: list[str],
     anim_nucmer_targets_filter_indir: Path,
     anim_nucmer_targets_filter_outdir: Path,
@@ -149,45 +149,3 @@ def test_snakemake_rule_filter(  # noqa: PLR0913
             anim_nucmer_targets_filter_outdir / fname,
         )
     compare_matrices(db, dir_anim_results)
-
-
-def test_snakemake_rule_delta(
-    anim_nucmer_targets_delta: list[str],
-    anim_nucmer_targets_delta_indir: Path,
-    anim_nucmer_targets_delta_outdir: Path,
-    config_anim_args: dict,
-    tmp_path: str,
-) -> None:
-    """Test nucmer delta snakemake wrapper.
-
-    Checks that the delta rule in the ANIm snakemake wrapper gives the
-    expected output.
-
-    If the output directory exists (i.e. the make clean_tests rule has not
-    been run), the tests will automatically pass as snakemake will not
-    attempt to re-run the rule. That would prevent us from seeing any
-    introduced bugs, so we force re-running the rule by deleting the
-    output directory before running the tests.
-    """
-    # Remove the output directory to force re-running the snakemake rule
-    shutil.rmtree(anim_nucmer_targets_delta_outdir, ignore_errors=True)
-
-    config = config_anim_args.copy()
-    config["outdir"] = anim_nucmer_targets_delta_outdir
-
-    # Run snakemake wrapper
-    run_snakemake_with_progress_bar(
-        executor=ToolExecutor.local,
-        workflow_name="snakemake_anim.smk",
-        targets=anim_nucmer_targets_delta,
-        params=config,
-        working_directory=Path(tmp_path),
-        show_progress_bar=False,
-    )
-
-    # Check output against target fixtures
-    for fname in anim_nucmer_targets_delta:
-        assert compare_files_with_skip(
-            anim_nucmer_targets_delta_indir / fname,
-            anim_nucmer_targets_delta_outdir / fname,
-        )

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -85,7 +85,7 @@ def compare_files_with_skip(file1: Path, file2: Path, skip: int = 1) -> bool:
     return True
 
 
-def test_snakemake_rule_ANIm(  # noqa: N802, PLR0913
+def test_rule_ANIm(  # noqa: N802, PLR0913
     anim_nucmer_targets_filter: list[str],
     anim_nucmer_targets_filter_indir: Path,
     anim_nucmer_targets_filter_outdir: Path,
@@ -93,9 +93,9 @@ def test_snakemake_rule_ANIm(  # noqa: N802, PLR0913
     config_anim_args: dict,
     tmp_path: str,
 ) -> None:
-    """Test nucmer filter snakemake wrapper.
+    """Test rule.
 
-    Checks that the filter rule in the ANIm snakemake wrapper gives the
+    Checks that the ANIm rule in the ANIm snakemake wrapper gives the
     expected output.
 
     If the output directory exists (i.e. the make clean_tests rule has not

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -86,9 +86,11 @@ def compare_files_with_skip(file1: Path, file2: Path, skip: int = 1) -> bool:
 
 
 def test_rule_ANIm(  # noqa: N802, PLR0913
-    anim_nucmer_targets_filter: list[str],
+    anim_nucmer_targets_filter: list[Path],
+    anim_nucmer_targets_delta: list[Path],
     anim_nucmer_targets_filter_indir: Path,
-    anim_nucmer_targets_filter_outdir: Path,
+    anim_targets_outdir: Path,
+    anim_nucmer_targets_delta_indir: Path,
     dir_anim_results: Path,
     config_anim_args: dict,
     tmp_path: str,
@@ -105,7 +107,7 @@ def test_rule_ANIm(  # noqa: N802, PLR0913
     output directory before running the tests.
     """
     # Remove the output directory to force re-running the snakemake rule
-    shutil.rmtree(anim_nucmer_targets_filter_outdir, ignore_errors=True)
+    shutil.rmtree(anim_targets_outdir, ignore_errors=True)
 
     # Assuming this will match but worker nodes might have a different version
     nucmer_tool = get_nucmer()
@@ -128,7 +130,7 @@ def test_rule_ANIm(  # noqa: N802, PLR0913
     assert db.is_file()
 
     config = config_anim_args.copy()
-    config["outdir"] = anim_nucmer_targets_filter_outdir
+    config["outdir"] = anim_targets_outdir
 
     # Run snakemake wrapper
     run_snakemake_with_progress_bar(
@@ -142,10 +144,18 @@ def test_rule_ANIm(  # noqa: N802, PLR0913
         show_progress_bar=False,
     )
 
-    # Check output against target fixtures
+    # Check delta-filter output against target fixtures
     for fname in anim_nucmer_targets_filter:
         assert compare_files_with_skip(
-            anim_nucmer_targets_filter_indir / fname,
-            anim_nucmer_targets_filter_outdir / fname,
+            anim_nucmer_targets_filter_indir / fname.name,
+            fname,
         )
+
+    # Check nucmer output against target fixtures
+    for fname in anim_nucmer_targets_delta:
+        assert compare_files_with_skip(
+            anim_nucmer_targets_delta_indir / fname.name,
+            fname,
+        )
+
     compare_matrices(db, dir_anim_results)

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -102,90 +102,6 @@ def compare_show_diff_files(file1: Path, file2: Path) -> bool:
     return True
 
 
-def test_snakemake_rule_delta(
-    dnadiff_nucmer_targets_delta: list[str],
-    dnadiff_nucmer_targets_delta_indir: Path,
-    dnadiff_nucmer_targets_delta_outdir: Path,
-    config_dnadiff_args: dict,
-    tmp_path: str,
-) -> None:
-    """Test nucmer delta snakemake wrapper.
-
-    Checks that the delta rule in the dnadiff snakemake wrapper gives the
-    expected output.
-
-    If the output directory exists (i.e. the make clean_tests rule has not
-    been run), the tests will automatically pass as snakemake will not
-    attempt to re-run the rule. That would prevent us from seeing any
-    introduced bugs, so we force re-running the rule by deleting the
-    output directory before running the tests.
-    """
-    # Remove the output directory to force re-running the snakemake rule
-    shutil.rmtree(dnadiff_nucmer_targets_delta_outdir, ignore_errors=True)
-
-    config = config_dnadiff_args.copy()
-    config["outdir"] = dnadiff_nucmer_targets_delta_outdir
-
-    # Run snakemake wrapper
-    run_snakemake_with_progress_bar(
-        executor=ToolExecutor.local,
-        workflow_name="snakemake_dnadiff.smk",
-        targets=dnadiff_nucmer_targets_delta,
-        params=config,
-        working_directory=Path(tmp_path),
-        show_progress_bar=False,
-    )
-
-    # Check output against target fixtures
-    for fname in dnadiff_nucmer_targets_delta:
-        assert compare_files_with_skip(
-            dnadiff_nucmer_targets_delta_indir / fname,
-            dnadiff_nucmer_targets_delta_outdir / fname,
-        )
-
-
-def test_snakemake_rule_filter(
-    dnadiff_nucmer_targets_filter: list[str],
-    dnadiff_nucmer_targets_filter_indir: Path,
-    dnadiff_nucmer_targets_filter_outdir: Path,
-    config_dnadiff_args: dict,
-    tmp_path: str,
-) -> None:
-    """Test nucmer filter snakemake wrapper.
-
-    Checks that the filter rule in the dnadiff snakemake wrapper gives the
-    expected output.
-
-    If the output directory exists (i.e. the make clean_tests rule has not
-    been run), the tests will automatically pass as snakemake will not
-    attempt to re-run the rule. That would prevent us from seeing any
-    introduced bugs, so we force re-running the rule by deleting the
-    output directory before running the tests.
-    """
-    # Remove the output directory to force re-running the snakemake rule
-    shutil.rmtree(dnadiff_nucmer_targets_filter_outdir, ignore_errors=True)
-
-    config = config_dnadiff_args.copy()
-    config["outdir"] = dnadiff_nucmer_targets_filter_outdir
-
-    # Run snakemake wrapper
-    run_snakemake_with_progress_bar(
-        executor=ToolExecutor.local,
-        workflow_name="snakemake_dnadiff.smk",
-        targets=dnadiff_nucmer_targets_filter,
-        params=config,
-        working_directory=Path(tmp_path),
-        show_progress_bar=False,
-    )
-
-    # Check output against target fixtures
-    for fname in dnadiff_nucmer_targets_filter:
-        assert compare_files_with_skip(
-            dnadiff_nucmer_targets_filter_indir / fname,
-            dnadiff_nucmer_targets_filter_outdir / fname,
-        )
-
-
 def test_snakemake_rule_show_diff_and_coords(  # noqa: PLR0913
     capsys: pytest.CaptureFixture[str],
     dnadiff_targets_showdiff: list[str],
@@ -256,7 +172,7 @@ def test_snakemake_rule_show_diff_and_coords(  # noqa: PLR0913
     compare_matrices(db, dir_dnadiff_matrices, absolute_tolerance=5e-5)
 
 
-def test_snakemake_rule_show_coords(  # noqa: PLR0913
+def test_dnadiff(  # noqa: PLR0913
     dnadiff_targets_showcoords: list[str],
     dnadiff_targets_showcoords_indir: Path,
     dnadiff_targets_showcoords_outdir: Path,
@@ -264,7 +180,7 @@ def test_snakemake_rule_show_coords(  # noqa: PLR0913
     dir_dnadiff_matrices: Path,
     tmp_path: str,
 ) -> None:
-    """Test dnadiff show-coords snakemake wrapper.
+    """Test rule dnadiff.
 
     Checks that the show_diff_and_coords rule in the dnadiff snakemake wrapper gives the
     expected show-coords output.

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -182,8 +182,8 @@ def test_dnadiff(  # noqa: PLR0913
 ) -> None:
     """Test rule dnadiff.
 
-    Checks that the show_diff_and_coords rule in the dnadiff snakemake wrapper gives the
-    expected show-coords output.
+    Checks that the dnadiff rule in the dnadiff snakemake wrapper gives the
+    expected output.
 
     If the output directory exists (i.e. the make clean_tests rule has not
     been run), the tests will automatically pass as snakemake will not


### PR DESCRIPTION
This fixes #182.

Following our discussion on Monday, this PR introduces changes to the `anim` and `dnadiff` workflows by merging multiple rules into single rules.

I also spotted some bugs in the tests (probably my fault initially) where comparing the content of the generated files (e.g., `delta`, `filter`, `mcoords`, etc.) against target fixtures resulted in false positives. I’ve fixed these issues here and also removed redundant tests.

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [X] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [X] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [ ] Rebase against `origin/master`
- [X] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [X] Request a code review
- [X] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
