### PR TITLE
Fix uncropped rug values in distribution plots

### DIFF
--- a/pyani_plus/plot_run.py
+++ b/pyani_plus/plot_run.py
@@ -160,6 +160,20 @@ def plot_distribution(
     axes[0].set_ylim(ymin=0)
     sns.kdeplot(values, ax=axes[1], warn_singular=False)
 
+    # In a possible bug, the rug-plot ignores the x-limits,
+    # so mask the data here
+    for _ in axes:
+        if name in ["hadamard", "coverage"]:
+            _.set_xlim(0, 1.01)
+            values = [v for v in values if v is not None and 0 <= v <= 1.01]  # noqa: PLR2004
+        if name in ["tANI"]:
+            _.set_xlim(0, 5.01)
+            values = [v for v in values if v is not None and 0 <= v <= 5.01]  # noqa: PLR2004
+        elif name == "identity":
+            # 80% default matches the heatmap grey/blue default
+            _.set_xlim(0.80, 1.01)
+            values = [v for v in values if v is not None and 0.80 <= v <= 1.01]  # noqa: PLR2004
+
     # Default rug height=.025 but that can obscure low values.
     # Negative means below the axis instead, needs clip_on=False
     # Adding alpha to try to reveal the density.
@@ -171,16 +185,6 @@ def plot_distribution(
         clip_on=False,
         alpha=0.1,
     )
-
-    # Modify axes after data is plotted
-    for _ in axes:
-        if name in ["hadamard", "coverage"]:
-            _.set_xlim(0, 1.01)
-        if name in ["tANI"]:
-            _.set_xlim(0, 5.01)
-        elif name == "identity":
-            # 80% default matches the heatmap grey/blue default
-            _.set_xlim(0.80, 1.01)
 
     # Tidy figure
     figure.tight_layout(rect=[0, 0.03, 1, 0.95])


### PR DESCRIPTION
Fix rug plot glitch in issue #325 by masking the data (appears to be due to a seaborn bug)?

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
