### PR TITLE
Catch logging to DB failing with InvalidRequestError

### DIFF
--- a/pyani_plus/db_orm.py
+++ b/pyani_plus/db_orm.py
@@ -47,7 +47,7 @@ from sqlalchemy import (
     insert,
 )
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy.exc import NoResultFound, OperationalError
+from sqlalchemy.exc import InvalidRequestError, NoResultFound, OperationalError
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
@@ -1007,7 +1007,7 @@ def insert_comparisons_with_retries(
     try:
         session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
         session.commit()
-    except OperationalError:  # pragma: no cover
+    except (OperationalError, InvalidRequestError):  # pragma: no cover
         pass
     else:
         return True
@@ -1020,7 +1020,7 @@ def insert_comparisons_with_retries(
     try:  # pragma: no cover
         session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
         session.commit()
-    except OperationalError:  # pragma: no cover
+    except (OperationalError, InvalidRequestError):  # pragma: no cover
         pass
     else:  # pragma: no cover
         return True
@@ -1033,7 +1033,7 @@ def insert_comparisons_with_retries(
     try:  # pragma: no cover
         session.execute(sqlite_insert(Comparison).on_conflict_do_nothing(), db_entries)
         session.commit()
-    except OperationalError:  # pragma: no cover
+    except (OperationalError, InvalidRequestError):  # pragma: no cover
         pass
     else:  # pragma: no cover
         return True


### PR DESCRIPTION
Testing ANIb on ArchieWest the retry from #301 was failing with `InvalidRequestError`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
