### PR TITLE
Separate genome prepare then compute for sourmash sketch

### DIFF
--- a/pyani_plus/methods/external_alignment.py
+++ b/pyani_plus/methods/external_alignment.py
@@ -1,0 +1,152 @@
+# The MIT License
+#
+# Copyright (c) 2025 University of Strathclyde
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Code to extract average nucleotide identity from an external alignment."""
+
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+ASCII_GAP = ord("-")  # 45
+
+
+def computer_external_alignment_column(
+    subject_hash: str,
+    query_hashes: set[str],
+    alignment: Path,
+    mapping: Callable[[str], str],
+    label: str,
+) -> Iterator[tuple[str, str, float, int, int, float, float]]:
+    """Parse a FASTA multiple alignment, and compute pairwise ANI values.
+
+    Returns tuples of (query genome (hash), reference/subject genome (hash),
+    ANI (float), alignment length (int), similarity errors (int), query
+    coverage (float) and suject coverage (float).
+
+    It will return two entries (a,b,...) and (b,a,...) for the off diagonals
+    since this is a symmetric method.
+
+    :param subject_hash: str, the genome MD5 hash to compute against
+    :param query_hashes: Set[str], which query genome MD5 hashes to compare
+    :param alignment: Path, path to the input FASTA alignment file
+    :param mapping: Callable mapping alignment names to genome MD5 hashes
+    :param label: str, description of the mapping for use in error messages
+    """
+    import numpy as np  # lazy import, although might be implicitly loaded already?
+
+    from pyani_plus.utils import fasta_bytes_iterator
+
+    # We could interpret the column number as the MSA ordering, but our internal
+    # API by subject hash - and we can't assume the MSA is in any particular order.
+    # Easiest way to solve this is two linear scans of the file, with a seek(0)
+    with alignment.open("rb") as handle:
+        subject_seq = subject_title = b""  # placeholder values
+        s_non_gaps = subject_seq_gaps = None  # placeholder values
+        # Note loading the file in binary mode, will be working in bytes
+        for query_title, query_seq in fasta_bytes_iterator(handle):
+            query_hash = mapping(query_title.decode().split(None, 1)[0])
+            if not query_hash:
+                msg = f"ERROR: Could not map {query_title.decode().split(None, 1)[0]} as {label}"
+                sys.exit(msg)
+            if query_hash == subject_hash:
+                # for use in rest of the loop - an array of bytes!
+                subject_seq = query_seq
+                s_array = np.array(list(subject_seq), np.ubyte)
+                s_non_gaps = s_array != ASCII_GAP
+                subject_seq_gaps = subject_seq.count(b"-")
+                subject_title = query_title  # for use in logging
+                break
+        else:
+            msg = f"Did not find subject {subject_hash} in {alignment.name}"
+            raise ValueError(msg)
+
+        handle.seek(0)
+        for query_title, query_seq in fasta_bytes_iterator(handle):
+            query_hash = mapping(query_title.decode().split(None, 1)[0])
+            if query_hash < subject_hash or query_hash not in query_hashes:
+                # Exploiting symmetry to avoid double computation,
+                # or not asked to compute this pairing (as already in the DB)
+                continue
+            if query_hash == subject_hash:
+                # 100% identity and coverage, but need to calculate aln_length
+                yield (
+                    query_hash,
+                    subject_hash,
+                    1.0,
+                    len(query_seq) - query_seq.count(b"-"),
+                    0,
+                    1.0,
+                    1.0,
+                )
+            else:
+                # Full calculation required
+                if len(query_seq) != len(subject_seq):
+                    msg = (
+                        "ERROR: Bad external-alignment, different lengths"
+                        f" {len(query_seq)} and {len(subject_seq)}"
+                        f" from {query_title.decode().split(None, 1)[0]}"
+                        f" and {subject_title.decode().split(None, 1)[0]}\n"
+                    )
+                    sys.exit(msg)
+
+                q_array = np.array(list(query_seq), np.ubyte)
+                q_non_gaps = q_array != ASCII_GAP
+                # & is AND
+                # | is OR
+                # ^ is XOR
+                # ~ is NOT
+                # e.g. ~(q_gaps | s_gaps) would be entries with no gaps
+                naive_matches = q_array == s_array  # includes double gaps!
+                matches = int((naive_matches & q_non_gaps).sum())
+                one_gapped = q_non_gaps ^ s_non_gaps
+                non_gap_mismatches = int((~naive_matches & ~one_gapped).sum())
+                either_gapped = int(one_gapped.sum())
+                del naive_matches, q_non_gaps, q_array
+
+                # Now compute the alignment metrics from that
+                query_cov = (matches + non_gap_mismatches) / (
+                    len(query_seq) - query_seq.count(b"-")
+                )
+                subject_cov = (matches + non_gap_mismatches) / (
+                    len(subject_seq) - subject_seq_gaps
+                )
+                aln_length = matches + non_gap_mismatches + either_gapped
+                sim_errors = non_gap_mismatches + either_gapped
+
+                yield (
+                    query_hash,
+                    subject_hash,
+                    matches / aln_length,
+                    aln_length,
+                    sim_errors,
+                    query_cov,
+                    subject_cov,
+                )
+                # And the symmetric entry
+                yield (
+                    subject_hash,
+                    query_hash,
+                    matches / aln_length,
+                    aln_length,
+                    sim_errors,
+                    subject_cov,
+                    query_cov,
+                )

--- a/pyani_plus/methods/external_alignment.py
+++ b/pyani_plus/methods/external_alignment.py
@@ -28,7 +28,7 @@ from pathlib import Path
 ASCII_GAP = ord("-")  # 45
 
 
-def computer_external_alignment_column(
+def compute_external_alignment_column(
     subject_hash: str,
     query_hashes: set[str],
     alignment: Path,

--- a/pyani_plus/methods/sourmash.py
+++ b/pyani_plus/methods/sourmash.py
@@ -40,11 +40,14 @@ def prepare_genomes(run: db_orm.Run, cache: Path) -> Iterator[str]:
     Yields the FASTA hashes as their signatures are completed for use with a progress bar.
     """
     config = run.configuration
+    if config.method != "sourmash":
+        msg = f"ERROR: Expected run to be for sourmash, not method {config.method}"
+        sys.exit(msg)
     if not config.kmersize:
         msg = f"ERROR: sourmash requires a k-mer size, default is {KMER_SIZE}"
         sys.exit(msg)
     if not config.extra:
-        msg = f"ERROR: sourmash requires scaled or num, default is scaled={SCALED}"
+        msg = f"ERROR: sourmash requires extra setting, default is scaled={SCALED}"
         sys.exit(msg)
     tool = tools.get_sourmash()
     if not cache.is_dir():

--- a/pyani_plus/methods/sourmash.py
+++ b/pyani_plus/methods/sourmash.py
@@ -26,8 +26,55 @@ import sys
 from collections.abc import Iterator
 from pathlib import Path
 
+from pyani_plus import db_orm, tools, utils
+
 SCALED = 1000
 KMER_SIZE = 31  # default
+
+
+def prepare_genomes(run: db_orm.Run, cache: Path) -> Iterator[str]:
+    """Build the sourmatch sketch signatures in the given directory.
+
+    Will use a sub-directory ``sourmash_k={kmersize}_scaled={number}``.
+
+    Yields the FASTA hashes as their signatures are completed for use with a progress bar.
+    """
+    config = run.configuration
+    if not config.kmersize:
+        msg = f"ERROR: sourmash requires a k-mer size, default is {KMER_SIZE}"
+        sys.exit(msg)
+    if not config.extra:
+        msg = f"ERROR: sourmash requires scaled or num, default is scaled={SCALED}"
+        sys.exit(msg)
+    tool = tools.get_sourmash()
+    if not cache.is_dir():
+        msg = f"ERROR: Cache directory {cache} does not exist"
+        raise ValueError(msg)
+    cache = cache / f"sourmash_k={config.kmersize}_{config.extra}"
+    cache.mkdir(exist_ok=True)
+    fasta_dir = Path(run.fasta_directory)
+    for entry in run.fasta_hashes:
+        fasta_filename = fasta_dir / entry.fasta_filename
+        # Note using sub-folders for different k-mer size etc
+        sig_filename = cache / f"{entry.genome_hash}.sig"
+        if not sig_filename.is_file():
+            utils.check_output(
+                [
+                    str(tool.exe_path),
+                    "scripts",
+                    "singlesketch",
+                    "-I",
+                    "DNA",
+                    "-p",
+                    f"k={config.kmersize},{config.extra}",
+                    "-n",
+                    entry.genome_hash,
+                    fasta_filename,
+                    "-o",
+                    str(sig_filename),
+                ],
+            )
+        yield entry
 
 
 def parse_sourmash_manysearch_csv(

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -1262,7 +1262,7 @@ def compute_external_alignment(  # noqa: C901, PLR0912, PLR0913, PLR0915
     label = args["label"]
     del args
 
-    from pyani_plus.methods.external_alignment import computer_external_alignment_column
+    from pyani_plus.methods.external_alignment import compute_external_alignment_column
     from pyani_plus.utils import file_md5sum, filename_stem
 
     if not quiet:
@@ -1304,7 +1304,7 @@ def compute_external_alignment(  # noqa: C901, PLR0912, PLR0913, PLR0915
             sim_errors,
             cov_query,
             cov_subject,
-        ) in computer_external_alignment_column(
+        ) in compute_external_alignment_column(
             subject_hash, set(query_hashes), alignment, mapping, label
         ):
             db_entries.append(

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -1414,9 +1414,9 @@ def compute_external_alignment(  # noqa: C901, PLR0912, PLR0913, PLR0915
                     )
     except KeyboardInterrupt:
         # Try to abort gracefully without wasting the work done.
-        msg = f"Interrupted, will attempt to log {len(db_entries)} completed comparisons\n"  # pragma: no cover
-        sys.stderr.write(msg)  # pragma: no cover
-        run.status = "Worker interrupted"  # pragma: no cover
+        msg = f"Interrupted, will attempt to log {len(db_entries)} completed comparisons\n"
+        sys.stderr.write(msg)
+        run.status = "Worker interrupted"
     if db_entries:
         session.execute(
             sqlite_insert(db_orm.Comparison).on_conflict_do_nothing(),

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -192,6 +192,8 @@ OPT_ARG_TYPE_CACHE = Annotated[
             " Default to .cache in the current directory."
         ),
         metavar="DIRECTORY",
+        # Want to distinguish unspecified (None meaning .cache) from explicit .cache
+        show_default=False,
         # Not requiring this exists, not all methods use a cache
         dir_okay=True,
         file_okay=False,

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -184,6 +184,19 @@ OPT_ARG_TYPE_CREATE_DB = Annotated[
 OPT_ARG_TYPE_EXECUTOR = Annotated[
     ToolExecutor, typer.Option(help="How should the internal tools be run?")
 ]
+OPT_ARG_TYPE_CACHE = Annotated[
+    Path | None,
+    typer.Option(
+        help=(
+            "Cache location if required for a method (must be visible to cluster workers)."
+            " Default to .cache in the current directory."
+        ),
+        metavar="DIRECTORY",
+        # Not requiring this exists, not all methods use a cache
+        dir_okay=True,
+        file_okay=False,
+    ),
+]
 # Would like to replace this with Literal["md5", "filename", "stem"] once typer updated
 OPT_ARG_TYPE_LABEL = Annotated[
     str,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 # $ conda install --file requirements.txt
 #
 # where we assume you have the conda-forge and bioconda channels.
-biopython
 intervaltree
 snakemake>=8.24
 snakemake-executor-plugin-slurm

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -39,7 +39,7 @@ def do_comparison(
     capsys: pytest.CaptureFixture[str],
     fasta_dir: Path,
     method: Callable,
-    **kwargs: float,
+    **kwargs: float | Path,
 ) -> db_orm.Run:
     """Execute an ANI method and return the run."""
     with tempfile.NamedTemporaryFile(suffix=".db") as tmp_db:
@@ -168,7 +168,9 @@ def test_coverage(capsys: pytest.CaptureFixture[str], tmp_path: str) -> None:
     )  # 25% and 75% rather than 30% and 70% expected via bp
 
     # Doesn't "work" with default scaling - nulls except for diagonal,
-    run = do_comparison(capsys, seq_dir, public_cli.cli_sourmash, scaled=50)
+    run = do_comparison(
+        capsys, seq_dir, public_cli.cli_sourmash, scaled=50, cache=tmp_dir
+    )
     assert run.df_identity == (
         "{"
         f'"columns":{checksums},"index":{checksums},"data":'

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -37,6 +37,7 @@ import pytest
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 from pyani_plus import db_orm, private_cli, tools
+from pyani_plus.utils import file_md5sum
 
 GENOMES = 100
 
@@ -253,6 +254,87 @@ def test_compute_column_sigint_anim(
     else:
         assert 0 < done < genomes, (
             f"Expected partial ANIb progress, not {done}/{genomes} and return {rc}"
+        )
+    assert rc == 0, (
+        f"Expecting return 0 on clean interruption, got {rc} with {done} done"
+    )
+    run = db_orm.load_run(session)
+    assert run.status == "Worker interrupted"
+
+
+def test_compute_column_sigint_external_alignment(
+    capfd: pytest.CaptureFixture[str],
+    tmp_path: str,
+    input_gzip_bacteria: Path,
+    large_set_of_bacterial_chunks: Path,
+) -> None:
+    """Check compute_column with SIGINT and external-alignment."""
+    tmp_dir = Path(tmp_path)
+    tmp_db = tmp_dir / "sigint.sqlite"
+    assert not tmp_db.is_file()
+
+    # Make a mock alignment - does not have to be the same content as the
+    # mock genomes, can be any equal-length chunks. Making this large to
+    # ensure when this is the only test it does not finish in 2s!
+    tmp_alignment = tmp_dir / "alignment.fasta"
+    with gzip.open(input_gzip_bacteria / "NC_010338.fna.gz", "rt") as handle:
+        title, seq = next(SimpleFastaParser(handle))
+    with tmp_alignment.open("w") as handle:
+        for i in range(GENOMES):
+            offset = i * 100
+            handle.write(f">genome{i}\n{seq[offset : offset + 2000000]}\n")
+    md5 = file_md5sum(tmp_alignment)
+
+    private_cli.log_run(
+        fasta=large_set_of_bacterial_chunks,
+        database=tmp_db,
+        cmdline="pyani-plus external-alignment ...",
+        status="Testing",
+        name="Testing SIGINT",
+        method="external-alignment",
+        mode="",
+        program="",
+        version="",
+        extra=f"md5={md5};label=stem;alignment={tmp_alignment}",
+        create_db=True,
+    )
+    output = capfd.readouterr().out
+    assert output.endswith("Run identifier 1\n")
+
+    with subprocess.Popen(
+        [
+            ".pyani-plus-private-cli",
+            "compute-column",
+            "--quiet",
+            "--database",
+            str(tmp_db),
+            "--run-id",
+            "1",
+            "--subject",
+            # Compute first column (slowest), which would not log until finished
+            # (unless interrupted):
+            "0",
+        ],
+        cwd=tmp_dir,
+    ) as process:
+        # Running the test alone, 1s is more than enough. However, as part of
+        # the full test suite with multiple workers must allow longer...
+        time.sleep(4)
+        process.send_signal(signal.SIGINT)
+        process.wait()
+        rc = process.returncode
+    output = capfd.readouterr().err
+
+    session = db_orm.connect_to_db(tmp_db)
+    done = session.query(db_orm.Comparison).count()
+    genomes = session.query(db_orm.Genome).count()
+    full = genomes * 2 - 1  # does first column & row at once (symmetric matrix)
+
+    if done < full:
+        assert "Interrupted, will attempt to log" in output, output
+    else:
+        assert 0 < done < full, (
+            f"Expected partial external-alignment progress, not {done}/{full} and return {rc}"
         )
     assert rc == 0, (
         f"Expecting return 0 on clean interruption, got {rc} with {done} done"

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -474,6 +474,32 @@ def test_log_wrong_config(
         )
 
 
+def test_validate_cache(tmp_path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check expected error handling in validate_cache."""
+    tmp_dir = Path(tmp_path)
+    monkeypatch.chdir(tmp_dir)
+
+    assert not Path(".cache").is_dir()
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: Specified cache directory /does/not/exist does not exist",
+    ):
+        private_cli.validate_cache(Path("/does/not/exist"))
+
+    default = private_cli.validate_cache(None, create_default=False)
+    assert default == Path(".cache")
+    assert not default.is_dir()
+    with pytest.raises(
+        SystemExit, match="Default cache directory .cache does not exist."
+    ):
+        private_cli.validate_cache(None, create_default=False, require=True)
+
+    default = private_cli.validate_cache(None, create_default=True)
+    assert default == Path(".cache")
+    assert default.is_dir()
+
+
 def test_missing_db(tmp_path: str) -> None:
     """Check expected error when DB does not exist."""
     tmp_db = Path(tmp_path) / "new.sqlite"

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -527,6 +527,31 @@ def test_missing_db(tmp_path: str) -> None:
         )
 
 
+def test_prepare_genomes_bad_args(tmp_path: str, input_genomes_tiny: Path) -> None:
+    """Check error handling in prepare-genomes."""
+    tmp_dir = Path(tmp_path)
+    tmp_db = tmp_dir / "bad.sqlite"
+    assert not tmp_db.is_file()
+
+    private_cli.log_run(
+        fasta=input_genomes_tiny,
+        database=tmp_db,
+        cmdline="pyani-plus sourmash ...",
+        status="Testing",
+        name="Testing compute-column",
+        method="guessing",
+        program="guestimate",
+        version="0.1.2beta3",
+        create_db=True,
+    )
+
+    with pytest.raises(
+        SystemExit,
+        match="ERROR: Unknown method guessing, check tool version?",
+    ):
+        private_cli.prepare_genomes(database=tmp_db, run_id=1, cache=tmp_dir)
+
+
 def test_compute_column_bad_args(
     capsys: pytest.CaptureFixture[str],
     tmp_path: str,

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -474,10 +474,16 @@ def test_log_wrong_config(
         )
 
 
-def test_compute_column_missing_db(tmp_path: str) -> None:
+def test_missing_db(tmp_path: str) -> None:
     """Check expected error when DB does not exist."""
     tmp_db = Path(tmp_path) / "new.sqlite"
     assert not tmp_db.is_file()
+
+    with pytest.raises(SystemExit, match="does not exist"):
+        private_cli.prepare_genomes(
+            database=tmp_db,
+            run_id=1,
+        )
 
     with pytest.raises(SystemExit, match="does not exist"):
         private_cli.compute_column(
@@ -788,3 +794,11 @@ def test_compute_column_fastani(
         "INFO: No fastANI comparisons needed against 5584c7029328dc48d33f95f0a78f7e57\n"
         in output
     )
+
+    # Don't need prepare-genomes with fastANI, but should get this message
+    private_cli.prepare_genomes(
+        database=tmp_db,
+        run_id=1,
+    )
+    output = capsys.readouterr().err
+    assert "No per-genome preparation required for fastANI\n" in output

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -850,6 +850,7 @@ def test_sourmash_gzip(tmp_path: str, input_gzip_bacteria: Path) -> None:
         fasta=input_gzip_bacteria,
         name="Test Run",
         create_db=True,
+        cache=tmp_dir,
     )
     public_cli.export_run(database=tmp_db, outdir=tmp_dir)
     compare_matrix_files(
@@ -874,6 +875,7 @@ def test_sourmash(
         name="Spaces etc",
         scaled=300,
         create_db=True,
+        cache=tmp_dir,
     )
     output = capsys.readouterr().out
     assert "Database already has 0 of 3²=9 sourmash comparisons, 9 needed\n" in output
@@ -885,6 +887,7 @@ def test_sourmash(
         name="Simple names",
         scaled=300,
         create_db=False,
+        cache=tmp_dir,
     )
     output = capsys.readouterr().out
     assert "Database already has all 3²=9 sourmash comparisons\n" in output
@@ -1148,7 +1151,8 @@ def test_resume_partial_sourmash(
     capsys: pytest.CaptureFixture[str], tmp_path: str, input_genomes_tiny: Path
 ) -> None:
     """Check list-runs and export-run with mock data including a partial sourmash run."""
-    tmp_db = Path(tmp_path) / "resume sourmash.sqlite"
+    tmp_dir = Path(tmp_path)
+    tmp_db = tmp_dir / "resume sourmash.sqlite"
     tool = tools.get_sourmash()
     session = db_orm.connect_to_db(tmp_db)
     config = db_orm.db_configuration(
@@ -1196,7 +1200,7 @@ def test_resume_partial_sourmash(
     assert " Method   ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
     assert " sourmash │    4 │    0 │    5 │  9=3² │ Partial " in output, output
 
-    public_cli.resume(database=tmp_db)
+    public_cli.resume(database=tmp_db, cache=tmp_dir)
     output = capsys.readouterr().out
     assert "Resuming run-id 1\n" in output, output
     assert "Database already has 4 of 3²=9 sourmash comparisons, 5 needed" in output, (

--- a/tests/test_self_vs_self.py
+++ b/tests/test_self_vs_self.py
@@ -39,16 +39,17 @@ def do_self_compare(
     capsys: pytest.CaptureFixture[str],
     fasta_dir: Path,
     method: Callable,
+    **kwargs: Path,
 ) -> db_orm.Comparison:
     """Run a self-vs-self ANI method and return the single comparison."""
     assert len(list(fasta_dir.glob("*.f*"))) == 1
     with tempfile.NamedTemporaryFile(suffix=".db") as tmp_db:
-        # Should we accept **kwargs too? e.g. ANIb fragsize
         method(
             database=tmp_db.name,
             fasta=fasta_dir,
             name="Self-vs-self",
             create_db=True,
+            **kwargs,
         )
         output = capsys.readouterr().out
         assert " run setup with 1 genomes in database\n" in output
@@ -87,7 +88,7 @@ def test_self_vs_self_anim(capsys: pytest.CaptureFixture[str], tmp_path: str) ->
     comp = do_self_compare(capsys, seq_dir, public_cli.cli_fastani)
     assert comp.identity == 1.0, comp
 
-    comp = do_self_compare(capsys, seq_dir, public_cli.cli_sourmash)
+    comp = do_self_compare(capsys, seq_dir, public_cli.cli_sourmash, cache=tmp_dir)
     assert comp.identity == 1.0, comp
 
 
@@ -119,5 +120,5 @@ def test_self_vs_self_fastani(
     comp = do_self_compare(capsys, seq_dir, public_cli.cli_fastani)
     assert comp.identity == 0.999953, comp  # noqa: PLR2004
 
-    comp = do_self_compare(capsys, seq_dir, public_cli.cli_sourmash)
+    comp = do_self_compare(capsys, seq_dir, public_cli.cli_sourmash, cache=tmp_dir)
     assert comp.identity == 1.0, comp


### PR DESCRIPTION
Builds on #292 (which should be merged first), adding a ``prepare-genomes`` step prior to the computation of pairwise ANI values (initially only used for sourmash). This then allows much easier switching of the sourmash pairwise computations to operate by column (like the other methods) or with tiling.

Being IO bound, this currently runs locally (single threaded) although could in princple use multiprocessing or even SLURM. It gives the user immediate feedback during the (slow) signature building stage:

```console
$ pyani-plus sourmash --database p.db --create-db --cache . ~/scratch/202310_pectobacterium_pangenome/refseq
Indexing FASTAs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:32 507/507
sourmash run setup with 507 genomes in database
Database already has 0 of 507²=257049 sourmash comparisons, 257049 needed
Processing...   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:07:07 507/507
host: gruffalo.hpc.hutton.ac.uk
Comparing pairs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:15 1/1
Completed sourmash run-id 3 with 507 genomes in database p.db
```

Once the cache is populated, future sourmash runs using the same signatures are then trivially fast. This uses a method _and parameter_ specific subdirectory under the specified ``--cache`` directory:

```console
$ ls -1 'sourmash_k=31_scaled=1000/' | wc -l
507
```

Note this is a new database (not resuing the one above; looks like the disk IO was slower this time doing the MD5 checksums):

```console
$ pyani-plus sourmash --database new.db --create-db --cache . ~/scratch/202310_pectobacterium_pangenome/refseq
Indexing FASTAs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:01:26 507/507
sourmash run setup with 507 genomes in database
Database already has 0 of 507²=257049 sourmash comparisons, 257049 needed
Processing...   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01 507/507
host: gruffalo.hpc.hutton.ac.uk
Comparing pairs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:12 1/1
Completed sourmash run-id 1 with 507 genomes in database new.db
```

Internally this is calling a new private CLI function:

```console
$ .pyani-plus-private-cli prepare-genomes -h

 Usage: .pyani-plus-private-cli prepare-genomes [OPTIONS]

 Prepare any intermediate files needed prior to computing ANI values.
 This requires you already have a run defined in the database, and would be
 followed by running the private CLI ``compute-column`` command. Most methods
 do not need a prepare step, but for example ``sourmash`` does.

╭─ Options ──────────────────────────────────────────────────────────────────╮
│ *  --database          FILE       Path to pyANI-plus SQLite3 database      │
│                                   [required]                               │
│ *  --run-id            INTEGER    Which run to prepare [required]          │
│    --cache             DIRECTORY  Cache location if required for a method  │
│                                   (must be visible to cluster workers).    │
│                                   Default to .cache in the current         │
│                                   directory.                               │
│    --quiet                        Suppress any output except if fails      │
│    --help      -h                 Show this message and exit.              │
╰────────────────────────────────────────────────────────────────────────────╯
```


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
