### PR TITLE
Plot nulls in heatmaps in orange (with placeholder value for clustering)

### DIFF
--- a/pyani_plus/plot_run.py
+++ b/pyani_plus/plot_run.py
@@ -280,7 +280,7 @@ def plot_scatter(
     return len(formats)
 
 
-def plot_single_run(  # noqa: C901
+def plot_single_run(
     run: db_orm.Run,
     outdir: Path,
     label: str,
@@ -303,7 +303,6 @@ def plot_single_run(  # noqa: C901
         ("hadamard", "viridis", 0),
         ("tANI", "viridis_r", -5),  # must follow hadamard!
     ]
-    did_any_heatmaps = False
     with Progress(*PROGRESS_BAR_COLUMNS) as progress:
         task = progress.add_task(
             "Plotting", total=len(scores_and_color_schemes) * 2 + 2
@@ -361,11 +360,7 @@ def plot_single_run(  # noqa: C901
             done += plot_heatmap(
                 matrix, outdir, name, method, color_scheme, formats, na_fill
             )
-            did_any_heatmaps = True
             progress.advance(task)
-    if not did_any_heatmaps:
-        msg = "ERROR: Unable to plot any heatmaps (check for nulls)"
-        sys.exit(msg)
     return done
 
 

--- a/pyani_plus/plot_run.py
+++ b/pyani_plus/plot_run.py
@@ -39,6 +39,7 @@ from pyani_plus import GRAPHICS_FORMATS, PROGRESS_BAR_COLUMNS, db_orm
 
 mpl.use("agg")  # non-interactive backend
 
+ORANGE = (0.934, 0.422, 0)
 GREY = (0.7, 0.7, 0.7)
 DULL_BLUE = (0.137, 0.412, 0.737)
 WHITE = (1.0, 1.0, 1.0)
@@ -77,6 +78,7 @@ def plot_heatmap(  # noqa: PLR0913
     method: str,
     color_scheme: str,
     formats: tuple[str, ...] = GRAPHICS_FORMATS,
+    na_fill: float = 0,
 ) -> int:
     """Plot heatmaps for the given matrix."""
     # Can't use square=True with seaborn clustermap, and when clustering
@@ -109,8 +111,9 @@ def plot_heatmap(  # noqa: PLR0913
             ),
         )
         figure = sns.clustermap(
-            matrix,
-            cmap=color_scheme,
+            matrix.fillna(na_fill),
+            mask=matrix.isna(),
+            cmap=colormaps[color_scheme].with_extremes(bad=ORANGE),
             vmin=0,
             vmax=5 if name == "tANI" else 1,
             figsize=(figsize, figsize),
@@ -295,10 +298,10 @@ def plot_single_run(  # noqa: C901
     """
     method = run.configuration.method
     scores_and_color_schemes = [
-        ("identity", "spbnd_BuRd"),
-        ("query_cov", "BuRd"),
-        ("hadamard", "viridis"),
-        ("tANI", "viridis_r"),  # must follow hadamard!
+        ("identity", "spbnd_BuRd", 0),
+        ("query_cov", "BuRd", 0),
+        ("hadamard", "viridis", 0),
+        ("tANI", "viridis_r", -5),  # must follow hadamard!
     ]
     did_any_heatmaps = False
     with Progress(*PROGRESS_BAR_COLUMNS) as progress:
@@ -311,7 +314,7 @@ def plot_single_run(  # noqa: C901
         progress.advance(task)
         progress.advance(task)
 
-        for name, color_scheme in scores_and_color_schemes:
+        for name, color_scheme, na_fill in scores_and_color_schemes:
             # The matrices are large, so load them one at a time
             if name == "identity":
                 matrix = run.identities
@@ -350,15 +353,15 @@ def plot_single_run(  # noqa: C901
 
             if nulls:
                 msg = (
-                    f"WARNING: Cannot plot {name} as matrix contains {nulls} nulls"
+                    f"WARNING: {name} matrix contains {nulls} nulls"
                     f" (out of {n}²={n**2} {method} comparisons)\n"
                 )
                 sys.stderr.write(msg)
-            else:
-                done += plot_heatmap(
-                    matrix, outdir, name, method, color_scheme, formats
-                )
-                did_any_heatmaps = True
+
+            done += plot_heatmap(
+                matrix, outdir, name, method, color_scheme, formats, na_fill
+            )
+            did_any_heatmaps = True
             progress.advance(task)
     if not did_any_heatmaps:
         msg = "ERROR: Unable to plot any heatmaps (check for nulls)"

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -1554,28 +1554,22 @@ def test_plot_bad_nulls(
 
     plot_out = tmp_dir / "plots"
     plot_out.mkdir()
-
-    with pytest.raises(
-        SystemExit,
-        match=(r"ERROR: Unable to plot any heatmaps \(check for nulls\)"),
-    ):
-        public_cli.plot_run(database=tmp_db, outdir=plot_out)
-
+    public_cli.plot_run(database=tmp_db, outdir=plot_out)
     stderr = capsys.readouterr().err
     assert (
-        "WARNING: Cannot plot identity as matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
+        "WARNING: identity matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
         in stderr
     ), stderr
     assert (
-        "WARNING: Cannot plot query_cov as matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
+        "WARNING: query_cov matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
         in stderr
     ), stderr
     assert (
-        "WARNING: Cannot plot hadamard as matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
+        "WARNING: hadamard matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
         in stderr
     ), stderr
     assert (
-        "WARNING: Cannot plot tANI as matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
+        "WARNING: tANI matrix contains 2 nulls (out of 2²=4 guessing comparisons)\n"
         in stderr
     ), stderr
 


### PR DESCRIPTION
Addresses #272 by plotting NA values (i.e. failed comparisons from divergent genomes which we record as null in the database) in orange (to stand out using a shade which I find contrasting with all our heatmap colour schemes).

To avoid the clustering failing due to the NA values they are replaced - typically with zeroes). The orange is applied via a mask and the colourmap's 'bad' value.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
