### PR TITLE
fastANI and BLAST by-column via subprocess in private-cli

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -49,6 +49,7 @@ from pyani_plus.methods import (
 from pyani_plus.public_cli import (
     OPT_ARG_TYPE_CREATE_DB,
     OPT_ARG_TYPE_FRAGSIZE,
+    OPT_ARG_TYPE_TEMP,
     REQ_ARG_TYPE_DATABASE,
     REQ_ARG_TYPE_FASTA_DIR,
     REQ_ARG_TYPE_OUTDIR,
@@ -420,18 +421,7 @@ def compute_column(  # noqa: C901
         ),
     ],
     *,
-    temp: Annotated[
-        Path | None,
-        typer.Option(
-            help="Directory to use for intermediate files, which will not be deleted."
-            " Default behaviour is to use a system specified temporary directory and"
-            " remove this afterwards.",
-            show_default=False,
-            exists=True,
-            dir_okay=True,
-            file_okay=False,
-        ),
-    ] = None,
+    temp: OPT_ARG_TYPE_TEMP = None,
     quiet: OPT_ARG_TYPE_QUIET = False,
 ) -> int:
     """Run the method for one column and log pairwise comparisons to the database.

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -868,8 +868,6 @@ def export_run(
             )
             sys.exit(msg)
 
-    conf = run.configuration
-
     if not run.comparisons().count():
         msg = f"ERROR: Database {database} run-id {run_id} has no comparisons"
         sys.exit(msg)
@@ -885,13 +883,14 @@ def export_run(
     # Question: Should we match the property in filenames to old pyANI (e.g. coverage)?
     # Question: Should we offer MD5 alternatives, and how? e.g. filename or labels
     # (seems more suited to a report command offering tables and plots)
-    run.identities.to_csv(outdir / f"{conf.method}_identity.tsv", sep="\t")
-    run.aln_length.to_csv(outdir / f"{conf.method}_aln_lengths.tsv", sep="\t")
-    run.sim_errors.to_csv(outdir / f"{conf.method}_sim_errors.tsv", sep="\t")
-    run.cov_query.to_csv(outdir / f"{conf.method}_query_cov.tsv", sep="\t")
-    run.hadamard.to_csv(outdir / f"{conf.method}_hadamard.tsv", sep="\t")
+    method = run.configuration.method
+    run.identities.to_csv(outdir / f"{method}_identity.tsv", sep="\t")
+    run.aln_length.to_csv(outdir / f"{method}_aln_lengths.tsv", sep="\t")
+    run.sim_errors.to_csv(outdir / f"{method}_sim_errors.tsv", sep="\t")
+    run.cov_query.to_csv(outdir / f"{method}_query_cov.tsv", sep="\t")
+    run.hadamard.to_csv(outdir / f"{method}_hadamard.tsv", sep="\t")
 
-    print(f"Wrote matrices to {outdir}/{conf.method}_*.tsv")
+    print(f"Wrote matrices to {outdir}/{method}_*.tsv")
 
     session.close()
     return 0

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -421,7 +421,6 @@ def anib(  # noqa: PLR0913
     """Execute ANIb calculations, logged to a pyANI-plus SQLite3 database."""
     check_db(database, create_db)
 
-    target_extension = ".tsv"
     tool = tools.get_blastn()
     alt = tools.get_makeblastdb()
     if tool.version != alt.version:
@@ -431,14 +430,16 @@ def anib(  # noqa: PLR0913
         "blastn": tool.exe_path,
         "makeblastdb": alt.exe_path,
     }
+    fasta_list = check_fasta(fasta)
+
     return start_and_run_method(
         executor,
         database,
         name,
         "ANIb",
         fasta,
-        [],
-        target_extension,
+        [f"all_vs_{Path(_).stem}.anib" for _ in fasta_list],
+        None,  # no pairwise target
         tool,
         binaries,
         fragsize=fragsize,

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -94,7 +94,8 @@ OPT_ARG_TYPE_FRAGSIZE = Annotated[
         min=1,
     ),
 ]
-# fastANI has maximum (and default) k-mer size 16
+# fastANI has maximum (and default) k-mer size 16,
+# so defined separately with max=16
 OPT_ARG_TYPE_KMERSIZE = Annotated[
     int,
     typer.Option(
@@ -454,7 +455,16 @@ def fastani(  # noqa: PLR0913
     # These are all for the configuration table:
     fragsize: OPT_ARG_TYPE_FRAGSIZE = method_fastani.FRAG_LEN,
     # Does not use mode
-    kmersize: OPT_ARG_TYPE_KMERSIZE = method_fastani.KMER_SIZE,
+    # Don't use OPT_ARG_TYPE_KMERSIZE as want to include max=16
+    kmersize: Annotated[
+        int,
+        typer.Option(
+            help="Comparison method k-mer size",
+            rich_help_panel="Method parameters",
+            min=1,
+            max=16,
+        ),
+    ] = method_fastani.KMER_SIZE,
     minmatch: OPT_ARG_TYPE_MINMATCH = method_fastani.MIN_FRACTION,
     create_db: OPT_ARG_TYPE_CREATE_DB = False,
     executor: OPT_ARG_TYPE_EXECUTOR = ToolExecutor.local,

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -818,7 +818,7 @@ def list_runs(
 
 
 @app.command()
-def export_run(
+def export_run(  # noqa: C901
     database: REQ_ARG_TYPE_DATABASE,
     outdir: REQ_ARG_TYPE_OUTDIR,
     run_id: Annotated[
@@ -868,10 +868,20 @@ def export_run(
             )
             sys.exit(msg)
 
-    if not run.comparisons().count():
+    done = run.comparisons().count()
+    n = run.genomes.count()
+    if not done:
         msg = f"ERROR: Database {database} run-id {run_id} has no comparisons"
         sys.exit(msg)
-    # What if the run is incomplete? Just output with NaN?
+    elif done < n**2:
+        # Would it be useful to allow partial export, perhaps with a --force option?
+        # Indicate this with blank strings?
+        msg = (
+            f"ERROR: Database {database} run-id {run_id} has only {done} of {n}²={n**2}"
+            f" comparisons, {n**2 - done} needed"
+        )
+        sys.exit(msg)
+
     if run.identities is None:
         run.cache_comparisons()
     if not isinstance(run.identities, pd.DataFrame):

--- a/pyani_plus/utils.py
+++ b/pyani_plus/utils.py
@@ -23,6 +23,7 @@
 
 import hashlib
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -136,3 +137,21 @@ def check_fasta(fasta: Path) -> list[Path]:
         sys.exit(msg)
 
     return fasta_names
+
+
+def _fmt_cmd(args: list[str]) -> str:
+    # Needs to handle spaces with quoting
+    return " ".join(f"'{_}'" if " " in str(_) else str(_) for _ in args)
+
+
+def check_call(args: list[str]) -> int:
+    """Wrap for subprocess.check_call and report any error to stderr."""
+    try:
+        return subprocess.check_call(
+            [str(_) for _ in args], stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+    except subprocess.CalledProcessError as err:
+        sys.stderr.write(f"ERROR: Return code {err.returncode} from {_fmt_cmd(args)}\n")
+        if err.output:
+            sys.stderr.write(err.output)
+        sys.exit(err.returncode)

--- a/pyani_plus/workflows/snakemake_anib.smk
+++ b/pyani_plus/workflows/snakemake_anib.smk
@@ -25,75 +25,23 @@ from pyani_plus.workflows import check_input_stems
 indir_files = check_input_stems(config["indir"])
 
 
-def get_genomeA(wildcards):
-    return indir_files[wildcards.genomeA]
-
-
 def get_genomeB(wildcards):
     return indir_files[wildcards.genomeB]
 
 
-# The fragments FASTA file is used for the ANIb query.
-# Should we put use fragment size in the filename?
-rule fragment:
-    params:
-        fragsize=config["fragsize"],
-        indir=config["indir"],
-        outdir=config["outdir"],
-    input:
-        genomeA=get_genomeA,
-    output:
-        "{outdir}/{genomeA}-fragments.fna",
-    shell:
-        ".pyani-plus-private-cli fragment-fasta --quiet --outdir {wildcards.outdir} --fragsize {params.fragsize} {input.genomeA}"
-
-
-# The nucleotide database of the FASTA file is used for the ANIb reference.
-# A nucleotide BLAST database is a set of files <stem>.n*
-# Picking <stem>.njs as the one we'll track for snakemake
-# as this is plain text, specifically a JSON summary
-rule blastdb:
-    params:
-        makeblastdb=config["makeblastdb"],
-        indir=config["indir"],
-        outdir=config["outdir"],
-    input:
-        genomeB=get_genomeB,
-    output:
-        "{outdir}/{genomeB}.njs",
-    shell:
-        """
-        {params.makeblastdb} -in {input.genomeB} -input_type fasta -dbtype nucl \
-            -title {wildcards.genomeB} -out {wildcards.outdir}/{wildcards.genomeB} \
-            > {wildcards.outdir}/{wildcards.genomeB}.log
-        """
-
-
-# For ANIb query the fragments FASTA from genomeA against a BLAST DB of genomeB.
-rule blastn:
+# For ANIb, query the fragments FASTA from genomeA against a BLAST DB of genomeB.
+rule anib:
     params:
         db=config["db"],
         run_id=config["run_id"],
-        blastn=config["blastn"],
-        fragsize=config["fragsize"],
-        indir=config["indir"],
         outdir=config["outdir"],
     input:
-        "{outdir}/{genomeA}-fragments.fna",
-        "{outdir}/{genomeB}.njs",
-        genomeA=get_genomeA,
         genomeB=get_genomeB,
     output:
-        "{outdir}/{genomeA}_vs_{genomeB}.tsv",
+        "{outdir}/all_vs_{genomeB}.anib",
     shell:
         """
