### PR TITLE
Run Python 3.13 on GitHub Actions

### DIFF
--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.13"]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.13"]
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We can't yet setup Python 3.14 (already at release candidate status), but it makes sense to test on the oldest and latest releases.