### PR TITLE
Catch bad ANIm/ANIb/fastANI parameters in compute-column explicitly

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -516,6 +516,18 @@ def fastani(  # noqa: PLR0913
     _check_tool_version(tool, run.configuration)
 
     config_id = run.configuration.configuration_id
+    fragsize = run.configuration.fragsize
+    if not fragsize:
+        msg = f"ERROR: fastANI run-id {run.run_id} is missing fragsize parameter"
+        sys.exit(msg)
+    kmersize = run.configuration.kmersize
+    if not kmersize:
+        msg = f"ERROR: fastANI run-id {run.run_id} is missing kmersize parameter"
+        sys.exit(msg)
+    minmatch = run.configuration.minmatch
+    if not minmatch:
+        msg = f"ERROR: fastANI run-id {run.run_id} is missing minmatch parameter"
+        sys.exit(msg)
 
     tmp_output = tmp_dir / f"queries_vs_{subject_hash}.csv"
     tmp_queries = tmp_dir / f"queries_vs_{subject_hash}.txt"
@@ -539,11 +551,11 @@ def fastani(  # noqa: PLR0913
             "-o",
             str(tmp_output),
             "--fragLen",
-            str(run.configuration.fragsize),
+            str(fragsize),
             "-k",
-            str(run.configuration.kmersize),
+            str(kmersize),
             "--minFraction",
-            str(run.configuration.minmatch),
+            str(minmatch),
         ],
     )
 
@@ -614,6 +626,10 @@ def anim(  # noqa: PLR0913
 
     config_id = run.configuration.configuration_id
     mode = run.configuration.mode
+    if not mode:
+        msg = f"ERROR: ANIm run-id {run.run_id} is missing mode parameter"
+        sys.exit(msg)
+
     subject_length = (
         session.query(db_orm.Genome)
         .where(db_orm.Genome.genome_hash == subject_hash)
@@ -741,6 +757,9 @@ def anib(  # noqa: PLR0913
 
     config_id = run.configuration_id
     fragsize = run.configuration.fragsize
+    if not fragsize:
+        msg = f"ERROR: ANIb run-id {run.run_id} is missing fragsize parameter"
+        sys.exit(msg)
     subject_length = (
         session.query(db_orm.Genome)
         .where(db_orm.Genome.genome_hash == subject_hash)

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -571,6 +571,167 @@ def test_compute_column_bad_args(
         )
 
 
+def test_compute_column_bad_anib(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: str,
+    input_genomes_tiny: Path,
+) -> None:
+    """Check how compute_column handles bad ANIb settings."""
+    tmp_db = Path(tmp_path) / "anib.sqlite"
+    assert not tmp_db.is_file()
+
+    tool = tools.get_blastn()
+    private_cli.log_run(
+        fasta=input_genomes_tiny,
+        database=tmp_db,
+        cmdline="pyani-plus guessing ...",
+        status="Testing",
+        name="Testing compute-column",
+        method="ANIb",
+        program=tool.exe_path.stem,
+        version=tool.version,
+        # fragsize=...,  <-- missing!
+        create_db=True,
+    )
+    output = capsys.readouterr().out
+    assert output.endswith("Run identifier 1\n")
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: ANIb run-id 1 is missing fragsize parameter",
+    ):
+        private_cli.compute_column(
+            database=tmp_db,
+            run_id=1,
+            subject="0",
+        )
+
+
+def test_compute_column_bad_anim(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: str,
+    input_genomes_tiny: Path,
+) -> None:
+    """Check how compute_column handles bad ANIm settings."""
+    tmp_db = Path(tmp_path) / "anim.sqlite"
+    assert not tmp_db.is_file()
+
+    tool = tools.get_nucmer()
+    private_cli.log_run(
+        fasta=input_genomes_tiny,
+        database=tmp_db,
+        cmdline="pyani-plus guessing ...",
+        status="Testing",
+        name="Testing compute-column",
+        method="ANIm",
+        program=tool.exe_path.stem,
+        version=tool.version,
+        # mode=...,  <-- missing!
+        create_db=True,
+    )
+    output = capsys.readouterr().out
+    assert output.endswith("Run identifier 1\n")
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: ANIm run-id 1 is missing mode parameter",
+    ):
+        private_cli.compute_column(
+            database=tmp_db,
+            run_id=1,
+            subject="0",
+        )
+
+
+def test_compute_column_bad_fastani(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: str,
+    input_genomes_tiny: Path,
+) -> None:
+    """Check how compute_column handles bad fastani settings."""
+    tmp_db = Path(tmp_path) / "fastani.sqlite"
+    assert not tmp_db.is_file()
+
+    tool = tools.get_fastani()
+    private_cli.log_run(
+        fasta=input_genomes_tiny,
+        database=tmp_db,
+        cmdline="pyani-plus guessing ...",
+        status="Testing",
+        name="Testing compute-column",
+        method="fastANI",
+        program=tool.exe_path.stem,
+        version=tool.version,
+        # fragsize=...,  <-- missing!
+        create_db=True,
+    )
+    output = capsys.readouterr().out
+    assert output.endswith("Run identifier 1\n")
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: fastANI run-id 1 is missing fragsize parameter",
+    ):
+        private_cli.compute_column(
+            database=tmp_db,
+            run_id=1,
+            subject="0",
+        )
+
+    tool = tools.get_fastani()
+    private_cli.log_run(
+        fasta=input_genomes_tiny,
+        database=tmp_db,
+        cmdline="pyani-plus guessing ...",
+        status="Testing",
+        name="Testing compute-column",
+        method="fastANI",
+        program=tool.exe_path.stem,
+        version=tool.version,
+        fragsize=1000,
+        # kmersize=...,  <-- missing!
+    )
+    output = capsys.readouterr().out
+    assert output.endswith("Run identifier 2\n")
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: fastANI run-id 2 is missing kmersize parameter",
+    ):
+        private_cli.compute_column(
+            database=tmp_db,
+            run_id=2,
+            subject="0",
+        )
+
+    tool = tools.get_fastani()
+    private_cli.log_run(
+        fasta=input_genomes_tiny,
+        database=tmp_db,
+        cmdline="pyani-plus guessing ...",
+        status="Testing",
+        name="Testing compute-column",
+        method="fastANI",
+        program=tool.exe_path.stem,
+        version=tool.version,
+        fragsize=1000,
+        kmersize=9,
+        # minmatch=..., <-- missing!
+    )
+    output = capsys.readouterr().out
+    assert output.endswith("Run identifier 3\n")
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: fastANI run-id 3 is missing minmatch parameter",
+    ):
+        private_cli.compute_column(
+            database=tmp_db,
+            run_id=3,
+            subject="0",
+        )
+
+
 def test_compute_column_fastani(
     capsys: pytest.CaptureFixture[str],
     tmp_path: str,


### PR DESCRIPTION
Makes for a much simpler error message while writing unit tests and accidentally triggering this.

Adding these checks explicitly was prompted by work on #225 where I accidentally setup a test case missing a parameter causing compute-column to fail with a cryptic message.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
