### PR TITLE
Offer MD5, stem or filename labels in export-runs

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -32,6 +32,7 @@ import tempfile
 from pathlib import Path
 from typing import Annotated
 
+import click
 import pandas as pd
 import typer
 from rich.console import Console
@@ -820,13 +821,21 @@ def list_runs(
 
 
 @app.command()
-def export_run(  # noqa: C901
+def export_run(  # noqa: C901, PLR0912, PLR0915
     database: REQ_ARG_TYPE_DATABASE,
     outdir: REQ_ARG_TYPE_OUTDIR,
     run_id: Annotated[
         int | None,
         typer.Option(help="Which run to report (optional if DB contains only one)"),
     ] = None,
+    # Would like to replace this with Literal["md5", "filename", "stem"] once typer updated
+    label: Annotated[
+        str,
+        typer.Option(
+            click_type=click.Choice(["md5", "filename", "stem"]),
+            help="How to label the genomes",
+        ),
+    ] = "md5",
 ) -> int:
     """Export any single run from the given pyANI-plus SQLite3 database.
 
@@ -896,11 +905,27 @@ def export_run(  # noqa: C901
     # Question: Should we offer MD5 alternatives, and how? e.g. filename or labels
     # (seems more suited to a report command offering tables and plots)
     method = run.configuration.method
-    run.identities.to_csv(outdir / f"{method}_identity.tsv", sep="\t")
-    run.aln_length.to_csv(outdir / f"{method}_aln_lengths.tsv", sep="\t")
-    run.sim_errors.to_csv(outdir / f"{method}_sim_errors.tsv", sep="\t")
-    run.cov_query.to_csv(outdir / f"{method}_query_cov.tsv", sep="\t")
-    run.hadamard.to_csv(outdir / f"{method}_hadamard.tsv", sep="\t")
+
+    for matrix, filename in (
+        (run.identities, f"{method}_identity.tsv"),
+        (run.aln_length, f"{method}_aln_lengths.tsv"),
+        (run.sim_errors, f"{method}_sim_errors.tsv"),
+        (run.cov_query, f"{method}_query_cov.tsv"),
+        (run.hadamard, f"{method}_hadamard.tsv"),
+    ):
+        if label == "filename":
+            mapping = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        elif label == "stem":
+            mapping = {
+                _.genome_hash: Path(_.fasta_filename).stem for _ in run.fasta_hashes
+            }
+        else:
+            mapping = None
+        if mapping:
+            matrix.rename(index=mapping, columns=mapping, inplace=True)  # noqa: PD002
+            matrix.sort_index(axis=0, inplace=True)  # noqa: PD002
+            matrix.sort_index(axis=1, inplace=True)  # noqa: PD002
+        matrix.to_csv(outdir / filename, sep="\t")
 
     print(f"Wrote matrices to {outdir}/{method}_*.tsv")
 


### PR DESCRIPTION
Example output:

```console
❯ conda install qsv
...
❯ pyani-plus anim --database 3V.db --create-db tests/fixtures/viral_example/
Indexing FASTAs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 3/3
ANIm run setup with 3 genomes in database
Database already has 0 of 3²=9 comparisons, 9 needed
host: Peters-iMac.local
Comparing pairs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:03 9/9
Completed run-id 1 with 3 genomes in database 3V.db
```

The default remains MD5 labeling:

```console
❯ pyani-plus export-run --database 3V.db --outdir /tmp
INFO: Reporting on run-id 1 from 3V.db
Wrote matrices to /tmp/ANIm_*.tsv

❯ qsv table /tmp/ANIm_identity.tsv
                                  5584c7029328dc48d33f95f0a78f7e57  689d3fd6881db36b5e08329cf23cecdd  78975d5144a1cd12e98898d573cf6536
5584c7029328dc48d33f95f0a78f7e57  1.0                               0.9993103184000001                0.9946424059000001
689d3fd6881db36b5e08329cf23cecdd  0.9993103184000001                1.0                               0.9962487644
78975d5144a1cd12e98898d573cf6536  0.9946424059000001                0.9962487644                      1.0
```

Here using what might be most commonly wanted, FASTA filename stems. Note this gets resorted by the new labels:

```console
❯ pyani-plus export-run --database 3V.db --outdir /tmp --label stem
INFO: Reporting on run-id 1 from 3V.db
Wrote matrices to /tmp/ANIm_*.tsv

❯ qsv table /tmp/ANIm_identity.tsv
                    MGV-GENOME-0264574  MGV-GENOME-0266457  OP073605
MGV-GENOME-0264574  1.0                 0.9962487644        0.9993103184000001
MGV-GENOME-0266457  0.9962487644        1.0                 0.9946424059000001
OP073605            0.9993103184000001  0.9946424059000001  1.0
```

And for completeness, labelled with the FASTA filename (no path), potentially useful if as here the extensions vary:

```console
❯ pyani-plus export-run --database 3V.db --outdir /tmp --label filename
INFO: Reporting on run-id 1 from 3V.db
Wrote matrices to /tmp/ANIm_*.tsv

❯ qsv table /tmp/ANIm_identity.tsv
                        MGV-GENOME-0264574.fas  MGV-GENOME-0266457.fna  OP073605.fasta
MGV-GENOME-0264574.fas  1.0                     0.9962487644            0.9993103184000001
MGV-GENOME-0266457.fna  0.9962487644            1.0                     0.9946424059000001
OP073605.fasta          0.9993103184000001      0.9946424059000001      1.0
```

As part of this I switched the 2 genomes in the test to check sorting on export (was using the two MGV which happen to sort the same as their MD5):

```console
$ md5sum *.f* | sort
5584c7029328dc48d33f95f0a78f7e57  OP073605.fasta
689d3fd6881db36b5e08329cf23cecdd  MGV-GENOME-0264574.fas
78975d5144a1cd12e98898d573cf6536  MGV-GENOME-0266457.fna
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