-        {params.blastn} -query {wildcards.outdir}/{wildcards.genomeA}-fragments.fna \
-            -db {wildcards.outdir}/{wildcards.genomeB} -out {output} -task blastn \
-            -outfmt '6 qseqid sseqid length mismatch pident nident qlen slen \
-                     qstart qend sstart send positive ppos gaps' \
-            -xdrop_gap_final 150 -dust no -evalue 1e-15 > {output}.log &&
-        .pyani-plus-private-cli log-anib --quiet \
+        .pyani-plus-private-cli anib --quiet \
             --database {params.db} --run-id {params.run_id} \
-            --query-fasta {input.genomeA} --subject-fasta {input.genomeB} \
-            --blastn {wildcards.outdir}/{wildcards.genomeA}_vs_{wildcards.genomeB}.tsv
+            --subject {input} && touch {output}
         """

--- a/pyani_plus/workflows/snakemake_anib.smk
+++ b/pyani_plus/workflows/snakemake_anib.smk
@@ -35,6 +35,7 @@ rule anib:
         db=config["db"],
         run_id=config["run_id"],
         outdir=config["outdir"],
+        temp=config["temp"],
     input:
         genomeB=get_genomeB,
     output:
@@ -43,5 +44,5 @@ rule anib:
         """
         .pyani-plus-private-cli compute-column --quiet \
             --database {params.db} --run-id {params.run_id} \
