### PR TITLE
Lazy imports for numpy and pandas in DB ORM code

### DIFF
--- a/pyani_plus/classify.py
+++ b/pyani_plus/classify.py
@@ -22,7 +22,6 @@
 """Code to implement the classify method indetnded to identify cliques within a set of genomes."""
 
 from collections.abc import Callable
-from enum import Enum
 from itertools import combinations
 from pathlib import Path
 from typing import NamedTuple
@@ -33,6 +32,7 @@ import pandas as pd
 from rich.progress import Progress
 
 from pyani_plus import PROGRESS_BAR_COLUMNS
+from pyani_plus.public_cli_args import EnumModeClassify
 
 AGG_FUNCS = {
     "min": min,
@@ -41,14 +41,6 @@ AGG_FUNCS = {
 }
 
 MIN_COVERAGE = 0.50
-
-
-class EnumModeClassify(str, Enum):
-    """Enum for the --mode command line argument passed to classify."""
-
-    identity = "identity"  # default
-    tani = "tANI"
-
 
 MODE = EnumModeClassify.identity  # constant for CLI default
 

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pandas import DataFrame
+    from pandas import DataFrame  # pragma: no cover
 
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 from sqlalchemy import (

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -33,9 +33,11 @@ import sys
 from io import StringIO
 from math import log, nan
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import numpy as np
-import pandas as pd
+if TYPE_CHECKING:
+    from pandas import DataFrame
+
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 from sqlalchemy import (
     ForeignKey,
@@ -397,6 +399,9 @@ class Run(Base):
 
         The caller must commit the updated Run object to the database explicitly!
         """
+        import numpy as np  # lazy import as slow and not generally required
+        import pandas as pd  # lazy import as slow and not generally required
+
         hashes = sorted(association.genome_hash for association in self.fasta_hashes)
         size = len(hashes)
         identity = np.full([size, size], np.nan, float)
@@ -432,7 +437,7 @@ class Run(Base):
         del sim_errors
 
     @property
-    def identities(self) -> pd.DataFrame | None:
+    def identities(self) -> "DataFrame | None":
         """All-vs-all percentage identity matrix for the run from the cached JSON.
 
         If cached, returns an N by N float matrix of percentage identities for the N genomes
@@ -445,10 +450,13 @@ class Run(Base):
         """
         if not self.df_identity:
             return None
+
+        import pandas as pd  # lazy import as slow and not generally required
+
         return pd.read_json(StringIO(self.df_identity), orient="split", dtype=float)
 
     @property
-    def cov_query(self) -> pd.DataFrame | None:
+    def cov_query(self) -> "DataFrame | None":
         """All-vs-all query-coverage matrix for the run from the cached JSON.
 
         If cached, returns an N by N float matrix of percentage identities for the N genomes
@@ -461,10 +469,13 @@ class Run(Base):
         """
         if not self.df_cov_query:
             return None
+
+        import pandas as pd  # lazy import as slow and not generally required
+
         return pd.read_json(StringIO(self.df_cov_query), orient="split", dtype=float)
 
     @property
-    def aln_length(self) -> pd.DataFrame | None:
+    def aln_length(self) -> "DataFrame | None":
         """All-vs-all alignment length matrix for the run from the cached JSON.
 
         If cached, returns an N by N integer matrix of alignment lengths for the N genomes
@@ -477,10 +488,13 @@ class Run(Base):
         """
         if not self.df_aln_length:
             return None
+
+        import pandas as pd  # lazy import as slow and not generally required
+
         return pd.read_json(StringIO(self.df_aln_length), orient="split")
 
     @property
-    def sim_errors(self) -> pd.DataFrame | None:
+    def sim_errors(self) -> "DataFrame | None":
         """All-vs-all similarity errors matrix for the run from the cached JSON.
 
         If cached, returns an N by N integer matrix of similarity errors for the N genomes
@@ -493,10 +507,13 @@ class Run(Base):
         """
         if not self.df_sim_errors:
             return None
+
+        import pandas as pd  # lazy import as slow and not generally required
+
         return pd.read_json(StringIO(self.df_sim_errors), orient="split")
 
     @property
-    def hadamard(self) -> pd.DataFrame | None:
+    def hadamard(self) -> "DataFrame | None":
         """All-vs-all Hadamard matrix (identity times coverage) for the run from the cached JSON.
 
         If cached, returns an N by N Hadamard matrix for the N genomes in the run as a
@@ -511,10 +528,13 @@ class Run(Base):
         # computing it from the cached identity and coverage data-frames?
         if not self.df_hadamard:
             return None
+
+        import pandas as pd  # lazy import as slow and not generally required
+
         return pd.read_json(StringIO(self.df_hadamard), orient="split", dtype=float)
 
     @property
-    def tani(self) -> pd.DataFrame | None:
+    def tani(self) -> "DataFrame | None":
         """All-vs-all tANI matrix (minus natural log of identity times coverage) for the run.
 
         Unlike the Hadamard matrix, this is not currently cached in the DB.
@@ -538,9 +558,7 @@ class Run(Base):
         # propagate any pre-existing NA values via the na_action
         return hadamard.map(lambda x: -log(x) if x else nan, na_action="ignore")
 
-    def relabelled_matrix(
-        self, matrix: pd.DataFrame, label: str = "md5"
-    ) -> pd.DataFrame:
+    def relabelled_matrix(self, matrix: "DataFrame", label: str = "md5") -> "DataFrame":
         """Convert a default MD5 based matrix of this run to another labelling.
 
         Here the matrix argument could be from ``.identities`` or similar, while

--- a/pyani_plus/methods/anim.py
+++ b/pyani_plus/methods/anim.py
@@ -41,18 +41,11 @@ percentage (of whole genome) for each pairwise comparison.
 """
 
 from collections import defaultdict
-from enum import Enum
 from pathlib import Path
 
 import intervaltree  # type: ignore  # noqa: PGH003
 
-
-class EnumModeANIm(str, Enum):
-    """Enum for the --mode command line argument passed to ANIm."""
-
-    mum = "mum"  # default
-    maxmatch = "maxmatch"
-
+from pyani_plus.public_cli_args import EnumModeANIm
 
 MODE = EnumModeANIm.mum  # constant for CLI default
 

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -35,11 +35,10 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from rich.progress import Progress
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
-from pyani_plus import PROGRESS_BAR_COLUMNS, db_orm, tools
+from pyani_plus import db_orm, tools
 from pyani_plus.public_cli_args import (
     OPT_ARG_TYPE_CREATE_DB,
     OPT_ARG_TYPE_TEMP,
@@ -236,6 +235,10 @@ def log_genome(
     print(f"Logging genome to {database}")
     session = db_orm.connect_to_db(database)
 
+    from rich.progress import Progress
+
+    from pyani_plus import PROGRESS_BAR_COLUMNS
+
     file_total = 0
     if fasta:
         with Progress(*PROGRESS_BAR_COLUMNS) as progress:
@@ -296,6 +299,10 @@ def log_run(  # noqa: PLR0913
         extra=extra,
         create=True,
     )
+
+    from rich.progress import Progress
+
+    from pyani_plus import PROGRESS_BAR_COLUMNS
 
     fasta_to_hash = {}
     fasta_names = check_fasta(fasta)

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -40,7 +40,6 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.orm import Session
 
 from pyani_plus import PROGRESS_BAR_COLUMNS, db_orm, tools
-from pyani_plus.methods import anib, anim, dnadiff, fastani, sourmash
 from pyani_plus.public_cli_args import (
     OPT_ARG_TYPE_CREATE_DB,
     OPT_ARG_TYPE_TEMP,
@@ -539,6 +538,8 @@ def compute_fastani(  # noqa: PLR0913
         msg = f"ERROR: fastANI run-id {run.run_id} is missing minmatch parameter"
         sys.exit(msg)
 
+    from pyani_plus.methods import fastani  # lazy import
+
     tmp_output = tmp_dir / f"queries_vs_{subject_hash}.csv"
     tmp_queries = tmp_dir / f"queries_vs_{subject_hash}.txt"
     with tmp_queries.open("w") as handle:
@@ -646,6 +647,8 @@ def compute_anim(  # noqa: C901, PLR0913, PLR0915
         .one()
         .length
     )
+
+    from pyani_plus.methods import anim  # lazy import
 
     # nucmer does not handle spaces in filenames, neither quoted nor
     # escaped as slash-space. Therefore symlink or decompress to <MD5>.fasta:
@@ -800,6 +803,9 @@ def compute_anib(  # noqa: PLR0913
         .one()
         .length
     )
+
+    from pyani_plus.methods import anib  # lazy import
+
     outfmt = "6 " + " ".join(anib.BLAST_COLUMNS)
 
     # makeblastdb does not handle spaces in filenames, neither quoted nor
@@ -954,6 +960,8 @@ def compute_dnadiff(  # noqa: C901, PLR0912, PLR0913, PLR0915
     _check_tool_version(nucmer, run.configuration)
 
     config_id = run.configuration.configuration_id
+
+    from pyani_plus.methods import dnadiff  # lazy import
 
     # nucmer does not handle spaces in filenames, neither quoted nor
     # escaped as slash-space. Therefore symlink or decompress to <MD5>.fasta:
@@ -1160,6 +1168,8 @@ def log_sourmash(
         sys.exit(msg)
 
     _check_tool_version(tools.get_sourmash(), run.configuration)
+
+    from pyani_plus.methods import sourmash  # lazy import
 
     config_id = run.configuration.configuration_id
     filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -26,6 +26,7 @@ the private and public API definitions without needed to import from each other
 (which adds to the start-up time unnecessarily).
 """
 
+from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
@@ -33,9 +34,31 @@ import click
 import typer
 
 from pyani_plus import FASTA_EXTENSIONS
-from pyani_plus.classify import EnumModeClassify
-from pyani_plus.methods.anim import EnumModeANIm
-from pyani_plus.workflows import ToolExecutor
+
+# CLI option Enums
+# ----------------
+
+
+class ToolExecutor(str, Enum):
+    """Enum for the executor command line argument passed to snakemake."""
+
+    local = "local"
+    slurm = "slurm"
+
+
+class EnumModeANIm(str, Enum):
+    """Enum for the --mode command line argument passed to ANIm."""
+
+    mum = "mum"  # default
+    maxmatch = "maxmatch"
+
+
+class EnumModeClassify(str, Enum):
+    """Enum for the --mode command line argument passed to classify."""
+
+    identity = "identity"  # default
+    tani = "tANI"
+
 
 # Reused required command line arguments (which have no default)
 # --------------------------------------------------------------

--- a/pyani_plus/workflows/__init__.py
+++ b/pyani_plus/workflows/__init__.py
@@ -34,13 +34,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 
 from pyani_plus import FASTA_EXTENSIONS, PROGRESS_BAR_COLUMNS, db_orm
-
-
-class ToolExecutor(str, Enum):
-    """Enum for the executor command line argument passed to snakemake."""
-
-    local = "local"
-    slurm = "slurm"
+from pyani_plus.public_cli_args import ToolExecutor
 
 
 class ShowProgress(str, Enum):


### PR DESCRIPTION
Prompted by ``Tests/test_interupt.py`` _sometimes_ failing locally as the private CLI was still importing pandas when the SIGINT was received.

The only complication here is the use of ``pd.DataFrame`` in the type annotation, which is now handled via an ``if TYPE_CHECKING`` condition. Sadly the initial simple version of this didn't work with ``pytest``, and I'm not really happy with the workaround.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
