### PR TITLE
Define --version and -v on the basic public and private commands

### DIFF
--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -47,6 +47,7 @@ from pyani_plus.public_cli_args import (
     OPT_ARG_TYPE_DEBUG,
     OPT_ARG_TYPE_LOG,
     OPT_ARG_TYPE_TEMP,
+    OPT_ARG_TYPE_VERSION,
     REQ_ARG_TYPE_DATABASE,
     REQ_ARG_TYPE_FASTA_DIR,
 )
@@ -54,8 +55,19 @@ from pyani_plus.public_cli_args import (
 ASCII_GAP = ord("-")  # 45
 
 app = typer.Typer(
+    no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+
+
+@app.callback()
+def common(
+    ctx: typer.Context,
+    *,
+    version: OPT_ARG_TYPE_VERSION = False,
+) -> None:
+    """Typer callback adding version to the base command."""
+
 
 REQ_ARG_TYPE_RUN_ID = Annotated[
     int,

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -74,6 +74,7 @@ from pyani_plus.public_cli_args import (
     OPT_ARG_TYPE_SOURMASH_SCALED,
     OPT_ARG_TYPE_TEMP,
     OPT_ARG_TYPE_TEMP_WORKFLOW,
+    OPT_ARG_TYPE_VERSION,
     REQ_ARG_TYPE_DATABASE,
     REQ_ARG_TYPE_FASTA_DIR,
     REQ_ARG_TYPE_OUTDIR,
@@ -93,8 +94,18 @@ from pyani_plus.workflows import (
 )
 
 app = typer.Typer(
+    no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
 )
+
+
+@app.callback()
+def common(
+    ctx: typer.Context,
+    *,
+    version: OPT_ARG_TYPE_VERSION = False,
+) -> None:
+    """Typer callback adding version to the base command."""
 
 
 def start_and_run_method(  # noqa: PLR0913

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -26,6 +26,7 @@ the private and public API definitions without needed to import from each other
 (which adds to the start-up time unnecessarily).
 """
 
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Annotated
@@ -33,7 +34,7 @@ from typing import Annotated
 import click
 import typer
 
-from pyani_plus import FASTA_EXTENSIONS
+from pyani_plus import FASTA_EXTENSIONS, __version__
 
 # CLI option Enums
 # ----------------
@@ -96,6 +97,26 @@ REQ_ARG_TYPE_FASTA_DIR = Annotated[
 # Reused optional command line arguments (defined with a default)
 # ---------------------------------------------------------------
 # These are named OPT_ARG_TYPE_* short for optional-argument type
+
+
+def version_callback(*, version: bool = False) -> None:
+    """Typer callback to print the version (and quit) if requested."""
+    if version:  # pragma: no cover
+        print(f"pyANI-plus {__version__}")  # noqa: T201
+        sys.exit(0)  # typer.Exit() does not quit immediately
+
+
+OPT_ARG_TYPE_VERSION = Annotated[
+    bool,
+    typer.Option(
+        "--version",
+        "-v",
+        help="Show tool version (on stdout) and quit.",
+        show_default=False,
+        is_eager=True,
+        callback=version_callback,
+    ),
+]
 OPT_ARG_TYPE_LOG = Annotated[
     Path,
     typer.Option(


### PR DESCRIPTION
This also makes the basic commands show the help when run without any arguments.

See also https://github.com/fastapi/typer/discussions/1195 for how we might add this to the individual subcommands, but in practice we would want `pyani-plus sourmash -v` for example to report not just the version of pyANI-plus, but also the version of sourmash found (and so on).

This does _not_ add any new tests as I can't see how to invoke the Typer app directly without perhaps monkey patching ``sys.argv``.

```console
❯ pyani-plus

 Usage: pyani-plus [OPTIONS] COMMAND [ARGS]...

 Typer callback adding version to the base command.

╭─ Options ──────────────────────────────────────────────────────────────────╮
│ --version             -v        Show tool version (on stdout) and quit.    │
│ --install-completion            Install completion for the current shell.  │
│ --show-completion               Show completion for the current shell, to  │
│                                 copy it or customize the installation.     │
│ --help                -h        Show this message and exit.                │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────╮
│ resume               Resume any (partial) run already logged in the        │
│                      database.                                             │
│ list-runs            List the runs defined in a given pyANI-plus SQLite3   │
│                      database.                                             │
│ delete-run           Delete any single run from the given pyANI-plus       │
│                      SQLite3 database.                                     │
│ export-run           Export any single run from the given pyANI-plus       │
│                      SQLite3 database.                                     │
│ plot-run             Plot heatmaps and distributions for any single run.   │
│ plot-run-comp        Plot comparisons between multiple runs.               │
│ classify             Classify genomes into clusters based on ANI results.  │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ ANI methods ──────────────────────────────────────────────────────────────╮
│ anim                 Execute ANIm calculations, logged to a pyANI-plus     │
│                      SQLite3 database.                                     │
│ dnadiff              Execute mumer-based dnadiff calculations, logged to a │
│                      pyANI-plus SQLite3 database.                          │
│ anib                 Execute ANIb calculations, logged to a pyANI-plus     │
│                      SQLite3 database.                                     │
│ fastani              Execute fastANI calculations, logged to a pyANI-plus  │
│                      SQLite3 database.                                     │
│ sourmash             Execute sourmash-plugin-branchwater ANI calculations, │
│                      logged to a pyANI-plus SQLite3 database.              │
│ external-alignment   Compute pairwise ANI from given                       │
│                      multiple-sequence-alignment (MSA) file.               │
╰────────────────────────────────────────────────────────────────────────────╯

❯ pyani-plus -v
pyANI-plus 0.0.1
❯ .pyani-plus-private-cli -v
pyANI-plus 0.0.1
```

Note only some of the private CLI subcommands support version, but the top level is the main way we expect this to be used.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
