### PR TITLE
Set some standard one-letter aliases like -d for --database, -o for --outdir

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -54,7 +54,7 @@ app = typer.Typer(
 
 REQ_ARG_TYPE_RUN_ID = Annotated[
     int,
-    typer.Option(help="Database run ID", show_default=False),
+    typer.Option("--run-id", "-r", help="Database run ID", show_default=False),
 ]
 REQ_ARG_TYPE_CONFIG_ID = Annotated[
     int,

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -66,7 +66,9 @@ class EnumModeClassify(str, Enum):
 REQ_ARG_TYPE_DATABASE = Annotated[
     Path,
     typer.Option(
-        help="Path to pyANI-plus SQLite3 database",
+        "--database",
+        "-d",
+        help="Path to pyANI-plus SQLite3 database.",
         show_default=False,
         dir_okay=False,
         file_okay=True,
@@ -75,7 +77,9 @@ REQ_ARG_TYPE_DATABASE = Annotated[
 REQ_ARG_TYPE_OUTDIR = Annotated[
     Path,
     typer.Option(
-        help="Output directory. If it does not exist, it will be created.",
+        "--outdir",
+        "-o",
+        help="Output directory. Created if does not already exist.",
         show_default=False,
         dir_okay=True,
         file_okay=False,
@@ -84,7 +88,7 @@ REQ_ARG_TYPE_OUTDIR = Annotated[
 REQ_ARG_TYPE_FASTA_DIR = Annotated[
     Path,
     typer.Argument(
-        help=f"Directory of FASTA files (extensions {', '.join(sorted(FASTA_EXTENSIONS))})",
+        help=f"Directory of FASTA files (extensions {', '.join(sorted(FASTA_EXTENSIONS))}).",
         show_default=False,
     ),
 ]
@@ -95,7 +99,12 @@ REQ_ARG_TYPE_FASTA_DIR = Annotated[
 
 OPT_ARG_TYPE_RUN_ID = Annotated[
     int | None,
-    typer.Option(help="Which run from the database (defaults to latest)"),
+    typer.Option(
+        "--run-id",
+        "-r",
+        help="Which run from the database (defaults to latest).",
+        show_default=False,
+    ),
 ]
 OPT_ARG_TYPE_RUN_NAME = Annotated[
     # Using None to mean the dynamic default value here:
@@ -137,7 +146,7 @@ OPT_ARG_TYPE_TEMP = Annotated[
 OPT_ARG_TYPE_FRAGSIZE = Annotated[
     int,
     typer.Option(
-        help="Comparison method fragment size",
+        help="Comparison method fragment size.",
         rich_help_panel="Method parameters",
         min=1,
     ),
@@ -147,7 +156,7 @@ OPT_ARG_TYPE_FRAGSIZE = Annotated[
 OPT_ARG_TYPE_KMERSIZE = Annotated[
     int,
     typer.Option(
-        help="Comparison method k-mer size",
+        help="Comparison method k-mer size.",
         rich_help_panel="Method parameters",
         min=1,
     ),
@@ -155,7 +164,7 @@ OPT_ARG_TYPE_KMERSIZE = Annotated[
 OPT_ARG_TYPE_MINMATCH = Annotated[
     float,
     typer.Option(
-        help="Comparison method min-match",
+        help="Comparison method min-match.",
         rich_help_panel="Method parameters",
         min=0.0,
         max=1.0,
@@ -164,21 +173,21 @@ OPT_ARG_TYPE_MINMATCH = Annotated[
 OPT_ARG_TYPE_ANIM_MODE = Annotated[
     EnumModeANIm,
     typer.Option(
-        help="Nucmer mode for ANIm",
+        help="Nucmer mode for ANIm.",
         rich_help_panel="Method parameters",
     ),
 ]
 OPT_ARG_TYPE_SOURMASH_SCALED = Annotated[
     int,
     typer.Option(
-        help="Sets the compression ratio",
+        help="Sets the compression scaling ratio.",
         rich_help_panel="Method parameters",
         min=1,
     ),
 ]
 OPT_ARG_TYPE_CREATE_DB = Annotated[
     # Listing name(s) explicitly to avoid automatic matching --no-create-db
-    bool, typer.Option("--create-db", help="Create database if does not exist")
+    bool, typer.Option("--create-db", help="Create database if does not exist.")
 ]
 OPT_ARG_TYPE_EXECUTOR = Annotated[
     ToolExecutor, typer.Option(help="How should the internal tools be run?")
@@ -188,7 +197,7 @@ OPT_ARG_TYPE_CACHE = Annotated[
     typer.Option(
         help=(
             "Cache location if required for a method (must be visible to cluster workers)."
-            " Default to .cache in the current directory."
+            " Defaults to .cache in the current directory."
         ),
         metavar="DIRECTORY",
         # Want to distinguish unspecified (None meaning .cache) from explicit .cache
@@ -203,7 +212,7 @@ OPT_ARG_TYPE_LABEL = Annotated[
     str,
     typer.Option(
         click_type=click.Choice(["md5", "filename", "stem"]),
-        help="How to label the genomes",
+        help="How to label the genomes.",
     ),
 ]
 OPT_ARG_TYPE_COV_MIN = Annotated[
@@ -218,7 +227,7 @@ OPT_ARG_TYPE_COV_MIN = Annotated[
 OPT_ARG_TYPE_CLASSIFY_MODE = Annotated[
     EnumModeClassify,
     typer.Option(
-        help="Classify mode intended to identify cliques within a set of genomes",
+        help="Classify mode intended to identify cliques within a set of genomes.",
         rich_help_panel="Method parameters",
     ),
 ]


### PR DESCRIPTION
We discussed this idea briefly this morning. Example changed help output:

```console
❯ pyani-plus delete-run -h

 Usage: pyani-plus delete-run [OPTIONS]

 Delete any single run from the given pyANI-plus SQLite3 database.
 This will prompt the user for confirmation if the run has comparisons, or if
 the run status is "Running", but that can be overridden.
 Currently this will *not* delete any linked comparisons, even if they are not
 currently linked to another run. They will be reused should you start a new
 run using an overlapping set of input FASTA files.

╭─ Options ────────────────────────────────────────────────────────────────────╮
│ *  --database  -d      FILE     Path to pyANI-plus SQLite3 database.         │
│                                 [required]                                   │
│    --run-id    -r      INTEGER  Which run from the database (defaults to     │
│                                 latest).                                     │
│    --force     -f               Delete without confirmation                  │
│    --help      -h               Show this message and exit.                  │
╰──────────────────────────────────────────────────────────────────────────────╯

❯ pyani-plus plot-run -h

 Usage: pyani-plus plot-run [OPTIONS]

 Plot heatmaps and distributions for any single run.
 The output directory must already exist. The heatmap files will be named
 <method>_<property>.<extension> and any pre-existing files will be
 overwritten.

╭─ Options ────────────────────────────────────────────────────────────────────╮
│ *  --database  -d      FILE                 Path to pyANI-plus SQLite3       │
│                                             database.                        │
│                                             [required]                       │
│ *  --outdir    -o      DIRECTORY            Output directory. Created if     │
│                                             does not already exist.          │
│                                             [required]                       │
│    --run-id    -r      INTEGER              Which run from the database      │
│                                             (defaults to latest).            │
│    --label             [md5|filename|stem]  How to label the genomes.        │
│                                             [default: stem]                  │
│    --help      -h                           Show this message and exit.      │
╰──────────────────────────────────────────────────────────────────────────────╯
```

See https://typer.tiangolo.com/tutorial/options/name/#cli-option-short-name-and-default for the how-and-why (this does require listing the desired long name then the short alias both explicitly).

It is tempting to add `-n` for `--name`, `-l` for `--label`, and `-c` for column(s), but might be premature depending what else we might add/change particularly on the analysis side.

Also adds some missing trailing full stops, and tweaks a few helps strings.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [x] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
