### PR TITLE
Drop --num support for sourmash

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -111,7 +111,9 @@ OPT_ARG_TYPE_FRAGSIZE = Annotated[
 OPT_ARG_TYPE_KMERSIZE = Annotated[
     int,
     typer.Option(
-        help="Comparison method k-mer size", rich_help_panel="Method parameters", min=1
+        help="Comparison method k-mer size",
+        rich_help_panel="Method parameters",
+        min=1,
     ),
 ]
 OPT_ARG_TYPE_MINMATCH = Annotated[
@@ -140,14 +142,7 @@ OPT_ARG_TYPE_SOURMASH_MODE = Annotated[
 OPT_ARG_TYPE_SOURMASH_SCALED = Annotated[
     int,
     typer.Option(
-        help="Sets the compression ratio", rich_help_panel="Method parameters", min=1
-    ),
-]
-OPT_ARG_TYPE_SOURMASH_NUM = Annotated[
-    int | None,
-    typer.Option(
-        help="""sets the maximum number of hashes \n
-            Note: num  and scaled options are mutually exclusive and cannot be used together.""",
+        help="Sets the compression ratio",
         rich_help_panel="Method parameters",
         min=1,
     ),
@@ -533,7 +528,6 @@ def sourmash(  # noqa: PLR0913
     executor: OPT_ARG_TYPE_EXECUTOR = ToolExecutor.local,
     temp: OPT_ARG_TYPE_TEMP = None,
     scaled: OPT_ARG_TYPE_SOURMASH_SCALED = method_sourmash.SCALED,  # 1000
-    num: OPT_ARG_TYPE_SOURMASH_NUM = None,  # will override scaled if used
     kmersize: OPT_ARG_TYPE_KMERSIZE = method_sourmash.KMER_SIZE,
 ) -> int:
     """Execute sourmash calculations, logged to a pyANI-plus SQLite3 database."""
@@ -543,7 +537,7 @@ def sourmash(  # noqa: PLR0913
     binaries = {
         "sourmash": tool.exe_path,
     }
-    extra = f"scaled={scaled}" if num is None else f"num={num}"
+    extra = f"scaled={scaled}"
     return start_and_run_method(
         executor,
         temp,
@@ -577,7 +571,6 @@ def branchwater(  # noqa: PLR0913
     executor: OPT_ARG_TYPE_EXECUTOR = ToolExecutor.local,
     temp: OPT_ARG_TYPE_TEMP = None,
     scaled: OPT_ARG_TYPE_SOURMASH_SCALED = method_sourmash.SCALED,  # 1000
-    num: OPT_ARG_TYPE_SOURMASH_NUM = None,  # will override scaled if used
     kmersize: OPT_ARG_TYPE_KMERSIZE = method_sourmash.KMER_SIZE,
 ) -> int:
     """Execute sourmash-plugin-branchwater ANI calculations, logged to a pyANI-plus SQLite3 database."""
@@ -587,7 +580,7 @@ def branchwater(  # noqa: PLR0913
     binaries = {
         "sourmash": tool.exe_path,
     }
-    extra = f"scaled={scaled}" if num is None else f"num={num}"
+    extra = f"scaled={scaled}"
     return start_and_run_method(
         executor,
         temp,


### PR DESCRIPTION
Building a signature with ``--num`` appears to be incompatible with ``sourmash compare`` using (max)containment. This PR removes the ``--num`` option (no changes to the tests required - we didn't actually try to use it).

Closes #204.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
