### PR TITLE
Log ANIm, dnadiff, and ANIb in batches

### DIFF
--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -145,7 +145,7 @@ def test_running_anib(
         input_genomes_tiny,
         hash_to_filename,
         {},  # not used for ANIb
-        query_hashes=set(hash_to_filename),  # order should not matter!
+        query_hashes=list(hash_to_filename),  # order should not matter!
         subject_hash=subject_hash,
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -123,7 +123,7 @@ def test_running_anim(
         input_genomes_tiny,
         hash_to_filename,
         {},  # not used for ANIm
-        query_hashes=set(hash_to_filename),  # order should not matter!
+        query_hashes=list(hash_to_filename),  # order should not matter!
         subject_hash=subject_hash,
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004

--- a/tests/test_dnadiff.py
+++ b/tests/test_dnadiff.py
@@ -128,7 +128,7 @@ def test_running_dnadiff(
         input_genomes_tiny,
         hash_to_filename,
         {},  # not used for dnadiff
-        query_hashes=set(hash_to_filename),  # order should not matter!
+        query_hashes=list(hash_to_filename),  # order should not matter!
         subject_hash=subject_hash,
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -82,7 +82,7 @@ def test_running_fastani(
         input_genomes_tiny,
         hash_to_filename,
         filename_to_hash,
-        query_hashes=set(hash_to_filename),
+        query_hashes=list(hash_to_filename),
         subject_hash=list(hash_to_filename)[1],
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004


### PR DESCRIPTION
In order to avoid locking errors writing to SQLite3 on a network drive we had switched to recording the comparisons for these methods a whole column at a time (#216) - and this has been tested with up to 400 workers on 400 genomes.

However, this change means the main application shows zero progress until the first column completes - which is not a good user experience. Quoting myself on #216:

> One minor downside is this does mean the progress bar will sit at zero until the first task completes and then it will jump to N / N² complete  (just like the fastANI implementation).

We therefore want to log DB output occasionally, in order to have the main thread progress bar update, but not too often, and not by multiple workers all at once.

Assuming all the pairwise comparisons take the same time, the design here would mean at each round a different column worker would log its progress. This would mean regular updates until all the columns complete, although at any one moment in addition to what has been logged and shown on the progress bar, there will be lots of completed calculations cached and waiting to be logged.

Note the progress bar progression will be non-linear with time, updated relatively slowly during the run (lagging the actual computational progress), and seemingly speed up and show rapid progress near the end as the columns complete.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
