### PR TITLE
PyPI, Conda, Zenodo DOI & black style badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 [![codecov](https://codecov.io/gh/pyani-plus/pyani-plus/graph/badge.svg?token=NSSTP6CIW0)](https://codecov.io/gh/pyani-plus/pyani-plus)
 
 [![PyPI](https://img.shields.io/pypi/v/pyani_plus.svg?label=PyPI)](https://pypi.org/project/pyani-plus/)
+[![BioConda](https://img.shields.io/conda/vn/bioconda/pyani-plus.svg?label=Bioconda)](https://anaconda.org/bioconda/pyani-plus)
 [![Zenodo DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15005805.svg)](https://doi.org/10.5281/zenodo.15005805)
-[![Zenodo DOI](https://img.shields.io/badge/Code%20style-black-000000.svg)](https://github.com/python/black)
+[![Code Style](https://img.shields.io/badge/Code%20style-black-000000.svg)](https://github.com/python/black)
 
 ## Citing `pyANI-plus`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/pyani-plus/pyani-plus/badge)](https://www.codefactor.io/repository/github/pyani-plus/pyani-plus)
 [![codecov](https://codecov.io/gh/pyani-plus/pyani-plus/graph/badge.svg?token=NSSTP6CIW0)](https://codecov.io/gh/pyani-plus/pyani-plus)
 
+[![Zenodo DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15005805.svg)](https://doi.org/10.5281/zenodo.15005805)
+[![Zenodo DOI](https://img.shields.io/badge/Code%20style-black-000000.svg)](https://github.com/python/black)
+
 ## Citing `pyANI-plus`
 
 A complete guide to citing `pyani` is included in the file [`CITATIONS`](CITATIONS). Please cite the following manuscript in your work, if you have found `pyani` useful:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/pyani-plus/pyani-plus/badge)](https://www.codefactor.io/repository/github/pyani-plus/pyani-plus)
 [![codecov](https://codecov.io/gh/pyani-plus/pyani-plus/graph/badge.svg?token=NSSTP6CIW0)](https://codecov.io/gh/pyani-plus/pyani-plus)
 
+[![PyPI](https://img.shields.io/pypi/v/pyani_plus.svg?label=PyPI)](https://pypi.org/project/pyani-plus/)
 [![Zenodo DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15005805.svg)](https://doi.org/10.5281/zenodo.15005805)
 [![Zenodo DOI](https://img.shields.io/badge/Code%20style-black-000000.svg)](https://github.com/python/black)
 


### PR DESCRIPTION
Add PyPI, Conda (these will also be blue once hit v1.0.0), Zenodo DOI (latest version) & black style badges.

cf. https://github.com/peterjc/thapbi-pict/blob/master/README.rst