### PR TITLE
Move --label definition to public_cli_args.py

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -49,6 +49,7 @@ from pyani_plus.public_cli_args import (
     OPT_ARG_TYPE_EXECUTOR,
     OPT_ARG_TYPE_FRAGSIZE,
     OPT_ARG_TYPE_KMERSIZE,
+    OPT_ARG_TYPE_LABEL,
     OPT_ARG_TYPE_MINMATCH,
     OPT_ARG_TYPE_RUN_ID,
     OPT_ARG_TYPE_RUN_NAME,
@@ -787,13 +788,7 @@ def export_run(  # noqa: C901
     outdir: REQ_ARG_TYPE_OUTDIR,
     run_id: OPT_ARG_TYPE_RUN_ID = None,
     # Would like to replace this with Literal["md5", "filename", "stem"] once typer updated
-    label: Annotated[
-        str,
-        typer.Option(
-            click_type=click.Choice(["md5", "filename", "stem"]),
-            help="How to label the genomes",
-        ),
-    ] = "stem",
+    label: OPT_ARG_TYPE_LABEL = "stem",
 ) -> int:
     """Export any single run from the given pyANI-plus SQLite3 database.
 
@@ -902,13 +897,7 @@ def plot_run(  # noqa: C901
     outdir: REQ_ARG_TYPE_OUTDIR,
     run_id: OPT_ARG_TYPE_RUN_ID = None,
     # Would like to replace this with Literal["md5", "filename", "stem"] once typer updated
-    label: Annotated[
-        str,
-        typer.Option(
-            click_type=click.Choice(["md5", "filename", "stem"]),
-            help="How to label the genomes",
-        ),
-    ] = "stem",
+    label: OPT_ARG_TYPE_LABEL = "stem",
 ) -> int:
     """Plot heatmaps and distributions for any single run.
 

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -29,6 +29,7 @@ the private and public API definitions without needed to import from each other
 from pathlib import Path
 from typing import Annotated
 
+import click
 import typer
 
 from pyani_plus import FASTA_EXTENSIONS
@@ -152,11 +153,18 @@ OPT_ARG_TYPE_SOURMASH_SCALED = Annotated[
         min=1,
     ),
 ]
-
 OPT_ARG_TYPE_CREATE_DB = Annotated[
     # Listing name(s) explicitly to avoid automatic matching --no-create-db
     bool, typer.Option("--create-db", help="Create database if does not exist")
 ]
 OPT_ARG_TYPE_EXECUTOR = Annotated[
     ToolExecutor, typer.Option(help="How should the internal tools be run?")
+]
+# Would like to replace this with Literal["md5", "filename", "stem"] once typer updated
+OPT_ARG_TYPE_LABEL = Annotated[
+    str,
+    typer.Option(
+        click_type=click.Choice(["md5", "filename", "stem"]),
+        help="How to label the genomes",
+    ),
 ]


### PR DESCRIPTION
We already use the ``--label`` option twice in the CLI so this should be defined centrally.

Spotted by Angelika Kiepas, excerpt from #255 which _should_ apply cleanly if this is merged first (which I suggest we do now rather than waiting till Monday).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [ ] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