-            --subject {input} && touch {output}
+            --subject {input} {params.temp} && touch {output}
         """

--- a/pyani_plus/workflows/snakemake_anib.smk
+++ b/pyani_plus/workflows/snakemake_anib.smk
@@ -41,7 +41,7 @@ rule anib:
         "{outdir}/all_vs_{genomeB}.anib",
     shell:
         """
-        .pyani-plus-private-cli anib --quiet \
+        .pyani-plus-private-cli compute-column --quiet \
             --database {params.db} --run-id {params.run_id} \
             --subject {input} && touch {output}
         """

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -43,7 +43,7 @@ rule fastani:
         "{outdir}/all_vs_{genomeB}.fastani",
     shell:
         """
-        .pyani-plus-private-cli fastani --quiet \
+        .pyani-plus-private-cli compute-column --quiet \
             --database {params.db} --run-id {params.run_id} \
             --subject {input} && touch {output}
         """

--- a/pyani_plus/workflows/snakemake_fastani.smk
+++ b/pyani_plus/workflows/snakemake_fastani.smk
@@ -37,6 +37,7 @@ rule fastani:
         db=config["db"],
         run_id=config["run_id"],
         outdir=config["outdir"],
+        temp=config["temp"],
     input:
         genomeB=get_genomeB,
     output:
@@ -45,5 +46,5 @@ rule fastani:
         """
         .pyani-plus-private-cli compute-column --quiet \
             --database {params.db} --run-id {params.run_id} \
