### PR TITLE
Implement simple delete-run command

### DIFF
--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -280,6 +280,8 @@ def test_partial_run(  # noqa: PLR0915
     assert (
         "INFO: Deleting most recent run\n"
         "INFO: Run 2 contains 4/9=3² fastANI comparisons, status: Running\n"
+        "INFO: Run name: Trial B\n"
+        "WARNING: Deleting a run still being computed will cause it to fail!\n"
     ) in output
 
     assert session.query(db_orm.Run).count() == 0

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -99,6 +99,24 @@ def test_check_fasta(tmp_path: str) -> None:
         public_cli.check_fasta(Path(tmp_path))
 
 
+def test_delete_empty(tmp_path: str) -> None:
+    """Check delete-run with no data."""
+    with pytest.raises(
+        SystemExit, match="ERROR: Database /does/not/exist does not exist"
+    ):
+        public_cli.delete_run(database=Path("/does/not/exist"))
+
+    tmp_db = Path(tmp_path) / "list-runs-empty.sqlite"
+    session = db_orm.connect_to_db(tmp_db)
+    session.close()
+
+    with pytest.raises(SystemExit, match="ERROR: Database contains no runs."):
+        public_cli.delete_run(database=tmp_db)
+
+    with pytest.raises(SystemExit, match="ERROR: Database has no run-id 1."):
+        public_cli.resume(database=tmp_db, run_id=1)
+
+
 def test_list_runs_empty(capsys: pytest.CaptureFixture[str], tmp_path: str) -> None:
     """Check list-runs with no data."""
     with pytest.raises(
@@ -129,14 +147,11 @@ def test_resume_empty(tmp_path: str) -> None:
     with pytest.raises(SystemExit, match="ERROR: Database contains no runs."):
         public_cli.resume(database=tmp_db)
 
-    with pytest.raises(
-        SystemExit,
-        match="ERROR: Database has no run-id 1.",
-    ):
+    with pytest.raises(SystemExit, match="ERROR: Database has no run-id 1."):
         public_cli.resume(database=tmp_db, run_id=1)
 
 
-def test_partial_run(
+def test_partial_run(  # noqa: PLR0915
     capsys: pytest.CaptureFixture[str], tmp_path: str, input_genomes_tiny: Path
 ) -> None:
     """Check list-runs and export-run with mock data including a partial run."""
@@ -179,7 +194,7 @@ def test_partial_run(
         config,
         cmdline="pyani fastani ...",
         fasta_directory=input_genomes_tiny,
-        status="Partial",
+        status="Running",  # simulate a partial run not ended cleanly
         name="Trial B",
         fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 4/9 comparisons
     )
@@ -199,7 +214,7 @@ def test_partial_run(
     assert " 3 analysis runs in " in output, output
     assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
     assert " fastANI │    0 │    0 │    0 │  0=0² │ Empty " in output, output
-    assert " fastANI │    4 │    0 │    5 │  9=3² │ Partial " in output, output
+    assert " fastANI │    4 │    0 │    5 │  9=3² │ Running " in output, output
     assert " fastANI │    4 │    0 │    0 │  4=2² │ Done " in output, output
 
     # Unlike a typical method calculation, we have not triggered
@@ -247,6 +262,32 @@ def test_partial_run(
     ):
         public_cli.resume(database=tmp_db, run_id=1)
 
+    output = capsys.readouterr().out
+
+    # Now delete the runs, and confirm what is left behind...
+    public_cli.delete_run(database=tmp_db, run_id=1)
+    output = capsys.readouterr().out
+    assert "INFO: Run 1 contains 0/0=0² fastANI comparisons, status: Empty\n" in output
+
+    # Forcing as this has data
+    public_cli.delete_run(database=tmp_db, run_id=3, force=True)
+    output = capsys.readouterr().out
+    assert "INFO: Run 3 contains all 4=2² fastANI comparisons, status: Done\n" in output
+
+    # Finally delete run 2, this will assume last one remaining
+    public_cli.delete_run(database=tmp_db, force=True)
+    output = capsys.readouterr().out
+    assert (
+        "INFO: Deleting most recent run\n"
+        "INFO: Run 2 contains 4/9=3² fastANI comparisons, status: Running\n"
+    ) in output
+
+    assert session.query(db_orm.Run).count() == 0
+    assert session.query(db_orm.RunGenomeAssociation).count() == 0
+    assert session.query(db_orm.Configuration).count() == 1
+    assert session.query(db_orm.Genome).count() == 3  # noqa: PLR2004
+    assert session.query(db_orm.Comparison).count() == 4  # noqa: PLR2004
+    session.close()
     tmp_db.unlink()
 
 


### PR DESCRIPTION
This adds the basic functionality discussed on #240, but does not do a cascading delete of orphaned comparisons, genomes and configurations which could be reused if a new run is started with the same configuration and some of the same FASTA files.

```console
❯ pyani-plus delete-run -h

 Usage: pyani-plus delete-run [OPTIONS]

 Delete any single run from the given pyANI-plus SQLite3 database.
 This will prompt the user for confirmation if the run has comparisons, or if
 the run status is "Running", but that can be overridden.
 Currently this will *not* delete any linked comparisons, even if they are not
 currently linked to another run. They will be reused should you start a new
 run using an overlapping set of input FASTA files.

╭─ Options ───────────────────────────────────────────────────────────────────╮
│ *  --database          FILE     Path to pyANI-plus SQLite3 database         │
│                                 [required]                                  │
│    --run-id            INTEGER  Which run from the database (defaults to    │
│                                 latest                                      │
│                                 [default: None]                             │
│    --force     -f               Delete without confirmation                 │
│    --help      -h               Show this message and exit.                 │
╰─────────────────────────────────────────────────────────────────────────────╯
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [ ] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
