### PR TITLE
Lookup all query lengths before compute column (reduce chance of DB locking)

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -384,7 +384,7 @@ def log_comparison(  # noqa: PLR0913
 
 
 @app.command()
-def compute_column(  # noqa: C901
+def compute_column(  # noqa: C901, PLR0912, PLR0915
     database: REQ_ARG_TYPE_DATABASE,
     run_id: REQ_ARG_TYPE_RUN_ID,
     subject: Annotated[
@@ -435,8 +435,10 @@ def compute_column(  # noqa: C901
 
     if subject in hash_to_filename:
         subject_hash = subject
+        column = sorted(hash_to_filename).index(subject_hash)
     elif Path(subject).name in filename_to_hash:
         subject_hash = filename_to_hash[Path(subject).name]
+        column = sorted(hash_to_filename).index(subject_hash)
     else:
         try:
             column = int(subject)
@@ -451,7 +453,6 @@ def compute_column(  # noqa: C901
                 sys.stderr.write("INFO: Treating subject N as 0 (first column)\n")
             column = 0
         subject_hash = sorted(hash_to_filename)[column]
-        del column
 
     # What comparisons are needed? Record the query genome lengths too
     # (doing this once at the start to avoid a small lookup for each query)
@@ -495,6 +496,9 @@ def compute_column(  # noqa: C901
 
     # Either use the specified temp-directory (and do not clean up),
     # or use a system temp-directory (and do clean up)
+    if temp:
+        temp = temp / f"column{column}"  # avoid worries about name clashes
+        temp.mkdir()
     with nullcontext(temp) if temp else tempfile.TemporaryDirectory() as tmp_dir:
         return compute(
             Path(tmp_dir),

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -497,8 +497,8 @@ def compute_column(  # noqa: C901, PLR0912, PLR0915
     # Either use the specified temp-directory (and do not clean up),
     # or use a system temp-directory (and do clean up)
     if temp:
-        temp = temp / f"column{column}"  # avoid worries about name clashes
-        temp.mkdir()
+        temp = temp / f"c{column}"  # avoid worries about name clashes
+        temp.mkdir(exist_ok=True)
     with nullcontext(temp) if temp else tempfile.TemporaryDirectory() as tmp_dir:
         return compute(
             Path(tmp_dir),

--- a/tests/snakemake/test_anim_workflow.py
+++ b/tests/snakemake/test_anim_workflow.py
@@ -145,12 +145,12 @@ def test_rule_ANIm(  # noqa: N802
 
     # Check delta-filter output against target fixtures
     for fname in (input_genomes_tiny / "intermediates/ANIm").glob("*.filter"):
-        generated = tmp_dir / fname.name
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
         assert compare_files_with_skip(fname, generated)
 
     # Check nucmer output against target fixtures
     for fname in (input_genomes_tiny / "intermediates/ANIm").glob("*.delta"):
-        generated = tmp_dir / fname.name
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
         assert compare_files_with_skip(fname, generated)
 
     compare_db_matrices(db, input_genomes_tiny / "matrices")
@@ -216,12 +216,12 @@ def test_rule_ANIm_bad_align(  # noqa: N802
 
     # Check delta-filter output against target fixtures
     for fname in (input_genomes_bad_alignments / "intermediates/ANIm").glob("*.filter"):
-        generated = tmp_dir / fname.name
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
         assert compare_files_with_skip(fname, generated)
 
     # Check nucmer output against target fixtures
     for fname in (input_genomes_bad_alignments / "intermediates/ANIm").glob("*.delta"):
-        generated = tmp_dir / fname.name
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
         assert compare_files_with_skip(fname, generated)
 
     compare_db_matrices(db, input_genomes_bad_alignments / "matrices")

--- a/tests/snakemake/test_dnadiff_workflow.py
+++ b/tests/snakemake/test_dnadiff_workflow.py
@@ -153,19 +153,23 @@ def test_dnadiff(
 
     # Check nucmer output (.delta) against target fixtures
     for fname in (input_genomes_tiny / "intermediates/dnadiff").glob("*.delta"):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated)
 
     # Check nucmer output (.filter) against target fixtures
     for fname in (input_genomes_tiny / "intermediates/dnadiff").glob("*.filter"):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated)
 
     # Check showdiff output (.qdiff) against target fixtures
     for fname in (input_genomes_tiny / "intermediates/dnadiff").glob("*.qdiff"):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name, skip=0)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated, skip=0)
 
     # Check show_coords output (.mcoords) against target fixtures
     for fname in (input_genomes_tiny / "intermediates/dnadiff").glob("*.mcoords"):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name, skip=0)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated, skip=0)
 
     compare_db_matrices(db, input_genomes_tiny / "matrices", absolute_tolerance=5e-5)
 
@@ -232,25 +236,29 @@ def test_dnadiff_bad_align(
     for fname in (input_genomes_bad_alignments / "intermediates/dnadiff").glob(
         "*.delta"
     ):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated)
 
     # Check nucmer output (.filter) against target fixtures
     for fname in (input_genomes_bad_alignments / "intermediates/dnadiff").glob(
         "*.filter"
     ):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated)
 
     # Check showdiff output (.qdiff) against target fixtures
     for fname in (input_genomes_bad_alignments / "intermediates/dnadiff").glob(
         "*.qdiff"
     ):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name, skip=0)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated, skip=0)
 
     # Check show_coords output (.mcoords) against target fixtures
     for fname in (input_genomes_bad_alignments / "intermediates/dnadiff").glob(
         "*.mcoords"
     ):
-        assert compare_files_with_skip(fname, tmp_dir / fname.name, skip=0)
+        generated = next(tmp_dir.glob(f"*/{fname.name}"))
+        assert compare_files_with_skip(fname, generated, skip=0)
 
     compare_db_matrices(
         db, input_genomes_bad_alignments / "matrices", absolute_tolerance=5e-5

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -134,6 +134,7 @@ def test_running_anib(
     run = session.query(db_orm.Run).one()
     assert run.run_id == 1
     hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+    hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
 
     subject_hash = list(hash_to_filename)[1]
     private_cli.compute_anib(
@@ -143,7 +144,7 @@ def test_running_anib(
         input_genomes_tiny,
         hash_to_filename,
         {},  # not used for ANIb
-        query_hashes=list(hash_to_filename),  # order should not matter!
+        query_hashes=hash_to_length,  # order should not matter!
         subject_hash=subject_hash,
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -114,6 +114,7 @@ def test_running_anim(
     run = session.query(db_orm.Run).one()
     assert run.run_id == 1
     hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+    hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
 
     subject_hash = list(hash_to_filename)[1]
     private_cli.compute_anim(
@@ -123,7 +124,7 @@ def test_running_anim(
         input_genomes_tiny,
         hash_to_filename,
         {},  # not used for ANIm
-        query_hashes=list(hash_to_filename),  # order should not matter!
+        query_hashes=hash_to_length,  # order should not matter!
         subject_hash=subject_hash,
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004

--- a/tests/test_dnadiff.py
+++ b/tests/test_dnadiff.py
@@ -119,6 +119,7 @@ def test_running_dnadiff(
     run = session.query(db_orm.Run).one()
     assert run.run_id == 1
     hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+    hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
 
     subject_hash = list(hash_to_filename)[1]
     private_cli.compute_dnadiff(
@@ -128,7 +129,7 @@ def test_running_dnadiff(
         input_genomes_tiny,
         hash_to_filename,
         {},  # not used for dnadiff
-        query_hashes=list(hash_to_filename),  # order should not matter!
+        query_hashes=hash_to_length,  # order should not matter!
         subject_hash=subject_hash,
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004

--- a/tests/test_external_alignment.py
+++ b/tests/test_external_alignment.py
@@ -412,7 +412,7 @@ def test_wrong_method(
         match="ERROR: Run-id 1 expected guessing results",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -445,7 +445,7 @@ def test_bad_program(
         match="ERROR: configuration.program='should-be-blank' unexpected",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -478,7 +478,7 @@ def test_bad_version(
         match="ERROR: configuration.version='should-be-blank' unexpected",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -511,7 +511,7 @@ def test_no_config(
         match="ERROR: Missing configuration.extra setting",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -543,7 +543,7 @@ def test_bad_config(
         match="ERROR: configuration.extra='file=example.fasta;md5=XXX;label=stem' unexpected",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -576,7 +576,7 @@ def test_missing_alignment(
         match="ERROR: Missing alignment file .*/does-not-exist.fasta",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -613,7 +613,7 @@ def test_bad_checksum(
         match="ERROR: MD5 checksum of .*/example.fasta didn't match.",
     ):
         private_cli.compute_external_alignment(
-            tmp_dir, session, run, tmp_dir, {}, {}, [], ""
+            tmp_dir, session, run, tmp_dir, {}, {}, {}, ""
         )
     session.close()
 
@@ -668,11 +668,11 @@ AA
             tmp_dir,
             {},
             {},
-            [
-                "5584c7029328dc48d33f95f0a78f7e57",
-                "689d3fd6881db36b5e08329cf23cecdd",
-                "78975d5144a1cd12e98898d573cf6536",
-            ],
+            {
+                "5584c7029328dc48d33f95f0a78f7e57": 57793,
+                "689d3fd6881db36b5e08329cf23cecdd": 39253,
+                "78975d5144a1cd12e98898d573cf6536": 39594,
+            },
             "689d3fd6881db36b5e08329cf23cecdd",
         )
     session.close()
@@ -720,11 +720,11 @@ AACT
         tmp_dir,
         {},
         {},
-        [
-            "5584c7029328dc48d33f95f0a78f7e57",
-            "689d3fd6881db36b5e08329cf23cecdd",
-            "78975d5144a1cd12e98898d573cf6536",
-        ],
+        {
+            "5584c7029328dc48d33f95f0a78f7e57": 57793,
+            "689d3fd6881db36b5e08329cf23cecdd": 39253,
+            "78975d5144a1cd12e98898d573cf6536": 39594,
+        },
         "5584c7029328dc48d33f95f0a78f7e57",
     )
     with pytest.raises(
@@ -738,11 +738,11 @@ AACT
             tmp_dir,
             {},
             {},
-            [
-                "5584c7029328dc48d33f95f0a78f7e57",
-                "689d3fd6881db36b5e08329cf23cecdd",
-                "78975d5144a1cd12e98898d573cf6536",
-            ],
+            {
+                "5584c7029328dc48d33f95f0a78f7e57": 57793,
+                "689d3fd6881db36b5e08329cf23cecdd": 39253,
+                "78975d5144a1cd12e98898d573cf6536": 39594,
+            },
             "689d3fd6881db36b5e08329cf23cecdd",
         )
     session.close()

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -74,6 +74,7 @@ def test_running_fastani(
     assert run.run_id == 1
     filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
     hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+    hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
 
     private_cli.compute_fastani(
         tmp_dir,
@@ -82,7 +83,7 @@ def test_running_fastani(
         input_genomes_tiny,
         hash_to_filename,
         filename_to_hash,
-        query_hashes=list(hash_to_filename),
+        query_hashes=hash_to_lengths,
         subject_hash=list(hash_to_filename)[1],
     )
     assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004


### PR DESCRIPTION
This is a relatively small change to replace lots of small DB lookups for query length with a single large lookup for all the query genome lengths of interest *before* computing pairwise comparisons in ANIm, ANIb, dnadiff.

This is hopefully going to fix a class of DB locking failures which @kiepczi ran into (with 400 worker nodes), where looking up query length failed and all the computations that worker had done thus far were lost.

If the new bulk query-length lookup were to fail, this at least happens at the start of the job - before any computations have started.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
