### PR TITLE
Wrap subprocess so as to enable testing failure error messages

### DIFF
--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -549,7 +549,7 @@ def test_compute_column_bad_args(
             subject="XXXX",
         )
 
-    with pytest.raises(  # noqa: PT012
+    with pytest.raises(
         SystemExit,
         match="ERROR: Unknown method guessing for run-id 1 in .*/new.sqlite",
     ):
@@ -558,9 +558,6 @@ def test_compute_column_bad_args(
             run_id=1,
             subject="3",
         )
-        # This has to be within the context manager to work:
-        output = capsys.readouterr().out
-        assert "INFO: Treating subject N as 0 (first column)" in output
 
     with pytest.raises(
         SystemExit,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,3 +55,15 @@ def test_md5_invalid() -> None:
         ValueError, match="Input file /does/not/exist.txt is not a file or symlink"
     ):
         utils.file_md5sum("/does/not/exist.txt")
+
+
+def test_check_output() -> None:
+    """Confirm our subprocess wrapper catches expected failures."""
+    # I wanted to check the full stderr, but couldn't get it to work.
+    # After and outside the context manager capsys.readouterr().out was empty.
+    # Inside the context manager, the code never ran...
+    with pytest.raises(
+        SystemExit,
+        match=r'ERROR: Return code 1 from: blastn -task blast\nError: Argument "task". Illegal value',
+    ):
+        utils.check_output(["blastn", "-task", "blast"])


### PR DESCRIPTION
~~First this moves from subprocess.check_call to subprocess.check_output guided by subprocess documentation: https://docs.python.org/3/library/subprocess.html#subprocess.check_call~~ (done on main)

Next moved from using ``sys.exit(returncode)`` to ``sys.exit(msg)`` in order to be able to easily test the error message (but have to accept always return code 1).

Sample command for testing:

```console
$ python -c "from pyani_plus.utils import check_output; check_output(['blastn', '-task','undefined'])"; echo "Return code $?"
```

Note the first commit, pytest capsys was not working for me to test the error message by looking in stderr instead (and I don't understand why - I thought this was working before).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
