### PR TITLE
Include .fa in the accepted FASTA extensions

### DIFF
--- a/pyani_plus/__init__.py
+++ b/pyani_plus/__init__.py
@@ -44,7 +44,7 @@ __version__ = "0.0.1"
 
 # The following are assorted centrally defined constants:
 LOG_FILE = Path("pyani-plus.log")
-FASTA_EXTENSIONS = {".fasta", ".fas", ".fna"}  # we'll consider .fasta.gz etc too
+FASTA_EXTENSIONS = {".fasta", ".fas", ".fna", ".fa"}  # we'll consider .fasta.gz etc too
 GRAPHICS_FORMATS = ("tsv", "png", "jpg", "svgz", "pdf")  # note no dots!
 PROGRESS_BAR_COLUMNS = [
     TextColumn("[progress.description]{task.description}"),

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -62,7 +62,7 @@ def evil_example(
     """Make a version of the viral directory of FASTA files using spaces, emoji, etc."""
     space_dir = tmp_path_factory.mktemp("with spaces " + input_genomes_tiny.stem)
     for fasta in input_genomes_tiny.glob("*.f*"):
-        space_fasta = space_dir / ("🦠 : " + fasta.name.replace("-", " "))
+        space_fasta = space_dir / ("🦠 : " + fasta.stem.replace("-", " ") + ".fa")
         space_fasta.symlink_to(fasta)
     return space_dir
 
@@ -120,9 +120,9 @@ def test_check_start_and_run(tmp_path: str) -> None:
     """Check error conditions."""
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "x.db"
-    (tmp_dir / "broken.fasta").symlink_to("/does/not/exist/example.fna")
+    (tmp_dir / "broken.fa").symlink_to("/does/not/exist/example.fna")
     logger = setup_logger(Path("-"))
-    with pytest.raises(SystemExit, match="Input /.*/broken.fasta is a broken symlink"):
+    with pytest.raises(SystemExit, match="Input /.*/broken.fa is a broken symlink"):
         public_cli.start_and_run_method(
             logger,
             ToolExecutor.local,


### PR DESCRIPTION
This matches legacy pyANI (which also allowed `.fsa_nt`) and closes https://github.com/pyani-plus/pyani-plus-docs/issues/6


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [x] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest-plus -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
