### PR TITLE
Move rug plot below axis, apply transparency

### DIFF
--- a/pyani_plus/plot_run.py
+++ b/pyani_plus/plot_run.py
@@ -221,7 +221,18 @@ def plot_distributions(
         )
         axes[0].set_ylim(ymin=0)
         sns.kdeplot(values, ax=axes[1], warn_singular=False)
-        sns.rugplot(values, ax=axes[1], color=rug)
+
+        # Default rug height=.025 but that can obscure low values.
+        # Negative means below the axis instead, needs clip_on=False
+        # Adding alpha to try to reveal the density.
+        sns.rugplot(
+            values,
+            ax=axes[1],
+            color=rug,
+            height=-0.025,
+            clip_on=False,
+            alpha=0.1,
+        )
 
         # Modify axes after data is plotted
         for _ in axes:


### PR DESCRIPTION
Closes #259.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository

Sample output from 875 Streptomyces from RefSeq using ANIm:

![ANIm_identity_dist](https://github.com/user-attachments/assets/34a2a5bb-2bbc-468e-baf6-f7a6d3f93730)

![ANIm_query_cov_dist](https://github.com/user-attachments/assets/abe19734-3ca0-4468-affe-53815b692ff8)

![ANIm_hadamard_dist](https://github.com/user-attachments/assets/4b9d6ac3-9720-43ad-98c3-d59f5f3058ce)
