### PR TITLE
Standard helper function for logging comparisons with retries

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -999,35 +999,38 @@ def insert_comparisons_with_retries(
     try:
         session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
         session.commit()
-    except OperationalError:
+    except OperationalError:  # pragma: no cover
         pass
     else:
         return True
-    msg = f"WARNING: Attempt 1/3 failed to record {source}\n"
-    sys.stdout.write(msg)
+    msg = f"WARNING: Attempt 1/3 failed to record {source}\n"  # pragma: no cover
 
-    sleep(10)
+    sys.stdout.write(msg)  # pragma: no cover
 
-    try:
+    sleep(10)  # pragma: no cover
+
+    try:  # pragma: no cover
         session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
         session.commit()
-    except OperationalError:
+    except OperationalError:  # pragma: no cover
         pass
-    else:
+    else:  # pragma: no cover
         return True
-    msg = f"WARNING: Attempt 2/3 failed to record {source}\n"
-    sys.stdout.write(msg)
+    msg = f"WARNING: Attempt 2/3 failed to record {source}\n"  # pragma: no cover
 
-    sleep(30)
+    sys.stdout.write(msg)  # pragma: no cover
 
-    try:
+    sleep(30)  # pragma: no cover
+
+    try:  # pragma: no cover
         session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
         session.commit()
-    except OperationalError:
+    except OperationalError:  # pragma: no cover
         pass
-    else:
+    else:  # pragma: no cover
         return True
-    msg = f"ERROR: Attempt 3/3 failed to record {source}\n"
-    sys.stdout.write(msg)
+    msg = f"ERROR: Attempt 3/3 failed to record {source}\n"  # pragma: no cover
 
-    return False
+    sys.stdout.write(msg)  # pragma: no cover
+
+    return False  # pragma: no cover

--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -33,6 +33,7 @@ import sys
 from io import StringIO
 from math import log, nan
 from pathlib import Path
+from time import sleep
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -966,3 +967,67 @@ def attempt_insert(
         return values  # pragma: no cover
     else:
         return []  # success!
+
+
+def insert_comparisons_with_retries(
+    session: Session,
+    db_entries: list[dict[str, str | float | int | None]],
+    source: str = "comparisons",
+) -> bool:
+    """Insert given comparisons, ignoring conflicts (duplicates), with retries.
+
+    Although we try to avoid re-computing values already in the database, that can
+    happen (e.g. race conditions, or a performance trade-off with fast methods).
+    To avoid sqlite3.IntegrityError for breaking uniqueness we use the SQLite3
+    supported SQL command "INSERT OR IGNORE" using the dialect's on_conflict_do_nothing
+    method.
+
+    This is intended for use in all our compute methods where we want to record lots
+    of comparison entries after computation - but occasionally the commit fails due to
+    locking (race conditions especially with the SQLite3 database accessed over the
+    network). This therefore makes three attempts with pauses of 10s and 30s.
+
+    Even if there are no rows given, it will still call commit!
+
+    Returns True for success (including rows being empty), False if the commit failed
+    after all attempts are exhausted.
+    """
+    if not db_entries:
+        session.commit()
+        return True
+
+    try:
+        session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
+        session.commit()
+    except OperationalError:
+        pass
+    else:
+        return True
+    msg = f"WARNING: Attempt 1/3 failed to record {source}\n"
+    sys.stdout.write(msg)
+
+    sleep(10)
+
+    try:
+        session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
+        session.commit()
+    except OperationalError:
+        pass
+    else:
+        return True
+    msg = f"WARNING: Attempt 2/3 failed to record {source}\n"
+    sys.stdout.write(msg)
+
+    sleep(30)
+
+    try:
+        session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
+        session.commit()
+    except OperationalError:
+        pass
+    else:
+        return True
+    msg = f"ERROR: Attempt 3/3 failed to record {source}\n"
+    sys.stdout.write(msg)
+
+    return False

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -656,3 +656,12 @@ def test_helper_functions(tmp_path: str, input_genomes_tiny: Path) -> None:
         '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],"data":[[0.99,0.9801,0.9801],[0.9801,0.99,0.9801],[0.9801,0.9801,0.99]]}'
     )
     tmp_db.unlink()
+
+
+def test_insert__no_comps(tmp_path: str) -> None:
+    """Checking a corner case with recording no comparisons."""
+    tmp_db = Path(tmp_path) / "empty.db"
+    session = db_orm.connect_to_db(tmp_db)
+    assert db_orm.insert_comparisons_with_retries(session, [], "test only")
+    session.close()
+    # Is there an easy way to test if this called commit or not?


### PR DESCRIPTION
This aims to close #291 by making three attempts to log comparisons at the end of computing a column - with pauses of 10s and 30s. This will hopefully solve most/all of the jobs failures with SLURM seen recently with ~1000 genomes.

The nature of the change makes an automated test impractical - the 2nd and 3rd attempts therefore have been marked as expecting no test coverage.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
