### PR TITLE
Avoid duplicating LICENSE file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,40 +43,16 @@ Please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file for more information
 
 ## Licensing
 
-Unless otherwise indicated, the material in this project is made available under the MIT License.
+Unless otherwise indicated, the material in this project is made available under the MIT License,
+and copyright The University of Strathclyde 2024 to present. See the LICENSE file.
 
-```text
-    (c) The University of Strathclyde 2024-present
-    Contact: leighton.pritchard@strath.ac.uk
-
-    Address:
-    Dr Leighton Pritchard,
-    Strathclyde Institute of Pharmacy and Biomedical Sciences
-    161 Cathedral Street
-    Glasgow
-    G4 0RE,
-    Scotland,
-    UK
-
-The MIT License
-
-Copyright (c) 2024-present University of Strathclyde
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-```
+> Contact: leighton.pritchard@strath.ac.uk
+>
+> Address:
+>    Dr Leighton Pritchard,
+>    Strathclyde Institute of Pharmacy and Biomedical Sciences
+>    161 Cathedral Street
+>    Glasgow
+>    G4 0RE,
+>    Scotland,
+>    UK


### PR DESCRIPTION
This should avoid getting the dates or names out of sync, eg c78da9e3e7b4283fa06ceceecf96d5300628b8c8 (already fixed on main).