### PR TITLE
Interupted workers should update run.status

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -779,7 +779,7 @@ def add_run(  # noqa: PLR0913
 
 
 def load_run(
-    session: Session, run_id: int | None, *, check_complete: bool = False
+    session: Session, run_id: int | None = None, *, check_complete: bool = False
 ) -> Run:
     """Load specified or latest Run from the DB.
 

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -775,6 +775,7 @@ def anim(  # noqa: C901, PLR0912, PLR0913, PLR0915
         # Try to abort gracefully without wasting the work done.
         msg = f"Interrupted, will attempt to log {len(db_entries)} completed comparisons\n"
         sys.stderr.write(msg)
+        run.status = "Worker interrupted"
 
     if db_entries:
         session.execute(
@@ -947,6 +948,7 @@ def anib(  # noqa: C901,PLR0913,PLR0915
         # Try to abort gracefully without wasting the work done.
         msg = f"Interrupted, will attempt to log {len(db_entries)} completed comparisons\n"
         sys.stderr.write(msg)
+        run.status = "Worker interrupted"
 
     if db_entries:
         session.execute(
@@ -1151,6 +1153,7 @@ def dnadiff(  # noqa: C901, PLR0912, PLR0913, PLR0915
         # Try to abort gracefully without wasting the work done.
         msg = f"Interrupted, will attempt to log {len(db_entries)} completed comparisons\n"
         sys.stderr.write(msg)
+        run.status = "Worker interrupted"
 
     if db_entries:
         session.execute(

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -128,6 +128,8 @@ def test_compute_column_sigint_anib(
     assert rc == 0, (
         f"Expecting return 0 on clean interruption, got {rc} with {done} done"
     )
+    run = db_orm.load_run(session)
+    assert run.status == "Worker interrupted"
 
 
 def test_compute_column_sigint_dnadiff(
@@ -190,6 +192,8 @@ def test_compute_column_sigint_dnadiff(
     assert rc == 0, (
         f"Expecting return 0 on clean interruption, got {rc} with {done} done"
     )
+    run = db_orm.load_run(session)
+    assert run.status == "Worker interrupted"
 
 
 def test_compute_column_sigint_anim(
@@ -253,3 +257,5 @@ def test_compute_column_sigint_anim(
     assert rc == 0, (
         f"Expecting return 0 on clean interruption, got {rc} with {done} done"
     )
+    run = db_orm.load_run(session)
+    assert run.status == "Worker interrupted"


### PR DESCRIPTION
We do not (yet) attempt to catch errors on the main thread of the public API, which might also want to update run.status?

Note this only applies to caught keyboard interruptions on ANIm, dnadiff and ANIb initially.

We should probably extend this to catching any failure in the workers, and logging something like ``run.status = "Worker error"`` instead?

See #156.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
