### PR TITLE
Explicitly tell snakemake to use all cores for local executor

### DIFF
--- a/pyani_plus/workflows/__init__.py
+++ b/pyani_plus/workflows/__init__.py
@@ -155,6 +155,7 @@ def run_snakemake_with_progress_bar(  # noqa: PLR0913
             *(["rules"] if display == ShowProgress.quiet else []),
             "--executor",
             executor.value,
+            *(["--cores", "all"] if executor.value == "local" else []),
             "--directory",
             str(working_directory),
             "--snakefile",


### PR DESCRIPTION
Solves failure moving from snakemake 9.1.16 to 9.2.0:

`ERROR    snakemake.logging:exceptions.py:181 Error: cores have to be specified for local execution (use --cores N with N being a number >= 1 or 'all')`

Please include a summary of the changes in your pull request.

Closes #336 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update
