### PR TITLE
"Spinner" for sourmash etc rather than progress bar.

### DIFF
--- a/tests/snakemake/test_snakemake_anib_workflow.py
+++ b/tests/snakemake/test_snakemake_anib_workflow.py
@@ -85,7 +85,6 @@ def test_snakemake_rule_fragments(
         targets=anib_targets_fragments,
         params=config_anib_args,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check output against target fixtures
@@ -126,7 +125,6 @@ def test_snakemake_rule_blastdb(
         targets=anib_targets_blastdb,
         params=config_anib_args,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check output against target fixtures
@@ -175,7 +173,6 @@ def test_snakemake_rule_blastn(  # noqa: PLR0913
         targets=anib_targets_blastn,
         params=config_anib_args,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check output against target fixtures

--- a/tests/snakemake/test_snakemake_anim_workflow.py
+++ b/tests/snakemake/test_snakemake_anim_workflow.py
@@ -141,7 +141,6 @@ def test_rule_ANIm(  # noqa: N802, PLR0913
         targets=anim_nucmer_targets_filter,
         params=config,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check delta-filter output against target fixtures

--- a/tests/snakemake/test_snakemake_dnadiff_workflow.py
+++ b/tests/snakemake/test_snakemake_dnadiff_workflow.py
@@ -162,7 +162,6 @@ def test_dnadiff(  # noqa: PLR0913
         targets=dnadiff_targets_showcoords,
         params=config,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check nucmer output (.delta) against target fixtures

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -134,7 +134,6 @@ def test_snakemake_rule_fastani(  # noqa: PLR0913
         targets=fastani_targets,
         params=config_fastani_args,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check output against target fixtures
@@ -180,5 +179,4 @@ def test_snakemake_duplicate_stems(
             targets=fastani_targets,
             params=dup_config,
             working_directory=Path(tmp_path),
-            show_progress_bar=False,
         )

--- a/tests/snakemake/test_snakemake_sourmash_workflow.py
+++ b/tests/snakemake/test_snakemake_sourmash_workflow.py
@@ -152,7 +152,6 @@ def test_snakemake_sketch_rule(
         targets=sourmash_targets_sig,
         params=config,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check output against target fixtures
@@ -221,7 +220,6 @@ def test_snakemake_compare_rule(  # noqa: PLR0913
         targets=[sourmash_targets_compare_outdir / "sourmash.csv"],
         params=config,
         working_directory=Path(tmp_path),
-        show_progress_bar=False,
     )
 
     # Check output against target fixture

--- a/tests/snakemake/test_workflows.py
+++ b/tests/snakemake/test_workflows.py
@@ -33,6 +33,7 @@ from pathlib import Path
 import pytest
 
 from pyani_plus.workflows import (
+    ShowProgress,
     ToolExecutor,
     check_input_stems,
     run_snakemake_with_progress_bar,
@@ -72,7 +73,7 @@ def test_duplicate_stems(
 
 def test_progress_bar_error() -> None:
     """Verify expected error message without database or run-in."""
-    msg = "Both database and run_id are required with show_progress_bar=True"
+    msg = "Both database and run_id are required with display as progress bar"
     with pytest.raises(ValueError, match=re.escape(msg)):
         run_snakemake_with_progress_bar(
             ToolExecutor.slurm,
@@ -80,5 +81,5 @@ def test_progress_bar_error() -> None:
             [Path("/mnt/shared/answer.tsv")],
             {},
             Path(),
-            show_progress_bar=True,
+            display=ShowProgress.bar,
         )


### PR DESCRIPTION
The progress bar wouldn't actually update until the end as this was an all-in-one computation and bulk import, so visually not ideal.

Worse, the useless progress bar was checking the database and I did in testing with sourmash brakewater see the logging fail with a conflict - _possibly_ due to this.

There is room to improve the look of the "spinner" (actually an indeterminate progress bar), I have opened an issue on rich.

We may be able to remove the spinner code if we fully move from sourmash to branchwater, and in doing so break up the final computation into parts - meaning we will get meaningful progress updates.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