-            --subject {input} && touch {output}
+            --subject {input} {params.temp} && touch {output}
         """

--- a/tests/snakemake/test_snakemake_anib_workflow.py
+++ b/tests/snakemake/test_snakemake_anib_workflow.py
@@ -106,6 +106,7 @@ def test_snakemake_rule_anib(
         ],
         params=config_anib_args,
         working_directory=Path(tmp_path),
+        temp=Path(tmp_path),
     )
 
     # Want to check the intermediate files, but currently lost in a temp folder...

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -26,6 +26,7 @@ These tests are intended to be run from the repository root using:
 make test
 """
 
+import filecmp
 import os
 import re
 import shutil
@@ -98,8 +99,7 @@ def test_snakemake_rule_fastani(
     Checks that the fastANI rule in the fastANI snakemake wrapper gives the
     expected output.
     """
-    # Remove the output directory to force re-running the snakemake rule
-    shutil.rmtree(fastani_targets_outdir, ignore_errors=True)
+    tmp_dir = Path(tmp_path)
 
     # Assuming this will match but worker nodes might have a different version
     fastani_tool = get_fastani()
@@ -138,7 +138,10 @@ def test_snakemake_rule_fastani(
         temp=Path(tmp_path),
     )
 
-    # Want to check the intermediate files, but currently lost in a temp folder...
+    # Check the intermediate files
+
+    for file in (input_genomes_tiny / "intermediates/fastANI").glob("*_vs_*.fastani"):
+        assert filecmp.cmp(file, tmp_dir / file), f"Wrong fastANI output in {file.name}"
 
     compare_db_matrices(db, input_genomes_tiny / "matrices")
 

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -135,6 +135,7 @@ def test_snakemake_rule_fastani(
         ],
         params=config_fastani_args,
         working_directory=Path(tmp_path),
+        temp=Path(tmp_path),
     )
 
     # Want to check the intermediate files, but currently lost in a temp folder...
@@ -180,4 +181,5 @@ def test_snakemake_duplicate_stems(
             targets=generated_targets,
             params=dup_config,
             working_directory=Path(tmp_path),
+            temp=Path(tmp_path),
         )

--- a/tests/snakemake/test_snakemake_fastani_workflow.py
+++ b/tests/snakemake/test_snakemake_fastani_workflow.py
@@ -125,23 +125,19 @@ def test_snakemake_rule_fastani(
     output = capsys.readouterr().out
     assert output.endswith("Run identifier 1\n")
 
-    expected_targets = list(
-        (input_genomes_tiny / "intermediates/fastANI").glob("*.fastani")
-    )
-    generated_targets = [fastani_targets_outdir / f.name for f in expected_targets]
-
     # Run snakemake wrapper
     run_snakemake_with_progress_bar(
         executor=ToolExecutor.local,
         workflow_name="snakemake_fastani.smk",
-        targets=generated_targets,
+        targets=[
+            fastani_targets_outdir / f"all_vs_{s.stem}.fastani"
+            for s in input_genomes_tiny.glob("*.f*")
+        ],
         params=config_fastani_args,
         working_directory=Path(tmp_path),
     )
 
-    # Check output against target fixtures
-    for expected, generated in zip(expected_targets, generated_targets, strict=False):
-        assert compare_fastani_files(expected, generated)
+    # Want to check the intermediate files, but currently lost in a temp folder...
 
     compare_db_matrices(db, input_genomes_tiny / "matrices")
 

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -104,7 +104,8 @@ def test_running_anib(
     input_genomes_tiny: Path,
 ) -> None:
     """Check can log a ANIb comparison to DB."""
-    tmp_db = Path(tmp_path) / "new.sqlite"
+    tmp_dir = Path(tmp_path)
+    tmp_db = tmp_dir / "new.sqlite"
     assert not tmp_db.is_file()
 
     tool = tools.get_blastn()
@@ -130,6 +131,7 @@ def test_running_anib(
     hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
 
     private_cli.anib(
+        tmp_dir,
         session,
         run,
         hash_to_filename,

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -98,19 +98,6 @@ def test_parse_blastn(input_genomes_tiny: Path) -> None:
     # Note final digit wobble from 3 (old) to 2 (new)
 
 
-def test_missing_db(tmp_path: str) -> None:
-    """Check expected error when DB does not exist."""
-    tmp_db = Path(tmp_path) / "new.sqlite"
-    assert not tmp_db.is_file()
-
-    with pytest.raises(SystemExit, match="does not exist"):
-        private_cli.anib(
-            database=tmp_db,
-            run_id=1,
-            subject="XXXX",
-        )
-
-
 def test_running_anib(
     capsys: pytest.CaptureFixture[str],
     tmp_path: str,
@@ -137,38 +124,21 @@ def test_running_anib(
     output = capsys.readouterr().out
     assert output.endswith("Run identifier 1\n")
 
-    with pytest.raises(
-        SystemExit,
-        match="ERROR: Did not recognise 'XXXX' as an MD5 hash or filename in run-id 1",
-    ):
-        private_cli.anib(
-            database=tmp_db,
-            run_id=1,
-            subject="XXXX",
-        )
-
-    private_cli.anib(
-        database=tmp_db,
-        run_id=1,
-        subject=input_genomes_tiny / "MGV-GENOME-0266457.fna",
-    )
-
-    # Check the recorded comparison values
     session = db_orm.connect_to_db(tmp_db)
+    run = session.query(db_orm.Run).one()
+    assert run.run_id == 1
+    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+
+    private_cli.anib(
+        session,
+        run,
+        hash_to_filename,
+        {},  # not used for ANIb
+        query_hashes=set(hash_to_filename),
+        subject_hash=list(hash_to_filename)[1],
+    )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
+
     # No need to test the ANI values here, will be done elsewhere.
-
-    # Do another row, should accept a hash:
-    private_cli.anib(
-        database=tmp_db, run_id=1, subject="689d3fd6881db36b5e08329cf23cecdd"
-    )
-    assert session.query(db_orm.Comparison).count() == 6  # noqa: PLR2004
-
-    # Do the same row again, should skip gracefully:
-    private_cli.anib(
-        database=tmp_db, run_id=1, subject="689d3fd6881db36b5e08329cf23cecdd"
-    )
-    assert session.query(db_orm.Comparison).count() == 6  # noqa: PLR2004
-
     session.close()
     tmp_db.unlink()

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -142,6 +142,7 @@ def test_running_anib(
         tmp_dir,
         session,
         run,
+        input_genomes_tiny,
         hash_to_filename,
         {},  # not used for ANIb
         query_hashes=set(hash_to_filename),  # order should not matter!

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -85,6 +85,7 @@ def test_running_fastani(
         tmp_dir,
         session,
         run,
+        input_genomes_tiny,
         hash_to_filename,
         filename_to_hash,
         query_hashes=set(hash_to_filename),

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -52,7 +52,8 @@ def test_running_fastani(
     input_genomes_tiny: Path,
 ) -> None:
     """Check can run a fastANI comparison to DB."""
-    tmp_db = Path(tmp_path) / "new.sqlite"
+    tmp_dir = Path(tmp_path)
+    tmp_db = tmp_dir / "new.sqlite"
     assert not tmp_db.is_file()
 
     tool = tools.get_fastani()
@@ -81,6 +82,7 @@ def test_running_fastani(
     hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
 
     private_cli.fastani(
+        tmp_dir,
         session,
         run,
         hash_to_filename,

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -26,7 +26,6 @@ These tests are intended to be run from the repository root using:
 pytest -v
 """
 
-import filecmp
 import multiprocessing
 import sys
 from pathlib import Path
@@ -436,42 +435,6 @@ def test_log_comparison_parallel(
 
     session = db_orm.connect_to_db(tmp_db)
     assert session.query(db_orm.Comparison).count() == len(fasta) ** 2
-
-
-def test_fragment_fasta(tmp_path: str, input_genomes_tiny: Path) -> None:
-    """Confirm fragmenting FASTA files (for ANIb) works."""
-    fasta = input_genomes_tiny.glob("*.f*")
-    out_dir = Path(tmp_path)
-    private_cli.fragment_fasta(fasta, out_dir)
-
-    old_frags = [
-        input_genomes_tiny / f"intermediates/ANIb/{f.stem}-fragments.fna" for f in fasta
-    ]
-    new_frags = [out_dir / (f.stem + "-fragments.fna") for f in fasta]
-    for old_file, new_file in zip(old_frags, new_frags, strict=True):
-        assert filecmp.cmp(old_file, new_file), f"Wrong output in {new_file}"
-
-
-def test_fragment_fasta_bad_args(tmp_path: str, input_genomes_tiny: Path) -> None:
-    """Check error handling for fragmenting FASTA files (for ANIb)."""
-    fasta = input_genomes_tiny.glob("*.f*")
-    out_dir = Path(tmp_path)
-
-    with pytest.raises(
-        SystemExit, match="ERROR: outdir /does/not/exist should be a directory"
-    ):
-        private_cli.fragment_fasta(fasta, outdir=Path("/does/not/exist"))
-
-    with pytest.raises(
-        FileNotFoundError, match="No such file or directory: '/does/not/exist.fasta'"
-    ):
-        private_cli.fragment_fasta([Path("/does/not/exist.fasta")], out_dir)
-
-    with pytest.raises(
-        TypeError,
-        match="Expected a Path object in list of FASTA files, got 'some/example.fasta'",
-    ):
-        private_cli.fragment_fasta(["some/example.fasta"], out_dir)
 
 
 def test_log_wrong_config(

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -676,7 +676,7 @@ def test_compute_column_fastani(
     )
     output = capsys.readouterr().out
     assert (
-        "INFO: No comparisons needed against 5584c7029328dc48d33f95f0a78f7e57\n"
+        "INFO: No fastANI comparisons needed against 5584c7029328dc48d33f95f0a78f7e57\n"
         in output
     )
 
@@ -688,6 +688,6 @@ def test_compute_column_fastani(
     )
     output = capsys.readouterr().out
     assert (
-        "INFO: No comparisons needed against 5584c7029328dc48d33f95f0a78f7e57\n"
+        "INFO: No fastANI comparisons needed against 5584c7029328dc48d33f95f0a78f7e57\n"
         in output
     )

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -636,7 +636,8 @@ def test_compute_column_fastani(
     input_genomes_tiny: Path,
 ) -> None:
     """Check compute_column with valid args (using fastANI)."""
-    tmp_db = Path(tmp_path) / "new.sqlite"
+    tmp_dir = Path(tmp_path)
+    tmp_db = tmp_dir / "new.sqlite"
     assert not tmp_db.is_file()
 
     tool = tools.get_fastani()
@@ -662,6 +663,7 @@ def test_compute_column_fastani(
         database=tmp_db,
         run_id=1,
         subject="0",  # here passing column number
+        temp=tmp_dir,
     )
     output = capsys.readouterr().out
     assert (

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -522,12 +522,10 @@ def test_log_wrong_config(
         )
 
     with pytest.raises(SystemExit, match="ERROR: Run-id 1 expected guessing results"):
-        private_cli.log_anib(
+        private_cli.anib(
             tmp_db,
             run_id=1,
-            query_fasta=input_genomes_tiny / "MGV-GENOME-0264574.fas",
-            subject_fasta=input_genomes_tiny / "MGV-GENOME-0266457.fna",
-            blastn=faked,
+            subject="XXX",
         )
 
     with pytest.raises(SystemExit, match="ERROR: Run-id 1 expected guessing results"):

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -316,13 +316,18 @@ def test_anib(tmp_path: str, input_genomes_tiny: Path) -> None:
     out = Path(tmp_path)
     tmp_db = out / "example.sqlite"
     public_cli.anib(
-        database=tmp_db, fasta=input_genomes_tiny, name="Test Run", create_db=True
+        database=tmp_db,
+        fasta=input_genomes_tiny,
+        name="Test Run",
+        create_db=True,
+        temp=out,
     )
     public_cli.export_run(database=tmp_db, outdir=out)
     compare_matrix_files(
         input_genomes_tiny / "matrices" / "ANIb_identity.tsv",
         out / "ANIb_identity.tsv",
     )
+    # Now check the intermediates...
 
 
 def test_fastani(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -330,13 +335,18 @@ def test_fastani(tmp_path: str, input_genomes_tiny: Path) -> None:
     out = Path(tmp_path)
     tmp_db = out / "example.sqlite"
     public_cli.fastani(
-        database=tmp_db, fasta=input_genomes_tiny, name="Test Run", create_db=True
+        database=tmp_db,
+        fasta=input_genomes_tiny,
+        name="Test Run",
+        create_db=True,
+        temp=out,
     )
     public_cli.export_run(database=tmp_db, outdir=out)
     compare_matrix_files(
         input_genomes_tiny / "matrices" / "fastANI_identity.tsv",
         out / "fastANI_identity.tsv",
     )
+    # Now check the intermediates...
 
 
 def test_sourmash(tmp_path: str, input_genomes_tiny: Path) -> None:


### PR DESCRIPTION
This is the followup to #183 (merged on Monday) which as discussed calls fastANI via the Python code in our private CLI.

Before, for each subject:
1. Snakemake called our private CLI to see which queries are needed
2. Snakemake called fastANI
3. Snakemake called our private CLI parse the fastANI output and log it

Now snakemake just calls our private CLI, and from there we call fastANI via subprocess. This greatly simplifies the snakemake rule, and makes it much easier to skip recomputing an already completed row.

It also means we can catch missing rows (from poor alignmnets) more easily in future. See #140.

It then goes further and changes ANIb to work by column. Previously:
1. For each FASTA file, make a BLAST DB and a fragmented FASTA file
2. For each pair, call blastn
3. For each pair, call our private CLI to parse the blastn output and log it

Now snakemake just calls our private CLI for many-vs-one-subject, and from there we make the subject BLAST DB, and loop over the required queries to call blastn, parse output, and log it.

Also, this introduces a new private CLI command to compute and log a many-vs-one-subject run (currently only used for fastANI and ANIb). The could become universal, and would only need a generic by-column snakemake files.

Via this route the temp files default to using the system temp (which should be local to a node and fast), but it can be told where to write intermediate files. This is used in the tests to verify the intermediate files as before (when we checked the output of each step in snakemake).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
