### PR TITLE
Db context management

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: pyupgrade
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.20
+  rev: v0.15.21
   hooks:
     # Run the formatter.
     - id: ruff-format
@@ -61,7 +61,7 @@ repos:
     - id: codespell
       files: \.(py|smk|md)$
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v2.1.0
+  rev: v2.3.0
   hooks:
     - id: mypy
       # equivalent to "files" in .mypy.ini

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -248,23 +248,22 @@ def log_configuration(  # noqa: PLR0913
 
     msg = f"Logging configuration to '{database}'"
     logger.info(msg)
-    session = db_orm.connect_to_db(logger, database)
-    config = db_orm.db_configuration(
-        session=session,
-        method=method,
-        program=program,
-        version=version,
-        fragsize=fragsize,
-        mode=mode,
-        kmersize=kmersize,
-        minmatch=minmatch,
-        extra=extra,
-        create=True,
-    )
-    session.commit()  # should be redundant
-    msg = f"Configuration identifier {config.configuration_id}"
-    logger.info(msg)
-    session.close()
+    with db_orm.connect_to_db(logger, database) as session:
+        config = db_orm.db_configuration(
+            session=session,
+            method=method,
+            program=program,
+            version=version,
+            fragsize=fragsize,
+            mode=mode,
+            kmersize=kmersize,
+            minmatch=minmatch,
+            extra=extra,
+            create=True,
+        )
+        session.commit()  # should be redundant
+        msg = f"Configuration identifier {config.configuration_id}"
+        logger.info(msg)
 
     return 0
 
@@ -287,22 +286,21 @@ def log_genome(
 
     msg = f"Logging genome to '{database}'"
     logger.info(msg)
-    session = db_orm.connect_to_db(logger, database)
+    with db_orm.connect_to_db(logger, database) as session:
+        from rich.progress import Progress  # noqa: PLC0415
 
-    from rich.progress import Progress  # noqa: PLC0415
+        from pyani_plus import PROGRESS_BAR_COLUMNS  # noqa: PLC0415
+        from pyani_plus.utils import file_md5sum  # noqa: PLC0415
 
-    from pyani_plus import PROGRESS_BAR_COLUMNS  # noqa: PLC0415
-    from pyani_plus.utils import file_md5sum  # noqa: PLC0415
+        file_total = 0
+        if fasta:
+            with Progress(*PROGRESS_BAR_COLUMNS) as progress:
+                for filename in progress.track(fasta, description="Processing..."):
+                    file_total += 1
+                    md5 = file_md5sum(filename)
+                    db_orm.db_genome(logger, session, filename, md5, create=True)
+        session.commit()
 
-    file_total = 0
-    if fasta:
-        with Progress(*PROGRESS_BAR_COLUMNS) as progress:
-            for filename in progress.track(fasta, description="Processing..."):
-                file_total += 1
-                md5 = file_md5sum(filename)
-                db_orm.db_genome(logger, session, filename, md5, create=True)
-    session.commit()
-    session.close()
     msg = f"Processed {file_total} FASTA files"
     logger.info(msg)
     return 0
@@ -341,54 +339,55 @@ def log_run(  # noqa: PLR0913
 
     msg = f"Logging run to '{database}'"
     logger.info(msg)
-    session = db_orm.connect_to_db(logger, database)
+    with db_orm.connect_to_db(logger, database) as session:
+        # Reuse existing config, or log a new one
+        config = db_orm.db_configuration(
+            session=session,
+            method=method,
+            program=program,
+            version=version,
+            fragsize=fragsize,
+            mode=mode,
+            kmersize=kmersize,
+            minmatch=minmatch,
+            extra=extra,
+            create=True,
+        )
 
-    # Reuse existing config, or log a new one
-    config = db_orm.db_configuration(
-        session=session,
-        method=method,
-        program=program,
-        version=version,
-        fragsize=fragsize,
-        mode=mode,
-        kmersize=kmersize,
-        minmatch=minmatch,
-        extra=extra,
-        create=True,
-    )
+        from rich.progress import Progress  # noqa: PLC0415
 
-    from rich.progress import Progress  # noqa: PLC0415
+        from pyani_plus import PROGRESS_BAR_COLUMNS  # noqa: PLC0415
+        from pyani_plus.utils import check_fasta, file_md5sum  # noqa: PLC0415
 
-    from pyani_plus import PROGRESS_BAR_COLUMNS  # noqa: PLC0415
-    from pyani_plus.utils import check_fasta, file_md5sum  # noqa: PLC0415
+        fasta_to_hash = {}
+        fasta_names = check_fasta(logger, fasta)
+        if fasta_names:
+            # Reuse existing genome entries and/or log new ones
+            with Progress(*PROGRESS_BAR_COLUMNS) as progress:
+                for filename in progress.track(
+                    fasta_names, description="Processing..."
+                ):
+                    md5 = file_md5sum(filename)
+                    fasta_to_hash[filename] = md5
+                    db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    fasta_to_hash = {}
-    fasta_names = check_fasta(logger, fasta)
-    if fasta_names:
-        # Reuse existing genome entries and/or log new ones
-        with Progress(*PROGRESS_BAR_COLUMNS) as progress:
-            for filename in progress.track(fasta_names, description="Processing..."):
-                md5 = file_md5sum(filename)
-                fasta_to_hash[filename] = md5
-                db_orm.db_genome(logger, session, filename, md5, create=True)
+        run = db_orm.add_run(
+            session,
+            config,
+            cmdline,
+            fasta,
+            status,
+            name,
+            date=None,
+            fasta_to_hash=fasta_to_hash,
+        )
+        # No point caching empty matrices, even partial ones is debatable
+        if run.comparisons().count() == len(fasta_to_hash) ** 2:
+            run.cache_comparisons()
+        run_id = run.run_id
 
-    run = db_orm.add_run(
-        session,
-        config,
-        cmdline,
-        fasta,
-        status,
-        name,
-        date=None,
-        fasta_to_hash=fasta_to_hash,
-    )
-    # No point caching empty matrices, even partial ones is debatable
-    if run.comparisons().count() == len(fasta_to_hash) ** 2:
-        run.cache_comparisons()
-    run_id = run.run_id
+        session.commit()
 
-    session.commit()
-    session.close()
     msg = f"Run identifier {run_id}"
     logger.info(msg)
     return 0
@@ -417,37 +416,38 @@ def log_comparison(  # noqa: PLR0913
 
     msg = f"Logging comparison to '{database}'"
     logger.info(msg)
-    session = db_orm.connect_to_db(logger, database)
-    # Give a better error message that if adding comparison fails:
-    if (
-        not session.query(db_orm.Configuration)
-        .where(db_orm.Configuration.configuration_id == config_id)
-        .count()
-    ):
-        msg = f"{database} does not contain configuration_id={config_id}"
-        log_sys_exit(logger, msg)
+    with db_orm.connect_to_db(logger, database) as session:
+        # Give a better error message that if adding comparison fails:
+        if (
+            not session.query(db_orm.Configuration)
+            .where(db_orm.Configuration.configuration_id == config_id)
+            .count()
+        ):
+            msg = f"{database} does not contain configuration_id={config_id}"
+            log_sys_exit(logger, msg)
 
-    from pyani_plus.utils import file_md5sum  # noqa: PLC0415
+        from pyani_plus.utils import file_md5sum  # noqa: PLC0415
 
-    query_md5 = file_md5sum(query_fasta)
-    db_orm.db_genome(logger, session, query_fasta, query_md5)
+        query_md5 = file_md5sum(query_fasta)
+        db_orm.db_genome(logger, session, query_fasta, query_md5)
 
-    subject_md5 = file_md5sum(subject_fasta)
-    db_orm.db_genome(logger, session, subject_fasta, subject_md5)
+        subject_md5 = file_md5sum(subject_fasta)
+        db_orm.db_genome(logger, session, subject_fasta, subject_md5)
 
-    db_orm.db_comparison(
-        session,
-        configuration_id=config_id,
-        query_hash=query_md5,
-        subject_hash=subject_md5,
-        identity=identity,
-        aln_length=aln_length,
-        sim_errors=sim_errors,
-        cov_query=cov_query,
-        cov_subject=cov_subject,
-    )
+        db_orm.db_comparison(
+            session,
+            configuration_id=config_id,
+            query_hash=query_md5,
+            subject_hash=subject_md5,
+            identity=identity,
+            aln_length=aln_length,
+            sim_errors=sim_errors,
+            cov_query=cov_query,
+            cov_subject=cov_subject,
+        )
 
-    session.commit()
+        session.commit()
+
     return 0
 
 
@@ -649,23 +649,28 @@ def import_comparisons(
 
     msg = f"Logging comparison to '{database}'"
     logger.info(msg)
-    session = db_orm.connect_to_db(logger, database)
+    with db_orm.connect_to_db(logger, database) as session:
+        if (
+            session.execute(
+                select(func.count()).select_from(db_orm.Configuration)
+            ).scalar()
+            == 0
+        ):
+            msg = f"{database} does not contain any configurations"
+            log_sys_exit(logger, msg)
 
-    if (
-        session.execute(select(func.count()).select_from(db_orm.Configuration)).scalar()
-        == 0
-    ):
-        msg = f"{database} does not contain any configurations"
-        log_sys_exit(logger, msg)
+        if (
+            session.execute(select(func.count()).select_from(db_orm.Genome)).scalar()
+            == 0
+        ):
+            msg = f"{database} does not contain any genomes"
+            log_sys_exit(logger, msg)
 
-    if session.execute(select(func.count()).select_from(db_orm.Genome)).scalar() == 0:
-        msg = f"{database} does not contain any genomes"
-        log_sys_exit(logger, msg)
+        for filename in json:
+            count = import_json_comparisons(logger, session, filename)
+            msg = f"Imported {count} from '{filename}'"
+            logger.info(msg)
 
-    for filename in json:
-        count = import_json_comparisons(logger, session, filename)
-        msg = f"Imported {count} from '{filename}'"
-        logger.info(msg)
     return 0
 
 
@@ -695,15 +700,15 @@ def prepare_genomes(
     if database != ":memory:" and not Path(database).is_file():
         msg = f"Database '{database}' does not exist"
         log_sys_exit(logger, msg)
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id)
-    try:
-        return prepare(logger, run, cache)
-    except Exception as err:  # pragma: nocover
-        logger.exception("Unhandled exception:")
-        msg = f"Unhandled exception preparing genomes: {err}"
-        log_sys_exit(logger, msg)
-        return 1  # for mypy
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id)
+        try:
+            return prepare(logger, run, cache)
+        except Exception as err:  # pragma: nocover
+            logger.exception("Unhandled exception:")
+            msg = f"Unhandled exception preparing genomes: {err}"
+            log_sys_exit(logger, msg)
+            return 1  # for mypy
 
 
 def prepare(logger: logging.Logger, run: db_orm.Run, cache: Path) -> int:

--- a/pyani_plus/private_cli.py
+++ b/pyani_plus/private_cli.py
@@ -822,146 +822,154 @@ def compute_column(  # noqa: C901, PLR0913, PLR0912, PLR0915
     # For simplicity, treat SIGTERM as a KeyboardInterrupt too.
     signal.signal(signal.SIGTERM, signal.default_int_handler)
 
-    try:
-        session = db_orm.connect_to_db(logger, database)
-        run = session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
-        config = run.configuration
-        method = config.method
-
-        filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
-        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-        n = len(hash_to_filename)
-
-        if subject in hash_to_filename:
-            subject_hash = subject
-            column = sorted(hash_to_filename).index(subject_hash) + 1
-        elif Path(subject).name in filename_to_hash:
-            subject_hash = filename_to_hash[Path(subject).name]
-            column = sorted(hash_to_filename).index(subject_hash) + 1
-        else:
-            try:
-                column = int(subject)
-            except ValueError:
-                msg = f"Did not recognise {subject!r} as an MD5 hash, filename, or column number in run-id {run_id}"
-                log_sys_exit(logger, msg)
-            if 0 < column <= n:
-                subject_hash = sorted(hash_to_filename)[column - 1]
-            elif column == 0:
-                if method == "sourmash":
-                    subject_hash = ""
-                else:
-                    msg = "All columns currently only implemented for sourmash"
-                    log_sys_exit(logger, msg)
-            else:
-                msg = (
-                    f"Single column should be in range 1 to {n},"
-                    f" or for some methods {0} meaning all columns, but not {subject}"
-                )
-                log_sys_exit(logger, msg)
-
-        if not log_ready:
-            # Column worker specific log files!
-            log = Path(str(log)[: -len(log.suffix)] + f".{column}" + log.suffix)
-            logger = setup_logger(
-                log,
-                terminal_level=logging.DEBUG if debug else logging.ERROR,
-                plain=True,
-            )
-        msg = f"Logging {method} compute-column {column} to {log}"
-        logger.info(msg)
-
-        if column == 0:
-            # Computing all the matrix, but are there might be some rows/cols already done?
-            query_hashes = {
-                _.genome_hash: _.length for _ in run.genomes
-            }  # assume all needed
-        else:
-            # What comparisons are needed? Record the query genome lengths too
-            # (doing this once at the start to avoid a small lookup for each query)
-            missing_query_hashes = set(hash_to_filename).difference(
-                comp.query_hash
-                for comp in run.comparisons().where(
-                    db_orm.Comparison.subject_hash == subject_hash
-                )
-            )
-            query_hashes = {
-                _.genome_hash: _.length
-                for _ in run.genomes
-                if _.genome_hash in missing_query_hashes
-            }
-            del missing_query_hashes
-
-        if not query_hashes:
-            msg = f"No {method} comparisons needed against {subject_hash}"
-            logger.info(msg)
-            return 0
-
-        # Will probably want to move each of these functions to the relevant method module...
+    # db session moved outside the try/except block to enable
+    # context management
+    with db_orm.connect_to_db(logger, database) as session:
         try:
-            compute = {
-                "fastANI": compute_fastani,
-                "ANIb": compute_anib,
-                "ANIm": compute_anim,
-                "dnadiff": compute_dnadiff,
-                "skani": compute_skani,
-                "sourmash": compute_sourmash,
-                "external-alignment": compute_external_alignment,
-            }[method]
-        except KeyError:
-            msg = f"Unknown method {method} for run-id {run_id} in {database}"
-            log_sys_exit(logger, msg)
+            run = session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
+            config = run.configuration
+            method = config.method
 
-        # On a cluster we are likely in a temp working directory, meaning
-        # if it is a relative path, run.fasta_directory is useless without
-        # evaluating it relative to the DB filename.
-        fasta_dir = Path(run.fasta_directory)
-        if not fasta_dir.is_absolute():
-            fasta_dir = (database.parent / fasta_dir).absolute()
-        msg = f"FASTA folder {fasta_dir}"
-        logger.debug(msg)
+            filename_to_hash = {
+                _.fasta_filename: _.genome_hash for _ in run.fasta_hashes
+            }
+            hash_to_filename = {
+                _.genome_hash: _.fasta_filename for _ in run.fasta_hashes
+            }
+            n = len(hash_to_filename)
 
-        # Either use the specified temp-directory (and do not clean up),
-        # or use a system temp-directory (and do clean up)
-        if temp == Path("-"):  # dummy value accepted at command line
-            temp = None
-        if temp:
-            temp = temp / f"c{column}"  # avoid worries about name clashes
-            temp.mkdir(exist_ok=True)
-            msg = f"Using temp folder {temp}"
+            if subject in hash_to_filename:
+                subject_hash = subject
+                column = sorted(hash_to_filename).index(subject_hash) + 1
+            elif Path(subject).name in filename_to_hash:
+                subject_hash = filename_to_hash[Path(subject).name]
+                column = sorted(hash_to_filename).index(subject_hash) + 1
+            else:
+                try:
+                    column = int(subject)
+                except ValueError:
+                    msg = f"Did not recognise {subject!r} as an MD5 hash, filename, or column number in run-id {run_id}"
+                    log_sys_exit(logger, msg)
+                if 0 < column <= n:
+                    subject_hash = sorted(hash_to_filename)[column - 1]
+                elif column == 0:
+                    if method == "sourmash":
+                        subject_hash = ""
+                    else:
+                        msg = "All columns currently only implemented for sourmash"
+                        log_sys_exit(logger, msg)
+                else:
+                    msg = (
+                        f"Single column should be in range 1 to {n},"
+                        f" or for some methods {0} meaning all columns, but not {subject}"
+                    )
+                    log_sys_exit(logger, msg)
+
+            if not log_ready:
+                # Column worker specific log files!
+                log = Path(str(log)[: -len(log.suffix)] + f".{column}" + log.suffix)
+                logger = setup_logger(
+                    log,
+                    terminal_level=logging.DEBUG if debug else logging.ERROR,
+                    plain=True,
+                )
+            msg = f"Logging {method} compute-column {column} to {log}"
+            logger.info(msg)
+
+            if column == 0:
+                # Computing all the matrix, but are there might be some rows/cols already done?
+                query_hashes = {
+                    _.genome_hash: _.length for _ in run.genomes
+                }  # assume all needed
+            else:
+                # What comparisons are needed? Record the query genome lengths too
+                # (doing this once at the start to avoid a small lookup for each query)
+                missing_query_hashes = set(hash_to_filename).difference(
+                    comp.query_hash
+                    for comp in run.comparisons().where(
+                        db_orm.Comparison.subject_hash == subject_hash
+                    )
+                )
+                query_hashes = {
+                    _.genome_hash: _.length
+                    for _ in run.genomes
+                    if _.genome_hash in missing_query_hashes
+                }
+                del missing_query_hashes
+
+            if not query_hashes:
+                msg = f"No {method} comparisons needed against {subject_hash}"
+                logger.info(msg)
+                return 0
+
+            # Will probably want to move each of these functions to the relevant method module...
+            try:
+                compute = {
+                    "fastANI": compute_fastani,
+                    "ANIb": compute_anib,
+                    "ANIm": compute_anim,
+                    "dnadiff": compute_dnadiff,
+                    "skani": compute_skani,
+                    "sourmash": compute_sourmash,
+                    "external-alignment": compute_external_alignment,
+                }[method]
+            except KeyError:
+                msg = f"Unknown method {method} for run-id {run_id} in {database}"
+                log_sys_exit(logger, msg)
+
+            # On a cluster we are likely in a temp working directory, meaning
+            # if it is a relative path, run.fasta_directory is useless without
+            # evaluating it relative to the DB filename.
+            fasta_dir = Path(run.fasta_directory)
+            if not fasta_dir.is_absolute():
+                fasta_dir = (database.parent / fasta_dir).absolute()
+            msg = f"FASTA folder {fasta_dir}"
             logger.debug(msg)
 
-        msg = (
-            f"Calling {method} for {len(query_hashes)} queries"
-            if column == 0
-            else f"Calling {method} for {len(query_hashes)} queries vs {subject_hash}."
-        )
-        logger.info(msg)
-    except Exception as err:  # pragma: nocover
-        logger.exception("Unhandled exception:")
-        msg = f"Unhandled exception before compute: {err}"
-        log_sys_exit(logger, msg)
-        return 1  # for mypy
+            # Either use the specified temp-directory (and do not clean up),
+            # or use a system temp-directory (and do clean up)
+            if temp == Path("-"):  # dummy value accepted at command line
+                temp = None
+            if temp:
+                temp = temp / f"c{column}"  # avoid worries about name clashes
+                temp.mkdir(exist_ok=True)
+                msg = f"Using temp folder {temp}"
+                logger.debug(msg)
 
-    try:
-        with nullcontext(temp) if temp else tempfile.TemporaryDirectory() as tmp_dir:
-            return compute(
-                logger,
-                Path(tmp_dir),
-                session,
-                run,
-                json,
-                fasta_dir,
-                hash_to_filename,
-                filename_to_hash,
-                query_hashes,
-                subject_hash,
-                cache=cache,
+            msg = (
+                f"Calling {method} for {len(query_hashes)} queries"
+                if column == 0
+                else f"Calling {method} for {len(query_hashes)} queries vs {subject_hash}."
             )
-    except Exception as err:  # pragma: nocover
-        logger.exception("Unhandled exception:")
-        msg = f"Unhandled exception during compute: {err}"
-        log_sys_exit(logger, msg)
-        return 1  # for mypy
+            logger.info(msg)
+        except Exception as err:  # pragma: nocover
+            logger.exception("Unhandled exception:")
+            msg = f"Unhandled exception before compute: {err}"
+            log_sys_exit(logger, msg)
+            return 1  # for mypy
+
+        try:
+            with (
+                nullcontext(temp) if temp else tempfile.TemporaryDirectory() as tmp_dir
+            ):
+                return compute(
+                    logger,
+                    Path(tmp_dir),
+                    session,
+                    run,
+                    json,
+                    fasta_dir,
+                    hash_to_filename,
+                    filename_to_hash,
+                    query_hashes,
+                    subject_hash,
+                    cache=cache,
+                )
+        except Exception as err:  # pragma: nocover
+            logger.exception("Unhandled exception:")
+            msg = f"Unhandled exception during compute: {err}"
+            log_sys_exit(logger, msg)
+            return 1  # for mypy
 
 
 def compute_fastani(  # noqa: PLR0913, PLR0915

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -137,69 +137,70 @@ def start_and_run_method(  # noqa: PLR0913
     # We should have caught all the obvious failures earlier,
     # including missing inputs or missing external tools.
     # Can now start talking to the DB.
-    session = db_orm.connect_to_db(logger, database)
+    with db_orm.connect_to_db(logger, database) as session:
+        # Reuse existing config, or log a new one
+        config = db_orm.db_configuration(
+            session,
+            method,
+            "" if tool is None else tool.exe_path.stem,
+            "" if tool is None else tool.version,
+            fragsize,
+            mode,
+            kmersize,
+            minmatch,
+            extra,
+            create=True,
+        )
 
-    # Reuse existing config, or log a new one
-    config = db_orm.db_configuration(
-        session,
-        method,
-        "" if tool is None else tool.exe_path.stem,
-        "" if tool is None else tool.version,
-        fragsize,
-        mode,
-        kmersize,
-        minmatch,
-        extra,
-        create=True,
-    )
+        n = len(fasta_names)
+        filename_to_md5 = {}
+        hashes = set()
+        with Progress(*PROGRESS_BAR_COLUMNS) as progress:
+            for filename in progress.track(fasta_names, description="Indexing FASTAs"):
+                try:
+                    md5 = file_md5sum(filename)
+                except ValueError as err:
+                    log_sys_exit(logger, str(err))
+                filename_to_md5[filename] = md5
+                if md5 in hashes:
+                    # This avoids hitting IntegrityError UNIQUE constraint failed
+                    dups = "\n" + "\n".join(
+                        sorted({str(k) for k, v in filename_to_md5.items() if v == md5})
+                    )
+                    msg = f"Multiple genomes with same MD5 checksum {md5}:{dups}"
+                    log_sys_exit(logger, msg)
+                hashes.add(md5)
+                db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    n = len(fasta_names)
-    filename_to_md5 = {}
-    hashes = set()
-    with Progress(*PROGRESS_BAR_COLUMNS) as progress:
-        for filename in progress.track(fasta_names, description="Indexing FASTAs"):
-            try:
-                md5 = file_md5sum(filename)
-            except ValueError as err:
-                log_sys_exit(logger, str(err))
-            filename_to_md5[filename] = md5
-            if md5 in hashes:
-                # This avoids hitting IntegrityError UNIQUE constraint failed
-                dups = "\n" + "\n".join(
-                    sorted({str(k) for k, v in filename_to_md5.items() if v == md5})
-                )
-                msg = f"Multiple genomes with same MD5 checksum {md5}:{dups}"
-                log_sys_exit(logger, msg)
-            hashes.add(md5)
-            db_orm.db_genome(logger, session, filename, md5, create=True)
+        # New run
+        run = db_orm.add_run(
+            session,
+            config,
+            cmdline=" ".join(sys.argv),
+            fasta_directory=fasta,
+            status="Initialising",
+            name=f"{len(filename_to_md5)} genomes using {method}"
+            if name is None
+            else name,
+            date=None,
+            fasta_to_hash=filename_to_md5,
+        )
+        session.commit()  # Redundant?
+        msg = f"{method} run setup with {n} genomes in database"
+        logger.info(msg)
 
-    # New run
-    run = db_orm.add_run(
-        session,
-        config,
-        cmdline=" ".join(sys.argv),
-        fasta_directory=fasta,
-        status="Initialising",
-        name=f"{len(filename_to_md5)} genomes using {method}" if name is None else name,
-        date=None,
-        fasta_to_hash=filename_to_md5,
-    )
-    session.commit()  # Redundant?
-    msg = f"{method} run setup with {n} genomes in database"
-    logger.info(msg)
-
-    return run_method(
-        logger,
-        executor,
-        cache,
-        temp,
-        workflow_temp,
-        filename_to_md5,
-        database,
-        log,
-        session,
-        run,
-    )
+        return run_method(
+            logger,
+            executor,
+            cache,
+            temp,
+            workflow_temp,
+            filename_to_md5,
+            database,
+            log,
+            session,
+            run,
+        )
 
 
 def run_method(  # noqa: PLR0913, PLR0915
@@ -683,100 +684,102 @@ def resume(  # noqa: C901, PLR0912, PLR0913, PLR0915
         msg = f"Database {database} does not exist"
         log_sys_exit(logger, msg)
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id)
-    if run_id is None:
-        run_id = run.run_id  # relevant if was None
-        msg = f"Resuming run-id {run_id}"
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id)
+        if run_id is None:
+            run_id = run.run_id  # relevant if was None
+            msg = f"Resuming run-id {run_id}"
+            logger.info(msg)
+        config = run.configuration
+        msg = (
+            f"This is a {config.method} run on {run.genomes.count()} genomes, "
+            f"using {config.program} version {config.version}"
+        )
         logger.info(msg)
-    config = run.configuration
-    msg = (
-        f"This is a {config.method} run on {run.genomes.count()} genomes, "
-        f"using {config.program} version {config.version}"
-    )
-    logger.info(msg)
-    if not run.genomes.count():
-        msg = f"No genomes recorded for run-id {run_id}, cannot resume."
-        log_sys_exit(logger, msg)
-
-    # The params dict has two kinds of entries,
-    # - tool paths, which ought to be handled more neatly
-    # - config entries, which ought to be named consistently and done centrally
-    tool: tools.ExternalToolData | None = None  # make type explicit for mypy
-    match config.method:
-        case "fastANI":
-            tool = tools.get_fastani()
-        case "ANIm":
-            tool = tools.get_nucmer()
-        case "dnadiff":
-            tool = tools.get_nucmer()
-        case "ANIb":
-            tool = tools.get_blastn()
-        case "skani":
-            tool = tools.get_skani()
-        case "sourmash":
-            tool = tools.get_sourmash()
-        case "external-alignment":
-            tool = None
-        case _:
-            msg = f"Unknown method {config.method} for run-id {run_id} in {database}"
+        if not run.genomes.count():
+            msg = f"No genomes recorded for run-id {run_id}, cannot resume."
             log_sys_exit(logger, msg)
-    if not tool:
-        if config.program != "" or config.version != "":
+
+        # The params dict has two kinds of entries,
+        # - tool paths, which ought to be handled more neatly
+        # - config entries, which ought to be named consistently and done centrally
+        tool: tools.ExternalToolData | None = None  # make type explicit for mypy
+        match config.method:
+            case "fastANI":
+                tool = tools.get_fastani()
+            case "ANIm":
+                tool = tools.get_nucmer()
+            case "dnadiff":
+                tool = tools.get_nucmer()
+            case "ANIb":
+                tool = tools.get_blastn()
+            case "skani":
+                tool = tools.get_skani()
+            case "sourmash":
+                tool = tools.get_sourmash()
+            case "external-alignment":
+                tool = None
+            case _:
+                msg = (
+                    f"Unknown method {config.method} for run-id {run_id} in {database}"
+                )
+                log_sys_exit(logger, msg)
+        if not tool:
+            if config.program != "" or config.version != "":
+                msg = (
+                    "We expect no tool information, but"
+                    f" run-id {run_id} used {config.program} version {config.version} instead."
+                )
+                log_sys_exit(logger, msg)
+        elif tool.exe_path.stem != config.program or tool.version != config.version:
             msg = (
-                "We expect no tool information, but"
+                f"We have {tool.exe_path.stem} version {tool.version}, but"
                 f" run-id {run_id} used {config.program} version {config.version} instead."
             )
             log_sys_exit(logger, msg)
-    elif tool.exe_path.stem != config.program or tool.version != config.version:
-        msg = (
-            f"We have {tool.exe_path.stem} version {tool.version}, but"
-            f" run-id {run_id} used {config.program} version {config.version} instead."
-        )
-        log_sys_exit(logger, msg)
 
-    del tool
+        del tool
 
-    # Now we need to check the fasta files in the directory
-    # against those included in the run...
-    fasta = Path(run.fasta_directory)
-    if not fasta.is_dir():
-        msg = f"run-id {run_id} used input folder {fasta}, but that is not a directory (now)."
-        log_sys_exit(logger, msg)
-
-    # Recombine the fasta directory name from the runs table with the plain filename from
-    # the run-genome linking table
-    filename_to_md5 = {
-        fasta / link.fasta_filename: link.genome_hash for link in run.fasta_hashes
-    }
-    for filename, md5 in filename_to_md5.items():
-        if not filename.is_file():
-            msg = (
-                f"run-id {run_id} used {filename} with MD5 {md5}"
-                f" but this FASTA file no longer exists"
-            )
+        # Now we need to check the fasta files in the directory
+        # against those included in the run...
+        fasta = Path(run.fasta_directory)
+        if not fasta.is_dir():
+            msg = f"run-id {run_id} used input folder {fasta}, but that is not a directory (now)."
             log_sys_exit(logger, msg)
 
-    # Resuming
-    run.status = "Resuming"
-    session.commit()
+        # Recombine the fasta directory name from the runs table with the plain filename from
+        # the run-genome linking table
+        filename_to_md5 = {
+            fasta / link.fasta_filename: link.genome_hash for link in run.fasta_hashes
+        }
+        for filename, md5 in filename_to_md5.items():
+            if not filename.is_file():
+                msg = (
+                    f"run-id {run_id} used {filename} with MD5 {md5}"
+                    f" but this FASTA file no longer exists"
+                )
+                log_sys_exit(logger, msg)
 
-    try:
-        return run_method(
-            logger,
-            executor,
-            cache,
-            temp,
-            wtemp,
-            filename_to_md5,
-            database,
-            log,
-            session,
-            run,
-        )
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
+        # Resuming
+        run.status = "Resuming"
+        session.commit()
+
+        try:
+            return run_method(
+                logger,
+                executor,
+                cache,
+                temp,
+                wtemp,
+                filename_to_md5,
+                database,
+                log,
+                session,
+                run,
+            )
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
 
 
 @app.command()
@@ -792,46 +795,46 @@ def list_runs(
         msg = f"Database {database} does not exist"
         log_sys_exit(logger, msg)
 
-    session = db_orm.connect_to_db(logger, database)
-    runs = session.query(db_orm.Run)
+    with db_orm.connect_to_db(logger, database) as session:
+        runs = session.query(db_orm.Run)
 
-    table = Table(
-        title=f"{runs.count()} analysis runs in {database}",
-        row_styles=["dim", ""],  # alternating zebra stripes
-    )
-    table.add_column("ID", justify="right", no_wrap=True)
-    table.add_column("Date")
-    table.add_column("Method")
-    table.add_column(Text("Done", justify="left"), justify="right", no_wrap=True)
-    table.add_column(Text("Null", justify="left"), justify="right", no_wrap=True)
-    table.add_column(Text("Miss", justify="left"), justify="right", no_wrap=True)
-    table.add_column(Text("Total", justify="left"), justify="right", no_wrap=True)
-    table.add_column("Status")
-    table.add_column("Name")
-    # Would be nice to report {conf.program} {conf.version} too,
-    # perhaps conditional on the terminal width?
-    for run in runs:
-        conf = run.configuration
-        n = run.genomes.count()
-        total = n**2
-        done = run.comparisons().count()
-        # Using is None does not work as expected, must use == None
-        nulls = run.comparisons().where(db_orm.Comparison.identity == None).count()  # noqa: E711
-        table.add_row(
-            str(run.run_id),
-            str(run.date.date()),
-            conf.method,
-            Text(
-                f"{done - nulls}",
-                style="green" if done == total and not nulls else "yellow",
-            ),
-            Text(f"{nulls}", style="red" if nulls else "green"),
-            Text(f"{total - done}", style="yellow" if done < total else "green"),
-            f"{n**2}={n}²",
-            run.status,
-            run.name,
+        table = Table(
+            title=f"{runs.count()} analysis runs in {database}",
+            row_styles=["dim", ""],  # alternating zebra stripes
         )
-    session.close()
+        table.add_column("ID", justify="right", no_wrap=True)
+        table.add_column("Date")
+        table.add_column("Method")
+        table.add_column(Text("Done", justify="left"), justify="right", no_wrap=True)
+        table.add_column(Text("Null", justify="left"), justify="right", no_wrap=True)
+        table.add_column(Text("Miss", justify="left"), justify="right", no_wrap=True)
+        table.add_column(Text("Total", justify="left"), justify="right", no_wrap=True)
+        table.add_column("Status")
+        table.add_column("Name")
+        # Would be nice to report {conf.program} {conf.version} too,
+        # perhaps conditional on the terminal width?
+        for run in runs:
+            conf = run.configuration
+            n = run.genomes.count()
+            total = n**2
+            done = run.comparisons().count()
+            # Using is None does not work as expected, must use == None
+            nulls = run.comparisons().where(db_orm.Comparison.identity == None).count()  # noqa: E711
+            table.add_row(
+                str(run.run_id),
+                str(run.date.date()),
+                conf.method,
+                Text(
+                    f"{done - nulls}",
+                    style="green" if done == total and not nulls else "yellow",
+                ),
+                Text(f"{nulls}", style="red" if nulls else "green"),
+                Text(f"{total - done}", style="yellow" if done < total else "green"),
+                f"{n**2}={n}²",
+                run.status,
+                run.name,
+            )
+
     console = Console()
     console.print(table)
     msg = f"Reporting on {len(table.rows)} runs."
@@ -867,56 +870,56 @@ def delete_run(
 
     confirm = False
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_complete=False)
-    if run_id is None:
-        run_id = run.run_id
-        logger.info("Deleting most recent run")
-        confirm = True
-
-    # Could use rish colours, match how list-runs colours the counts?
-    done = run.comparisons().count()
-    n = run.genomes.count()
-    if n and done == n**2:
-        msg = (
-            f"Run {run_id} contains all {n**2}={n}²"
-            f" {run.configuration.method} comparisons, status: {run.status}"
-        )
-        logger.info(msg)
-        confirm = True
-    else:
-        msg = (
-            f"Run {run_id} contains {done}/{n**2}={n}²"
-            f" {run.configuration.method} comparisons, status: {run.status}"
-        )
-        logger.info(msg)
-        if done:
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_complete=False)
+        if run_id is None:
+            run_id = run.run_id
+            logger.info("Deleting most recent run")
             confirm = True
-    msg = f"Run name: {run.name}"
-    logger.info(msg)
 
-    if run.status == "Running":  # should be a constant or enum?
-        # Should we also look at the date of the run? If old probably it failed.
-        msg = "Deleting a run still being computed will cause it to fail!"
-        logger.warning(msg)
-        confirm = True
+        # Could use rish colours, match how list-runs colours the counts?
+        done = run.comparisons().count()
+        n = run.genomes.count()
+        if n and done == n**2:
+            msg = (
+                f"Run {run_id} contains all {n**2}={n}²"
+                f" {run.configuration.method} comparisons, status: {run.status}"
+            )
+            logger.info(msg)
+            confirm = True
+        else:
+            msg = (
+                f"Run {run_id} contains {done}/{n**2}={n}²"
+                f" {run.configuration.method} comparisons, status: {run.status}"
+            )
+            logger.info(msg)
+            if done:
+                confirm = True
+        msg = f"Run name: {run.name}"
+        logger.info(msg)
 
-    if confirm and not force:
-        click.confirm("Do you want to continue?", abort=True)  # pragma: no cover
+        if run.status == "Running":  # should be a constant or enum?
+            # Should we also look at the date of the run? If old probably it failed.
+            msg = "Deleting a run still being computed will cause it to fail!"
+            logger.warning(msg)
+            confirm = True
 
-    # Plan to offer an extended mode, perhaps --all, which will also
-    # delete orphaned entries in the configuration,  genomes, and
-    # comparisons tables. By default will just drop the runs entry
-    # and direct links in runs_genomes thanks to the relationship.
+        if confirm and not force:
+            click.confirm("Do you want to continue?", abort=True)  # pragma: no cover
 
-    # Explicitly delete the no longer wanted entries in runs_genomes
-    # (ought to be able to trigger this automatically in a cascade
-    # when the run itself is deleted, but that didn't work for me):
-    session.query(db_orm.RunGenomeAssociation).where(
-        db_orm.RunGenomeAssociation.run_id == run_id
-    ).delete()
-    session.delete(run)
-    session.commit()
+        # Plan to offer an extended mode, perhaps --all, which will also
+        # delete orphaned entries in the configuration,  genomes, and
+        # comparisons tables. By default will just drop the runs entry
+        # and direct links in runs_genomes thanks to the relationship.
+
+        # Explicitly delete the no longer wanted entries in runs_genomes
+        # (ought to be able to trigger this automatically in a cascade
+        # when the run itself is deleted, but that didn't work for me):
+        session.query(db_orm.RunGenomeAssociation).where(
+            db_orm.RunGenomeAssociation.run_id == run_id
+        ).delete()
+        session.delete(run)
+        session.commit()
     session.close()
     return 0
 
@@ -954,88 +957,88 @@ def export_run(  # noqa: C901, PLR0913
         logger.warning(msg)
         outdir.mkdir()
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_empty=True)
-    if run_id is None:
-        run_id = run.run_id
-        msg = f"Exporting run-id {run_id}"
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_empty=True)
+        if run_id is None:
+            run_id = run.run_id
+            msg = f"Exporting run-id {run_id}"
+            logger.info(msg)
+
+        # Question: Should we export a plain text of JSON summary of the configuration etc?
+        # Question: Should we include the run-id in the matrix filenames?
+        # Question: Should we match the property in filenames to old pyANI (e.g. coverage)?
+        method = run.configuration.method
+
+        def float_or_na(value: float | None) -> str:
+            """Format a float where represent None as NA (null in our DB)."""
+            # Should this allow configurable float formatting?
+            return "NA" if value is None else str(value)
+
+        if label == "md5":
+            mapping = lambda x: x  # noqa: E731
+        elif label == "filename":
+            mapping = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}.get
+        else:
+            mapping = {
+                _.genome_hash: filename_stem(_.fasta_filename) for _ in run.fasta_hashes
+            }.get
+
+        long_filename = f"{method}_run_{run_id}.tsv"
+        with (outdir / long_filename).open("w") as handle:
+            # Should the column names match our internal naming?
+            handle.write(
+                "#Query\tSubject\tIdentity\tQuery-Cov\tSubject-Cov\tHadamard\ttANI\tAlign-Len\tSim-Errors\n"
+            )
+            for _ in run.comparisons():
+                # Below for the matrix output we use the cached DataFrame for Hadamard.
+                # Here compute it on the fly (we might be exporting partial results).
+                hadamard = (
+                    None
+                    if _.identity is None or _.cov_query is None
+                    else _.identity * _.cov_query
+                )
+                tani = None if hadamard is None else -math_log(hadamard)
+                handle.write(
+                    f"{mapping(_.query_hash)}\t{mapping(_.subject_hash)}"
+                    f"\t{float_or_na(_.identity)}"
+                    f"\t{float_or_na(_.cov_query)}"
+                    f"\t{float_or_na(_.cov_subject)}"
+                    f"\t{float_or_na(hadamard)}"
+                    f"\t{float_or_na(tani)}"
+                    f"\t{float_or_na(_.aln_length)}"
+                    f"\t{float_or_na(_.sim_errors)}\n"
+                )
+        msg = f"Wrote long-form to {outdir}/{long_filename}"
         logger.info(msg)
 
-    # Question: Should we export a plain text of JSON summary of the configuration etc?
-    # Question: Should we include the run-id in the matrix filenames?
-    # Question: Should we match the property in filenames to old pyANI (e.g. coverage)?
-    method = run.configuration.method
+        # Reload the run checking it is complete (quick) (might abort here!),
+        # and caching the matrices if needed (slower):
+        run = db_orm.load_run(session, run_id, check_complete=True)
 
-    def float_or_na(value: float | None) -> str:
-        """Format a float where represent None as NA (null in our DB)."""
-        # Should this allow configurable float formatting?
-        return "NA" if value is None else str(value)
+        for matrix, filename in (
+            (run.identities, f"{method}_identity.tsv"),
+            (run.aln_length, f"{method}_aln_lengths.tsv"),
+            (run.sim_errors, f"{method}_sim_errors.tsv"),
+            (run.cov_query, f"{method}_query_cov.tsv"),
+            (run.hadamard, f"{method}_hadamard.tsv"),
+            (run.tani, f"{method}_tANI.tsv"),
+        ):
+            if matrix is None:  # pragma: no cover
+                # This is mainly for mypy to assert the matrix is not None
+                msg = f"Could not load run {method} matrix"
+                log_sys_exit(logger, msg)
+                return 1  # not called but mbpy doesn't understand that (yet)
 
-    if label == "md5":
-        mapping = lambda x: x  # noqa: E731
-    elif label == "filename":
-        mapping = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}.get
-    else:
-        mapping = {
-            _.genome_hash: filename_stem(_.fasta_filename) for _ in run.fasta_hashes
-        }.get
+            try:
+                matrix = run.relabelled_matrix(matrix, label)  # noqa: PLW2901
+            except ValueError as err:
+                msg = f"{err}"
+                log_sys_exit(logger, msg)
 
-    long_filename = f"{method}_run_{run_id}.tsv"
-    with (outdir / long_filename).open("w") as handle:
-        # Should the column names match our internal naming?
-        handle.write(
-            "#Query\tSubject\tIdentity\tQuery-Cov\tSubject-Cov\tHadamard\ttANI\tAlign-Len\tSim-Errors\n"
-        )
-        for _ in run.comparisons():
-            # Below for the matrix output we use the cached DataFrame for Hadamard.
-            # Here compute it on the fly (we might be exporting partial results).
-            hadamard = (
-                None
-                if _.identity is None or _.cov_query is None
-                else _.identity * _.cov_query
-            )
-            tani = None if hadamard is None else -math_log(hadamard)
-            handle.write(
-                f"{mapping(_.query_hash)}\t{mapping(_.subject_hash)}"
-                f"\t{float_or_na(_.identity)}"
-                f"\t{float_or_na(_.cov_query)}"
-                f"\t{float_or_na(_.cov_subject)}"
-                f"\t{float_or_na(hadamard)}"
-                f"\t{float_or_na(tani)}"
-                f"\t{float_or_na(_.aln_length)}"
-                f"\t{float_or_na(_.sim_errors)}\n"
-            )
-    msg = f"Wrote long-form to {outdir}/{long_filename}"
-    logger.info(msg)
+            matrix.to_csv(outdir / filename, sep="\t")
 
-    # Reload the run checking it is complete (quick) (might abort here!),
-    # and caching the matrices if needed (slower):
-    run = db_orm.load_run(session, run_id, check_complete=True)
-
-    for matrix, filename in (
-        (run.identities, f"{method}_identity.tsv"),
-        (run.aln_length, f"{method}_aln_lengths.tsv"),
-        (run.sim_errors, f"{method}_sim_errors.tsv"),
-        (run.cov_query, f"{method}_query_cov.tsv"),
-        (run.hadamard, f"{method}_hadamard.tsv"),
-        (run.tani, f"{method}_tANI.tsv"),
-    ):
-        if matrix is None:  # pragma: no cover
-            # This is mainly for mypy to assert the matrix is not None
-            msg = f"Could not load run {method} matrix"
-            log_sys_exit(logger, msg)
-            return 1  # not called but mbpy doesn't understand that (yet)
-
-        try:
-            matrix = run.relabelled_matrix(matrix, label)  # noqa: PLW2901
-        except ValueError as err:
-            msg = f"{err}"
-            log_sys_exit(logger, msg)
-
-        matrix.to_csv(outdir / filename, sep="\t")
-
-    msg = f"Wrote matrices to {outdir}/{method}_*.tsv"
-    logger.info(msg)
+        msg = f"Wrote matrices to {outdir}/{method}_*.tsv"
+        logger.info(msg)
 
     session.close()
     return 0
@@ -1066,24 +1069,24 @@ def plot_run(  # noqa: PLR0913
         logger.warning(msg)
         outdir.mkdir()
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_complete=True)
-    if run_id is None:
-        run_id = run.run_id
-        msg = f"Plotting {run.configuration.method} run-id {run_id}"
-        logger.info(msg)
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_complete=True)
+        if run_id is None:
+            run_id = run.run_id
+            msg = f"Plotting {run.configuration.method} run-id {run_id}"
+            logger.info(msg)
 
-    try:
-        from pyani_plus import plot_run  # noqa: PLC0415
+        try:
+            from pyani_plus import plot_run  # noqa: PLC0415
 
-        count = plot_run.plot_single_run(logger, run, outdir, label)
-        msg = f"Wrote {count} images to {outdir}/{run.configuration.method}_*.*"
-        logger.info(msg)
-        session.close()
-        return 0 if count else 1  # noqa: TRY300
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
+            count = plot_run.plot_single_run(logger, run, outdir, label)
+            msg = f"Wrote {count} images to {outdir}/{run.configuration.method}_*.*"
+            logger.info(msg)
+            session.close()
+            return 0 if count else 1  # noqa: TRY300
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
 
 
 @app.command()
@@ -1135,27 +1138,27 @@ def plot_run_comp(  # noqa: PLR0913
         msg = "Need at least two runs for a comparison"
         log_sys_exit(logger, msg)
 
-    session = db_orm.connect_to_db(logger, database)
-    ref_run = db_orm.load_run(session, run_id, check_complete=False)
+    with db_orm.connect_to_db(logger, database) as session:
+        ref_run = db_orm.load_run(session, run_id, check_complete=False)
 
-    if not ref_run.comparisons().count():
-        msg = f"Run {run_id} has no comparisons"
-        log_sys_exit(logger, msg)
+        if not ref_run.comparisons().count():
+            msg = f"Run {run_id} has no comparisons"
+            log_sys_exit(logger, msg)
 
-    try:
-        from pyani_plus import plot_run  # noqa: PLC0415
+        try:
+            from pyani_plus import plot_run  # noqa: PLC0415
 
-        done = plot_run.plot_run_comparison(
-            logger, session, ref_run, other_runs, outdir, columns
-        )
-        msg = f"Wrote {done} images to {outdir}/{ref_run.configuration.method}_identity_{run_id}_vs_*.*"
-        logger.info(msg)
-        session.close()
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
-    else:
-        return 0
+            done = plot_run.plot_run_comparison(
+                logger, session, ref_run, other_runs, outdir, columns
+            )
+            msg = f"Wrote {done} images to {outdir}/{ref_run.configuration.method}_identity_{run_id}_vs_*.*"
+            logger.info(msg)
+            session.close()
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
+        else:
+            return 0
 
 
 @app.command("classify", rich_help_panel="Commands")
@@ -1203,100 +1206,108 @@ def cli_classify(  # noqa: C901, PLR0912, PLR0913, PLR0915
         logger.warning(msg)
         outdir.mkdir()
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_complete=True)
-    if run_id is None:
-        run_id = run.run_id
-        msg = f"Exporting run-id {run_id}"
-        logger.info(msg)
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_complete=True)
+        if run_id is None:
+            run_id = run.run_id
+            msg = f"Exporting run-id {run_id}"
+            logger.info(msg)
 
-    method = run.configuration.method
+        method = run.configuration.method
 
-    matrix = None
-    if mode == "identity":
-        matrix = run.identities
-    elif mode == "tANI" and run.tani is not None:
-        matrix = run.tani.where(run.tani.isna(), run.tani * -1)
+        matrix = None
+        if mode == "identity":
+            matrix = run.identities
+        elif mode == "tANI" and run.tani is not None:
+            matrix = run.tani.where(run.tani.isna(), run.tani * -1)
 
-    if matrix is None:
-        msg = f"Could not load run {method} matrix"  # pragma: no cover
-        log_sys_exit(logger, msg)  # pragma: no cover
+        if matrix is None:
+            msg = f"Could not load run {method} matrix"  # pragma: no cover
+            log_sys_exit(logger, msg)  # pragma: no cover
 
-    done = run.comparisons().count()
-    run_genomes = run.genomes.count()
+        done = run.comparisons().count()
+        run_genomes = run.genomes.count()
 
-    single_genome_run = False
-    if done == 1 and run_genomes == 1:
-        single_genome_run = True
-        msg = f"Run {run_id} has {done} comparison across {run_genomes} genome. Reporting single clique."
-        logger.warning(msg)
-    else:
-        msg = f"Run {run_id} has {done} comparisons across {run_genomes} genomes."
-        logger.info(msg)
-
-    cov = run.cov_query
-    if cov is None:  # pragma: no cover
-        msg = f"Could not load run {method} matrix"
-        log_sys_exit(logger, msg)
-
-    try:
-        score_matrix = run.relabelled_matrix(matrix, label)
-        cov = run.relabelled_matrix(cov, label)
-    except ValueError as err:
-        msg = f"{err}"
-        log_sys_exit(logger, msg)
-
-    try:
-        # Map the string inputs to callable functions
-        coverage_agg_func = classify.AGG_FUNCS[coverage_edges]
-        identity_agg_func = classify.AGG_FUNCS[score_edges]
-
-        # Construct the graph with the correct functions
-        complete_graph = classify.construct_graph(
-            cov, score_matrix, coverage_agg_func, identity_agg_func, cov_min
-        )
-        # Finding cliques
-        if len(list(nx.connected_components(complete_graph))) != 1:
-            initial_cliques = classify.find_initial_cliques(complete_graph)
+        single_genome_run = False
+        if done == 1 and run_genomes == 1:
+            single_genome_run = True
+            msg = f"Run {run_id} has {done} comparison across {run_genomes} genome. Reporting single clique."
+            logger.warning(msg)
         else:
-            initial_cliques = []
-        recursive_cliques = classify.find_cliques_recursively(complete_graph)
+            msg = f"Run {run_id} has {done} comparisons across {run_genomes} genomes."
+            logger.info(msg)
 
-        # Get a list of unique cliques to avoid duplicates. Prioritise initial_cliques
-        unique_cliques = classify.get_unique_cliques(initial_cliques, recursive_cliques)
+        cov = run.cov_query
+        if cov is None:  # pragma: no cover
+            msg = f"Could not load run {method} matrix"
+            log_sys_exit(logger, msg)
 
-        # Determine column name based on mode
-        suffix = "identity" if mode == EnumModeClassify.identity else "-tANI"
-        column_map = {
-            "min_score": f"min_{suffix}",
-            "max_score": f"max_{suffix}",
-        }
+        try:
+            score_matrix = run.relabelled_matrix(matrix, label)
+            cov = run.relabelled_matrix(cov, label)
+        except ValueError as err:
+            msg = f"{err}"
+            log_sys_exit(logger, msg)
 
-        # Writing the results to .tsv
-        _clique_data, clique_df = classify.compute_classify_output(
-            unique_cliques, method, outdir, column_map
-        )
-        msg = f"Wrote classify output to {outdir}"
-        logger.info(msg)
+        try:
+            # Map the string inputs to callable functions
+            coverage_agg_func = classify.AGG_FUNCS[coverage_edges]
+            identity_agg_func = classify.AGG_FUNCS[score_edges]
 
-        # Only plot classify if more than one genome in comparisons and the initial graph consist of at least one clique
-        if not single_genome_run:
-            if set(clique_df["n_nodes"]) == {1}:
-                msg = "All genomes are singletons. No plot can be generated."
-                logger.warning(msg)
+            # Construct the graph with the correct functions
+            complete_graph = classify.construct_graph(
+                cov, score_matrix, coverage_agg_func, identity_agg_func, cov_min
+            )
+            # Finding cliques
+            if len(list(nx.connected_components(complete_graph))) != 1:
+                initial_cliques = classify.find_initial_cliques(complete_graph)
             else:
-                logger.info("Plotting classify output...")
-                genome_groups = classify.get_genome_cligue_ids(clique_df, suffix)
-                genome_positions = classify.get_genome_order(genome_groups)
-                classify.plot_classify(
-                    genome_positions, clique_df, outdir, method, suffix, vertical_line
-                )
-        session.close()
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
-    else:
-        return 0
+                initial_cliques = []
+            recursive_cliques = classify.find_cliques_recursively(complete_graph)
+
+            # Get a list of unique cliques to avoid duplicates. Prioritise initial_cliques
+            unique_cliques = classify.get_unique_cliques(
+                initial_cliques, recursive_cliques
+            )
+
+            # Determine column name based on mode
+            suffix = "identity" if mode == EnumModeClassify.identity else "-tANI"
+            column_map = {
+                "min_score": f"min_{suffix}",
+                "max_score": f"max_{suffix}",
+            }
+
+            # Writing the results to .tsv
+            _clique_data, clique_df = classify.compute_classify_output(
+                unique_cliques, method, outdir, column_map
+            )
+            msg = f"Wrote classify output to {outdir}"
+            logger.info(msg)
+
+            # Only plot classify if more than one genome in comparisons and
+            # the initial graph consist of at least one clique
+            if not single_genome_run:
+                if set(clique_df["n_nodes"]) == {1}:
+                    msg = "All genomes are singletons. No plot can be generated."
+                    logger.warning(msg)
+                else:
+                    logger.info("Plotting classify output...")
+                    genome_groups = classify.get_genome_cligue_ids(clique_df, suffix)
+                    genome_positions = classify.get_genome_order(genome_groups)
+                    classify.plot_classify(
+                        genome_positions,
+                        clique_df,
+                        outdir,
+                        method,
+                        suffix,
+                        vertical_line,
+                    )
+            session.close()
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
+        else:
+            return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -299,30 +299,33 @@ def run_method(  # noqa: PLR0913, PLR0915
             )
 
             # Reconnect to the DB
-            session = db_orm.connect_to_db(logger, database)
-            run = session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
-            done = run.comparisons().count()
-
-            if done < n**2:  # pragma: no cover
-                logger.debug(
-                    "Importing final JSON files, as not all comparisons in DB (yet)"
+            with db_orm.connect_to_db(logger, database) as _session:
+                run = (
+                    _session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
                 )
-                # Can happen if progress-bar thread didn't finish in time
-                for json in target_paths:
-                    private_cli.import_json_comparisons(logger, session, json)
                 done = run.comparisons().count()
 
-    if done != n**2:
-        # There is no obvious way to test this hypothetical failure:
-        msg = f"Only have {done} of {n}²={n**2} {method} comparisons needed"  # pragma: no cover
-        log_sys_exit(logger, msg)  # pragma: no cover
+                if done < n**2:  # pragma: no cover
+                    logger.debug(
+                        "Importing final JSON files, as not all comparisons in DB (yet)"
+                    )
+                    # Can happen if progress-bar thread didn't finish in time
+                    for json in target_paths:
+                        private_cli.import_json_comparisons(logger, _session, json)
+                    done = run.comparisons().count()
 
-    run.cache_comparisons()  # will this needs a progress bar too with large n?
-    run.status = "Done"
-    session.commit()
-    msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
-    logger.info(msg)
-    session.close()
+                if done != n**2:
+                    # There is no obvious way to test this hypothetical failure:
+                    msg = f"Only have {done} of {n}²={n**2} {method} comparisons needed"  # pragma: no cover
+                    log_sys_exit(logger, msg)  # pragma: no cover
+
+                run.cache_comparisons()  # will this needs a progress bar too with large n?
+                run.status = "Done"
+                _session.commit()
+
+            msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
+            logger.info(msg)
+
     return 0
 
 

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -298,15 +298,9 @@ def run_method(  # noqa: PLR0913, PLR0915
             )
 
             # Reconnect to the DB
-<<<<<<< HEAD
             with db_orm.connect_to_db(logger, database) as session2:
                 run = (
                     session2.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
-=======
-            with db_orm.connect_to_db(logger, database) as _session:
-                run = (
-                    _session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
->>>>>>> 17edb76 (change final session assignment to use context management)
                 )
                 done = run.comparisons().count()
 
@@ -316,11 +310,7 @@ def run_method(  # noqa: PLR0913, PLR0915
                     )
                     # Can happen if progress-bar thread didn't finish in time
                     for json in target_paths:
-<<<<<<< HEAD
                         private_cli.import_json_comparisons(logger, session2, json)
-=======
-                        private_cli.import_json_comparisons(logger, _session, json)
->>>>>>> 17edb76 (change final session assignment to use context management)
                     done = run.comparisons().count()
 
                 if done != n**2:
@@ -330,11 +320,7 @@ def run_method(  # noqa: PLR0913, PLR0915
 
                 run.cache_comparisons()  # will this needs a progress bar too with large n?
                 run.status = "Done"
-<<<<<<< HEAD
                 session2.commit()
-=======
-                _session.commit()
->>>>>>> 17edb76 (change final session assignment to use context management)
 
             msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
             logger.info(msg)

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -298,9 +298,9 @@ def run_method(  # noqa: PLR0913, PLR0915
             )
 
             # Reconnect to the DB
-            with db_orm.connect_to_db(logger, database) as _session:
+            with db_orm.connect_to_db(logger, database) as session2:
                 run = (
-                    _session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
+                    session2.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
                 )
                 done = run.comparisons().count()
 
@@ -310,7 +310,7 @@ def run_method(  # noqa: PLR0913, PLR0915
                     )
                     # Can happen if progress-bar thread didn't finish in time
                     for json in target_paths:
-                        private_cli.import_json_comparisons(logger, _session, json)
+                        private_cli.import_json_comparisons(logger, session2, json)
                     done = run.comparisons().count()
 
                 if done != n**2:
@@ -320,7 +320,7 @@ def run_method(  # noqa: PLR0913, PLR0915
 
                 run.cache_comparisons()  # will this needs a progress bar too with large n?
                 run.status = "Done"
-                _session.commit()
+                session2.commit()
 
             msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
             logger.info(msg)

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -298,9 +298,15 @@ def run_method(  # noqa: PLR0913, PLR0915
             )
 
             # Reconnect to the DB
+<<<<<<< HEAD
             with db_orm.connect_to_db(logger, database) as session2:
                 run = (
                     session2.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
+=======
+            with db_orm.connect_to_db(logger, database) as _session:
+                run = (
+                    _session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
+>>>>>>> 17edb76 (change final session assignment to use context management)
                 )
                 done = run.comparisons().count()
 
@@ -310,7 +316,11 @@ def run_method(  # noqa: PLR0913, PLR0915
                     )
                     # Can happen if progress-bar thread didn't finish in time
                     for json in target_paths:
+<<<<<<< HEAD
                         private_cli.import_json_comparisons(logger, session2, json)
+=======
+                        private_cli.import_json_comparisons(logger, _session, json)
+>>>>>>> 17edb76 (change final session assignment to use context management)
                     done = run.comparisons().count()
 
                 if done != n**2:
@@ -320,7 +330,11 @@ def run_method(  # noqa: PLR0913, PLR0915
 
                 run.cache_comparisons()  # will this needs a progress bar too with large n?
                 run.status = "Done"
+<<<<<<< HEAD
                 session2.commit()
+=======
+                _session.commit()
+>>>>>>> 17edb76 (change final session assignment to use context management)
 
             msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
             logger.info(msg)

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -136,69 +136,70 @@ def start_and_run_method(  # noqa: PLR0913
     # We should have caught all the obvious failures earlier,
     # including missing inputs or missing external tools.
     # Can now start talking to the DB.
-    session = db_orm.connect_to_db(logger, database)
+    with db_orm.connect_to_db(logger, database) as session:
+        # Reuse existing config, or log a new one
+        config = db_orm.db_configuration(
+            session,
+            method,
+            "" if tool is None else tool.exe_path.stem,
+            "" if tool is None else tool.version,
+            fragsize,
+            mode,
+            kmersize,
+            minmatch,
+            extra,
+            create=True,
+        )
 
-    # Reuse existing config, or log a new one
-    config = db_orm.db_configuration(
-        session,
-        method,
-        "" if tool is None else tool.exe_path.stem,
-        "" if tool is None else tool.version,
-        fragsize,
-        mode,
-        kmersize,
-        minmatch,
-        extra,
-        create=True,
-    )
+        n = len(fasta_names)
+        filename_to_md5 = {}
+        hashes = set()
+        with Progress(*PROGRESS_BAR_COLUMNS) as progress:
+            for filename in progress.track(fasta_names, description="Indexing FASTAs"):
+                try:
+                    md5 = file_md5sum(filename)
+                except ValueError as err:
+                    log_sys_exit(logger, str(err))
+                filename_to_md5[filename] = md5
+                if md5 in hashes:
+                    # This avoids hitting IntegrityError UNIQUE constraint failed
+                    dups = "\n" + "\n".join(
+                        sorted({str(k) for k, v in filename_to_md5.items() if v == md5})
+                    )
+                    msg = f"Multiple genomes with same MD5 checksum {md5}:{dups}"
+                    log_sys_exit(logger, msg)
+                hashes.add(md5)
+                db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    n = len(fasta_names)
-    filename_to_md5 = {}
-    hashes = set()
-    with Progress(*PROGRESS_BAR_COLUMNS) as progress:
-        for filename in progress.track(fasta_names, description="Indexing FASTAs"):
-            try:
-                md5 = file_md5sum(filename)
-            except ValueError as err:
-                log_sys_exit(logger, str(err))
-            filename_to_md5[filename] = md5
-            if md5 in hashes:
-                # This avoids hitting IntegrityError UNIQUE constraint failed
-                dups = "\n" + "\n".join(
-                    sorted({str(k) for k, v in filename_to_md5.items() if v == md5})
-                )
-                msg = f"Multiple genomes with same MD5 checksum {md5}:{dups}"
-                log_sys_exit(logger, msg)
-            hashes.add(md5)
-            db_orm.db_genome(logger, session, filename, md5, create=True)
+        # New run
+        run = db_orm.add_run(
+            session,
+            config,
+            cmdline=" ".join(sys.argv),
+            fasta_directory=fasta,
+            status="Initialising",
+            name=f"{len(filename_to_md5)} genomes using {method}"
+            if name is None
+            else name,
+            date=None,
+            fasta_to_hash=filename_to_md5,
+        )
+        session.commit()  # Redundant?
+        msg = f"{method} run setup with {n} genomes in database"
+        logger.info(msg)
 
-    # New run
-    run = db_orm.add_run(
-        session,
-        config,
-        cmdline=" ".join(sys.argv),
-        fasta_directory=fasta,
-        status="Initialising",
-        name=f"{len(filename_to_md5)} genomes using {method}" if name is None else name,
-        date=None,
-        fasta_to_hash=filename_to_md5,
-    )
-    session.commit()  # Redundant?
-    msg = f"{method} run setup with {n} genomes in database"
-    logger.info(msg)
-
-    return run_method(
-        logger,
-        executor,
-        cache,
-        temp,
-        workflow_temp,
-        filename_to_md5,
-        database,
-        log,
-        session,
-        run,
-    )
+        return run_method(
+            logger,
+            executor,
+            cache,
+            temp,
+            workflow_temp,
+            filename_to_md5,
+            database,
+            log,
+            session,
+            run,
+        )
 
 
 def run_method(  # noqa: PLR0913, PLR0915
@@ -681,100 +682,102 @@ def resume(  # noqa: C901, PLR0912, PLR0913, PLR0915
         msg = f"Database {database} does not exist"
         log_sys_exit(logger, msg)
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id)
-    if run_id is None:
-        run_id = run.run_id  # relevant if was None
-        msg = f"Resuming run-id {run_id}"
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id)
+        if run_id is None:
+            run_id = run.run_id  # relevant if was None
+            msg = f"Resuming run-id {run_id}"
+            logger.info(msg)
+        config = run.configuration
+        msg = (
+            f"This is a {config.method} run on {run.genomes.count()} genomes, "
+            f"using {config.program} version {config.version}"
+        )
         logger.info(msg)
-    config = run.configuration
-    msg = (
-        f"This is a {config.method} run on {run.genomes.count()} genomes, "
-        f"using {config.program} version {config.version}"
-    )
-    logger.info(msg)
-    if not run.genomes.count():
-        msg = f"No genomes recorded for run-id {run_id}, cannot resume."
-        log_sys_exit(logger, msg)
-
-    # The params dict has two kinds of entries,
-    # - tool paths, which ought to be handled more neatly
-    # - config entries, which ought to be named consistently and done centrally
-    tool: tools.ExternalToolData | None = None  # make type explicit for mypy
-    match config.method:
-        case "fastANI":
-            tool = tools.get_fastani()
-        case "ANIm":
-            tool = tools.get_nucmer()
-        case "dnadiff":
-            tool = tools.get_nucmer()
-        case "ANIb":
-            tool = tools.get_blastn()
-        case "skani":
-            tool = tools.get_skani()
-        case "sourmash":
-            tool = tools.get_sourmash()
-        case "external-alignment":
-            tool = None
-        case _:
-            msg = f"Unknown method {config.method} for run-id {run_id} in {database}"
+        if not run.genomes.count():
+            msg = f"No genomes recorded for run-id {run_id}, cannot resume."
             log_sys_exit(logger, msg)
-    if not tool:
-        if config.program != "" or config.version != "":
+
+        # The params dict has two kinds of entries,
+        # - tool paths, which ought to be handled more neatly
+        # - config entries, which ought to be named consistently and done centrally
+        tool: tools.ExternalToolData | None = None  # make type explicit for mypy
+        match config.method:
+            case "fastANI":
+                tool = tools.get_fastani()
+            case "ANIm":
+                tool = tools.get_nucmer()
+            case "dnadiff":
+                tool = tools.get_nucmer()
+            case "ANIb":
+                tool = tools.get_blastn()
+            case "skani":
+                tool = tools.get_skani()
+            case "sourmash":
+                tool = tools.get_sourmash()
+            case "external-alignment":
+                tool = None
+            case _:
+                msg = (
+                    f"Unknown method {config.method} for run-id {run_id} in {database}"
+                )
+                log_sys_exit(logger, msg)
+        if not tool:
+            if config.program != "" or config.version != "":
+                msg = (
+                    "We expect no tool information, but"
+                    f" run-id {run_id} used {config.program} version {config.version} instead."
+                )
+                log_sys_exit(logger, msg)
+        elif tool.exe_path.stem != config.program or tool.version != config.version:
             msg = (
-                "We expect no tool information, but"
+                f"We have {tool.exe_path.stem} version {tool.version}, but"
                 f" run-id {run_id} used {config.program} version {config.version} instead."
             )
             log_sys_exit(logger, msg)
-    elif tool.exe_path.stem != config.program or tool.version != config.version:
-        msg = (
-            f"We have {tool.exe_path.stem} version {tool.version}, but"
-            f" run-id {run_id} used {config.program} version {config.version} instead."
-        )
-        log_sys_exit(logger, msg)
 
-    del tool
+        del tool
 
-    # Now we need to check the fasta files in the directory
-    # against those included in the run...
-    fasta = Path(run.fasta_directory)
-    if not fasta.is_dir():
-        msg = f"run-id {run_id} used input folder {fasta}, but that is not a directory (now)."
-        log_sys_exit(logger, msg)
-
-    # Recombine the fasta directory name from the runs table with the plain filename from
-    # the run-genome linking table
-    filename_to_md5 = {
-        fasta / link.fasta_filename: link.genome_hash for link in run.fasta_hashes
-    }
-    for filename, md5 in filename_to_md5.items():
-        if not filename.is_file():
-            msg = (
-                f"run-id {run_id} used {filename} with MD5 {md5}"
-                f" but this FASTA file no longer exists"
-            )
+        # Now we need to check the fasta files in the directory
+        # against those included in the run...
+        fasta = Path(run.fasta_directory)
+        if not fasta.is_dir():
+            msg = f"run-id {run_id} used input folder {fasta}, but that is not a directory (now)."
             log_sys_exit(logger, msg)
 
-    # Resuming
-    run.status = "Resuming"
-    session.commit()
+        # Recombine the fasta directory name from the runs table with the plain filename from
+        # the run-genome linking table
+        filename_to_md5 = {
+            fasta / link.fasta_filename: link.genome_hash for link in run.fasta_hashes
+        }
+        for filename, md5 in filename_to_md5.items():
+            if not filename.is_file():
+                msg = (
+                    f"run-id {run_id} used {filename} with MD5 {md5}"
+                    f" but this FASTA file no longer exists"
+                )
+                log_sys_exit(logger, msg)
 
-    try:
-        return run_method(
-            logger,
-            executor,
-            cache,
-            temp,
-            wtemp,
-            filename_to_md5,
-            database,
-            log,
-            session,
-            run,
-        )
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
+        # Resuming
+        run.status = "Resuming"
+        session.commit()
+
+        try:
+            return run_method(
+                logger,
+                executor,
+                cache,
+                temp,
+                wtemp,
+                filename_to_md5,
+                database,
+                log,
+                session,
+                run,
+            )
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
 
 
 @app.command()
@@ -790,46 +793,46 @@ def list_runs(
         msg = f"Database {database} does not exist"
         log_sys_exit(logger, msg)
 
-    session = db_orm.connect_to_db(logger, database)
-    runs = session.query(db_orm.Run)
+    with db_orm.connect_to_db(logger, database) as session:
+        runs = session.query(db_orm.Run)
 
-    table = Table(
-        title=f"{runs.count()} analysis runs in {database}",
-        row_styles=["dim", ""],  # alternating zebra stripes
-    )
-    table.add_column("ID", justify="right", no_wrap=True)
-    table.add_column("Date")
-    table.add_column("Method")
-    table.add_column(Text("Done", justify="left"), justify="right", no_wrap=True)
-    table.add_column(Text("Null", justify="left"), justify="right", no_wrap=True)
-    table.add_column(Text("Miss", justify="left"), justify="right", no_wrap=True)
-    table.add_column(Text("Total", justify="left"), justify="right", no_wrap=True)
-    table.add_column("Status")
-    table.add_column("Name")
-    # Would be nice to report {conf.program} {conf.version} too,
-    # perhaps conditional on the terminal width?
-    for run in runs:
-        conf = run.configuration
-        n = run.genomes.count()
-        total = n**2
-        done = run.comparisons().count()
-        # Using is None does not work as expected, must use == None
-        nulls = run.comparisons().where(db_orm.Comparison.identity == None).count()  # noqa: E711
-        table.add_row(
-            str(run.run_id),
-            str(run.date.date()),
-            conf.method,
-            Text(
-                f"{done - nulls}",
-                style="green" if done == total and not nulls else "yellow",
-            ),
-            Text(f"{nulls}", style="red" if nulls else "green"),
-            Text(f"{total - done}", style="yellow" if done < total else "green"),
-            f"{n**2}={n}²",
-            run.status,
-            run.name,
+        table = Table(
+            title=f"{runs.count()} analysis runs in {database}",
+            row_styles=["dim", ""],  # alternating zebra stripes
         )
-    session.close()
+        table.add_column("ID", justify="right", no_wrap=True)
+        table.add_column("Date")
+        table.add_column("Method")
+        table.add_column(Text("Done", justify="left"), justify="right", no_wrap=True)
+        table.add_column(Text("Null", justify="left"), justify="right", no_wrap=True)
+        table.add_column(Text("Miss", justify="left"), justify="right", no_wrap=True)
+        table.add_column(Text("Total", justify="left"), justify="right", no_wrap=True)
+        table.add_column("Status")
+        table.add_column("Name")
+        # Would be nice to report {conf.program} {conf.version} too,
+        # perhaps conditional on the terminal width?
+        for run in runs:
+            conf = run.configuration
+            n = run.genomes.count()
+            total = n**2
+            done = run.comparisons().count()
+            # Using is None does not work as expected, must use == None
+            nulls = run.comparisons().where(db_orm.Comparison.identity == None).count()  # noqa: E711
+            table.add_row(
+                str(run.run_id),
+                str(run.date.date()),
+                conf.method,
+                Text(
+                    f"{done - nulls}",
+                    style="green" if done == total and not nulls else "yellow",
+                ),
+                Text(f"{nulls}", style="red" if nulls else "green"),
+                Text(f"{total - done}", style="yellow" if done < total else "green"),
+                f"{n**2}={n}²",
+                run.status,
+                run.name,
+            )
+
     console = Console()
     console.print(table)
     msg = f"Reporting on {len(table.rows)} runs."
@@ -865,56 +868,56 @@ def delete_run(
 
     confirm = False
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_complete=False)
-    if run_id is None:
-        run_id = run.run_id
-        logger.info("Deleting most recent run")
-        confirm = True
-
-    # Could use rish colours, match how list-runs colours the counts?
-    done = run.comparisons().count()
-    n = run.genomes.count()
-    if n and done == n**2:
-        msg = (
-            f"Run {run_id} contains all {n**2}={n}²"
-            f" {run.configuration.method} comparisons, status: {run.status}"
-        )
-        logger.info(msg)
-        confirm = True
-    else:
-        msg = (
-            f"Run {run_id} contains {done}/{n**2}={n}²"
-            f" {run.configuration.method} comparisons, status: {run.status}"
-        )
-        logger.info(msg)
-        if done:
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_complete=False)
+        if run_id is None:
+            run_id = run.run_id
+            logger.info("Deleting most recent run")
             confirm = True
-    msg = f"Run name: {run.name}"
-    logger.info(msg)
 
-    if run.status == "Running":  # should be a constant or enum?
-        # Should we also look at the date of the run? If old probably it failed.
-        msg = "Deleting a run still being computed will cause it to fail!"
-        logger.warning(msg)
-        confirm = True
+        # Could use rish colours, match how list-runs colours the counts?
+        done = run.comparisons().count()
+        n = run.genomes.count()
+        if n and done == n**2:
+            msg = (
+                f"Run {run_id} contains all {n**2}={n}²"
+                f" {run.configuration.method} comparisons, status: {run.status}"
+            )
+            logger.info(msg)
+            confirm = True
+        else:
+            msg = (
+                f"Run {run_id} contains {done}/{n**2}={n}²"
+                f" {run.configuration.method} comparisons, status: {run.status}"
+            )
+            logger.info(msg)
+            if done:
+                confirm = True
+        msg = f"Run name: {run.name}"
+        logger.info(msg)
 
-    if confirm and not force:
-        typer.confirm("Do you want to continue?", abort=True)  # pragma: no cover
+        if run.status == "Running":  # should be a constant or enum?
+            # Should we also look at the date of the run? If old probably it failed.
+            msg = "Deleting a run still being computed will cause it to fail!"
+            logger.warning(msg)
+            confirm = True
 
-    # Plan to offer an extended mode, perhaps --all, which will also
-    # delete orphaned entries in the configuration,  genomes, and
-    # comparisons tables. By default will just drop the runs entry
-    # and direct links in runs_genomes thanks to the relationship.
+        if confirm and not force:
+            click.confirm("Do you want to continue?", abort=True)  # pragma: no cover
 
-    # Explicitly delete the no longer wanted entries in runs_genomes
-    # (ought to be able to trigger this automatically in a cascade
-    # when the run itself is deleted, but that didn't work for me):
-    session.query(db_orm.RunGenomeAssociation).where(
-        db_orm.RunGenomeAssociation.run_id == run_id
-    ).delete()
-    session.delete(run)
-    session.commit()
+        # Plan to offer an extended mode, perhaps --all, which will also
+        # delete orphaned entries in the configuration,  genomes, and
+        # comparisons tables. By default will just drop the runs entry
+        # and direct links in runs_genomes thanks to the relationship.
+
+        # Explicitly delete the no longer wanted entries in runs_genomes
+        # (ought to be able to trigger this automatically in a cascade
+        # when the run itself is deleted, but that didn't work for me):
+        session.query(db_orm.RunGenomeAssociation).where(
+            db_orm.RunGenomeAssociation.run_id == run_id
+        ).delete()
+        session.delete(run)
+        session.commit()
     session.close()
     return 0
 
@@ -952,88 +955,88 @@ def export_run(  # noqa: C901, PLR0913
         logger.warning(msg)
         outdir.mkdir()
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_empty=True)
-    if run_id is None:
-        run_id = run.run_id
-        msg = f"Exporting run-id {run_id}"
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_empty=True)
+        if run_id is None:
+            run_id = run.run_id
+            msg = f"Exporting run-id {run_id}"
+            logger.info(msg)
+
+        # Question: Should we export a plain text of JSON summary of the configuration etc?
+        # Question: Should we include the run-id in the matrix filenames?
+        # Question: Should we match the property in filenames to old pyANI (e.g. coverage)?
+        method = run.configuration.method
+
+        def float_or_na(value: float | None) -> str:
+            """Format a float where represent None as NA (null in our DB)."""
+            # Should this allow configurable float formatting?
+            return "NA" if value is None else str(value)
+
+        if label == "md5":
+            mapping = lambda x: x  # noqa: E731
+        elif label == "filename":
+            mapping = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}.get
+        else:
+            mapping = {
+                _.genome_hash: filename_stem(_.fasta_filename) for _ in run.fasta_hashes
+            }.get
+
+        long_filename = f"{method}_run_{run_id}.tsv"
+        with (outdir / long_filename).open("w") as handle:
+            # Should the column names match our internal naming?
+            handle.write(
+                "#Query\tSubject\tIdentity\tQuery-Cov\tSubject-Cov\tHadamard\ttANI\tAlign-Len\tSim-Errors\n"
+            )
+            for _ in run.comparisons():
+                # Below for the matrix output we use the cached DataFrame for Hadamard.
+                # Here compute it on the fly (we might be exporting partial results).
+                hadamard = (
+                    None
+                    if _.identity is None or _.cov_query is None
+                    else _.identity * _.cov_query
+                )
+                tani = None if hadamard is None else -math_log(hadamard)
+                handle.write(
+                    f"{mapping(_.query_hash)}\t{mapping(_.subject_hash)}"
+                    f"\t{float_or_na(_.identity)}"
+                    f"\t{float_or_na(_.cov_query)}"
+                    f"\t{float_or_na(_.cov_subject)}"
+                    f"\t{float_or_na(hadamard)}"
+                    f"\t{float_or_na(tani)}"
+                    f"\t{float_or_na(_.aln_length)}"
+                    f"\t{float_or_na(_.sim_errors)}\n"
+                )
+        msg = f"Wrote long-form to {outdir}/{long_filename}"
         logger.info(msg)
 
-    # Question: Should we export a plain text of JSON summary of the configuration etc?
-    # Question: Should we include the run-id in the matrix filenames?
-    # Question: Should we match the property in filenames to old pyANI (e.g. coverage)?
-    method = run.configuration.method
+        # Reload the run checking it is complete (quick) (might abort here!),
+        # and caching the matrices if needed (slower):
+        run = db_orm.load_run(session, run_id, check_complete=True)
 
-    def float_or_na(value: float | None) -> str:
-        """Format a float where represent None as NA (null in our DB)."""
-        # Should this allow configurable float formatting?
-        return "NA" if value is None else str(value)
+        for matrix, filename in (
+            (run.identities, f"{method}_identity.tsv"),
+            (run.aln_length, f"{method}_aln_lengths.tsv"),
+            (run.sim_errors, f"{method}_sim_errors.tsv"),
+            (run.cov_query, f"{method}_query_cov.tsv"),
+            (run.hadamard, f"{method}_hadamard.tsv"),
+            (run.tani, f"{method}_tANI.tsv"),
+        ):
+            if matrix is None:  # pragma: no cover
+                # This is mainly for mypy to assert the matrix is not None
+                msg = f"Could not load run {method} matrix"
+                log_sys_exit(logger, msg)
+                return 1  # not called but mbpy doesn't understand that (yet)
 
-    if label == "md5":
-        mapping = lambda x: x  # noqa: E731
-    elif label == "filename":
-        mapping = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}.get
-    else:
-        mapping = {
-            _.genome_hash: filename_stem(_.fasta_filename) for _ in run.fasta_hashes
-        }.get
+            try:
+                matrix = run.relabelled_matrix(matrix, label)  # noqa: PLW2901
+            except ValueError as err:
+                msg = f"{err}"
+                log_sys_exit(logger, msg)
 
-    long_filename = f"{method}_run_{run_id}.tsv"
-    with (outdir / long_filename).open("w") as handle:
-        # Should the column names match our internal naming?
-        handle.write(
-            "#Query\tSubject\tIdentity\tQuery-Cov\tSubject-Cov\tHadamard\ttANI\tAlign-Len\tSim-Errors\n"
-        )
-        for _ in run.comparisons():
-            # Below for the matrix output we use the cached DataFrame for Hadamard.
-            # Here compute it on the fly (we might be exporting partial results).
-            hadamard = (
-                None
-                if _.identity is None or _.cov_query is None
-                else _.identity * _.cov_query
-            )
-            tani = None if hadamard is None else -math_log(hadamard)
-            handle.write(
-                f"{mapping(_.query_hash)}\t{mapping(_.subject_hash)}"
-                f"\t{float_or_na(_.identity)}"
-                f"\t{float_or_na(_.cov_query)}"
-                f"\t{float_or_na(_.cov_subject)}"
-                f"\t{float_or_na(hadamard)}"
-                f"\t{float_or_na(tani)}"
-                f"\t{float_or_na(_.aln_length)}"
-                f"\t{float_or_na(_.sim_errors)}\n"
-            )
-    msg = f"Wrote long-form to {outdir}/{long_filename}"
-    logger.info(msg)
+            matrix.to_csv(outdir / filename, sep="\t")
 
-    # Reload the run checking it is complete (quick) (might abort here!),
-    # and caching the matrices if needed (slower):
-    run = db_orm.load_run(session, run_id, check_complete=True)
-
-    for matrix, filename in (
-        (run.identities, f"{method}_identity.tsv"),
-        (run.aln_length, f"{method}_aln_lengths.tsv"),
-        (run.sim_errors, f"{method}_sim_errors.tsv"),
-        (run.cov_query, f"{method}_query_cov.tsv"),
-        (run.hadamard, f"{method}_hadamard.tsv"),
-        (run.tani, f"{method}_tANI.tsv"),
-    ):
-        if matrix is None:  # pragma: no cover
-            # This is mainly for mypy to assert the matrix is not None
-            msg = f"Could not load run {method} matrix"
-            log_sys_exit(logger, msg)
-            return 1  # not called but mbpy doesn't understand that (yet)
-
-        try:
-            matrix = run.relabelled_matrix(matrix, label)  # noqa: PLW2901
-        except ValueError as err:
-            msg = f"{err}"
-            log_sys_exit(logger, msg)
-
-        matrix.to_csv(outdir / filename, sep="\t")
-
-    msg = f"Wrote matrices to {outdir}/{method}_*.tsv"
-    logger.info(msg)
+        msg = f"Wrote matrices to {outdir}/{method}_*.tsv"
+        logger.info(msg)
 
     session.close()
     return 0
@@ -1064,24 +1067,24 @@ def plot_run(  # noqa: PLR0913
         logger.warning(msg)
         outdir.mkdir()
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_complete=True)
-    if run_id is None:
-        run_id = run.run_id
-        msg = f"Plotting {run.configuration.method} run-id {run_id}"
-        logger.info(msg)
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_complete=True)
+        if run_id is None:
+            run_id = run.run_id
+            msg = f"Plotting {run.configuration.method} run-id {run_id}"
+            logger.info(msg)
 
-    try:
-        from pyani_plus import plot_run  # noqa: PLC0415
+        try:
+            from pyani_plus import plot_run  # noqa: PLC0415
 
-        count = plot_run.plot_single_run(logger, run, outdir, label)
-        msg = f"Wrote {count} images to {outdir}/{run.configuration.method}_*.*"
-        logger.info(msg)
-        session.close()
-        return 0 if count else 1  # noqa: TRY300
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
+            count = plot_run.plot_single_run(logger, run, outdir, label)
+            msg = f"Wrote {count} images to {outdir}/{run.configuration.method}_*.*"
+            logger.info(msg)
+            session.close()
+            return 0 if count else 1  # noqa: TRY300
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
 
 
 @app.command()
@@ -1133,27 +1136,27 @@ def plot_run_comp(  # noqa: PLR0913
         msg = "Need at least two runs for a comparison"
         log_sys_exit(logger, msg)
 
-    session = db_orm.connect_to_db(logger, database)
-    ref_run = db_orm.load_run(session, run_id, check_complete=False)
+    with db_orm.connect_to_db(logger, database) as session:
+        ref_run = db_orm.load_run(session, run_id, check_complete=False)
 
-    if not ref_run.comparisons().count():
-        msg = f"Run {run_id} has no comparisons"
-        log_sys_exit(logger, msg)
+        if not ref_run.comparisons().count():
+            msg = f"Run {run_id} has no comparisons"
+            log_sys_exit(logger, msg)
 
-    try:
-        from pyani_plus import plot_run  # noqa: PLC0415
+        try:
+            from pyani_plus import plot_run  # noqa: PLC0415
 
-        done = plot_run.plot_run_comparison(
-            logger, session, ref_run, other_runs, outdir, columns
-        )
-        msg = f"Wrote {done} images to {outdir}/{ref_run.configuration.method}_identity_{run_id}_vs_*.*"
-        logger.info(msg)
-        session.close()
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
-    else:
-        return 0
+            done = plot_run.plot_run_comparison(
+                logger, session, ref_run, other_runs, outdir, columns
+            )
+            msg = f"Wrote {done} images to {outdir}/{ref_run.configuration.method}_identity_{run_id}_vs_*.*"
+            logger.info(msg)
+            session.close()
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
+        else:
+            return 0
 
 
 @app.command("classify", rich_help_panel="Commands")
@@ -1201,100 +1204,108 @@ def cli_classify(  # noqa: C901, PLR0912, PLR0913, PLR0915
         logger.warning(msg)
         outdir.mkdir()
 
-    session = db_orm.connect_to_db(logger, database)
-    run = db_orm.load_run(session, run_id, check_complete=True)
-    if run_id is None:
-        run_id = run.run_id
-        msg = f"Exporting run-id {run_id}"
-        logger.info(msg)
+    with db_orm.connect_to_db(logger, database) as session:
+        run = db_orm.load_run(session, run_id, check_complete=True)
+        if run_id is None:
+            run_id = run.run_id
+            msg = f"Exporting run-id {run_id}"
+            logger.info(msg)
 
-    method = run.configuration.method
+        method = run.configuration.method
 
-    matrix = None
-    if mode == "identity":
-        matrix = run.identities
-    elif mode == "tANI" and run.tani is not None:
-        matrix = run.tani.where(run.tani.isna(), run.tani * -1)
+        matrix = None
+        if mode == "identity":
+            matrix = run.identities
+        elif mode == "tANI" and run.tani is not None:
+            matrix = run.tani.where(run.tani.isna(), run.tani * -1)
 
-    if matrix is None:
-        msg = f"Could not load run {method} matrix"  # pragma: no cover
-        log_sys_exit(logger, msg)  # pragma: no cover
+        if matrix is None:
+            msg = f"Could not load run {method} matrix"  # pragma: no cover
+            log_sys_exit(logger, msg)  # pragma: no cover
 
-    done = run.comparisons().count()
-    run_genomes = run.genomes.count()
+        done = run.comparisons().count()
+        run_genomes = run.genomes.count()
 
-    single_genome_run = False
-    if done == 1 and run_genomes == 1:
-        single_genome_run = True
-        msg = f"Run {run_id} has {done} comparison across {run_genomes} genome. Reporting single clique."
-        logger.warning(msg)
-    else:
-        msg = f"Run {run_id} has {done} comparisons across {run_genomes} genomes."
-        logger.info(msg)
-
-    cov = run.cov_query
-    if cov is None:  # pragma: no cover
-        msg = f"Could not load run {method} matrix"
-        log_sys_exit(logger, msg)
-
-    try:
-        score_matrix = run.relabelled_matrix(matrix, label)
-        cov = run.relabelled_matrix(cov, label)
-    except ValueError as err:
-        msg = f"{err}"
-        log_sys_exit(logger, msg)
-
-    try:
-        # Map the string inputs to callable functions
-        coverage_agg_func = classify.AGG_FUNCS[coverage_edges]
-        identity_agg_func = classify.AGG_FUNCS[score_edges]
-
-        # Construct the graph with the correct functions
-        complete_graph = classify.construct_graph(
-            cov, score_matrix, coverage_agg_func, identity_agg_func, cov_min
-        )
-        # Finding cliques
-        if len(list(nx.connected_components(complete_graph))) != 1:
-            initial_cliques = classify.find_initial_cliques(complete_graph)
+        single_genome_run = False
+        if done == 1 and run_genomes == 1:
+            single_genome_run = True
+            msg = f"Run {run_id} has {done} comparison across {run_genomes} genome. Reporting single clique."
+            logger.warning(msg)
         else:
-            initial_cliques = []
-        recursive_cliques = classify.find_cliques_recursively(complete_graph)
+            msg = f"Run {run_id} has {done} comparisons across {run_genomes} genomes."
+            logger.info(msg)
 
-        # Get a list of unique cliques to avoid duplicates. Prioritise initial_cliques
-        unique_cliques = classify.get_unique_cliques(initial_cliques, recursive_cliques)
+        cov = run.cov_query
+        if cov is None:  # pragma: no cover
+            msg = f"Could not load run {method} matrix"
+            log_sys_exit(logger, msg)
 
-        # Determine column name based on mode
-        suffix = "identity" if mode == EnumModeClassify.identity else "-tANI"
-        column_map = {
-            "min_score": f"min_{suffix}",
-            "max_score": f"max_{suffix}",
-        }
+        try:
+            score_matrix = run.relabelled_matrix(matrix, label)
+            cov = run.relabelled_matrix(cov, label)
+        except ValueError as err:
+            msg = f"{err}"
+            log_sys_exit(logger, msg)
 
-        # Writing the results to .tsv
-        _clique_data, clique_df = classify.compute_classify_output(
-            unique_cliques, method, outdir, column_map
-        )
-        msg = f"Wrote classify output to {outdir}"
-        logger.info(msg)
+        try:
+            # Map the string inputs to callable functions
+            coverage_agg_func = classify.AGG_FUNCS[coverage_edges]
+            identity_agg_func = classify.AGG_FUNCS[score_edges]
 
-        # Only plot classify if more than one genome in comparisons and the initial graph consist of at least one clique
-        if not single_genome_run:
-            if set(clique_df["n_nodes"]) == {1}:
-                msg = "All genomes are singletons. No plot can be generated."
-                logger.warning(msg)
+            # Construct the graph with the correct functions
+            complete_graph = classify.construct_graph(
+                cov, score_matrix, coverage_agg_func, identity_agg_func, cov_min
+            )
+            # Finding cliques
+            if len(list(nx.connected_components(complete_graph))) != 1:
+                initial_cliques = classify.find_initial_cliques(complete_graph)
             else:
-                logger.info("Plotting classify output...")
-                genome_groups = classify.get_genome_cligue_ids(clique_df, suffix)
-                genome_positions = classify.get_genome_order(genome_groups)
-                classify.plot_classify(
-                    genome_positions, clique_df, outdir, method, suffix, vertical_line
-                )
-        session.close()
-    except Exception:  # pragma: nocover
-        logger.exception("Unhandled exception.")
-        return 1
-    else:
-        return 0
+                initial_cliques = []
+            recursive_cliques = classify.find_cliques_recursively(complete_graph)
+
+            # Get a list of unique cliques to avoid duplicates. Prioritise initial_cliques
+            unique_cliques = classify.get_unique_cliques(
+                initial_cliques, recursive_cliques
+            )
+
+            # Determine column name based on mode
+            suffix = "identity" if mode == EnumModeClassify.identity else "-tANI"
+            column_map = {
+                "min_score": f"min_{suffix}",
+                "max_score": f"max_{suffix}",
+            }
+
+            # Writing the results to .tsv
+            _clique_data, clique_df = classify.compute_classify_output(
+                unique_cliques, method, outdir, column_map
+            )
+            msg = f"Wrote classify output to {outdir}"
+            logger.info(msg)
+
+            # Only plot classify if more than one genome in comparisons and
+            # the initial graph consist of at least one clique
+            if not single_genome_run:
+                if set(clique_df["n_nodes"]) == {1}:
+                    msg = "All genomes are singletons. No plot can be generated."
+                    logger.warning(msg)
+                else:
+                    logger.info("Plotting classify output...")
+                    genome_groups = classify.get_genome_cligue_ids(clique_df, suffix)
+                    genome_positions = classify.get_genome_order(genome_groups)
+                    classify.plot_classify(
+                        genome_positions,
+                        clique_df,
+                        outdir,
+                        method,
+                        suffix,
+                        vertical_line,
+                    )
+            session.close()
+        except Exception:  # pragma: nocover
+            logger.exception("Unhandled exception.")
+            return 1
+        else:
+            return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -298,30 +298,33 @@ def run_method(  # noqa: PLR0913, PLR0915
             )
 
             # Reconnect to the DB
-            session = db_orm.connect_to_db(logger, database)
-            run = session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
-            done = run.comparisons().count()
-
-            if done < n**2:  # pragma: no cover
-                logger.debug(
-                    "Importing final JSON files, as not all comparisons in DB (yet)"
+            with db_orm.connect_to_db(logger, database) as _session:
+                run = (
+                    _session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
                 )
-                # Can happen if progress-bar thread didn't finish in time
-                for json in target_paths:
-                    private_cli.import_json_comparisons(logger, session, json)
                 done = run.comparisons().count()
 
-    if done != n**2:
-        # There is no obvious way to test this hypothetical failure:
-        msg = f"Only have {done} of {n}²={n**2} {method} comparisons needed"  # pragma: no cover
-        log_sys_exit(logger, msg)  # pragma: no cover
+                if done < n**2:  # pragma: no cover
+                    logger.debug(
+                        "Importing final JSON files, as not all comparisons in DB (yet)"
+                    )
+                    # Can happen if progress-bar thread didn't finish in time
+                    for json in target_paths:
+                        private_cli.import_json_comparisons(logger, _session, json)
+                    done = run.comparisons().count()
 
-    run.cache_comparisons()  # will this needs a progress bar too with large n?
-    run.status = "Done"
-    session.commit()
-    msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
-    logger.info(msg)
-    session.close()
+                if done != n**2:
+                    # There is no obvious way to test this hypothetical failure:
+                    msg = f"Only have {done} of {n}²={n**2} {method} comparisons needed"  # pragma: no cover
+                    log_sys_exit(logger, msg)  # pragma: no cover
+
+                run.cache_comparisons()  # will this needs a progress bar too with large n?
+                run.status = "Done"
+                _session.commit()
+
+            msg = f"Completed {method} run-id {run_id} with {n} genomes in database {database}"
+            logger.info(msg)
+
     return 0
 
 

--- a/pyani_plus/workflows/__init__.py
+++ b/pyani_plus/workflows/__init__.py
@@ -58,54 +58,55 @@ def progress_bar_via_db_comparisons(
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
     logger = setup_logger(None)  # this is not on the main thead!
-    session = db_orm.connect_to_db(logger, database)
-    run = session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
+    with db_orm.connect_to_db(logger, database) as session:
+        run = session.query(db_orm.Run).where(db_orm.Run.run_id == run_id).one()
 
-    already_done = run.comparisons().count()
-    total = run.genomes.count() ** 2 - already_done
+        already_done = run.comparisons().count()
+        total = run.genomes.count() ** 2 - already_done
 
-    json_time_stamps: dict[Path, float] = {}
-    json_counts: dict[Path, int] = {}
-    with Progress(*PROGRESS_BAR_COLUMNS) as progress:
-        task = progress.add_task("Comparing pairs", total=total)
-        while sum(json_counts.values()) < total:
-            time.sleep(interval)
+        json_time_stamps: dict[Path, float] = {}
+        json_counts: dict[Path, int] = {}
+        with Progress(*PROGRESS_BAR_COLUMNS) as progress:
+            task = progress.add_task("Comparing pairs", total=total)
+            while sum(json_counts.values()) < total:
+                time.sleep(interval)
 
-            # Have there been any JSON changes? Try to minimise disk access
-            for json in json_files:
-                try:
-                    if (
-                        # If new file import it
-                        json not in json_time_stamps and json.is_file()
-                    ):
-                        json_time_stamps[json] = time.time()
-                        count = import_json_comparisons(logger, session, json)
-                        msg = f"Loaded '{json.name}', {count} entries"
-                        logger.debug(msg)
-                        if count:
-                            progress.update(task, advance=count)
-                        json_counts[json] = count
-                    elif (
-                        json in json_time_stamps  # existing file
-                        and json_time_stamps[json] + 10
-                        < time.time()  # imported over 10s ago
-                        and json.is_file()  # and still there
-                    ):  # pragma: no cover
-                        last_checked = time.time()
-                        if json_time_stamps[json] < json.stat().st_mtime:
+                # Have there been any JSON changes? Try to minimise disk access
+                for json in json_files:
+                    try:
+                        if (
+                            # If new file import it
+                            json not in json_time_stamps and json.is_file()
+                        ):
+                            json_time_stamps[json] = time.time()
                             count = import_json_comparisons(logger, session, json)
-                            msg = f"Reloaded '{json.name}', now {count} entries"
+                            msg = f"Loaded '{json.name}', {count} entries"
                             logger.debug(msg)
                             if count:
-                                progress.update(task, advance=count - json_counts[json])
-                                json_counts[json] = count
-                        # Update last checked time (even if didn't reload file):
-                        json_time_stamps[json] = last_checked
-                except Exception:  # pragma: no cover
-                    # e.g. stat failed
-                    msg = f"Unhandled exception with '{json}':"
-                    logger.exception(msg)
-    session.close()
+                                progress.update(task, advance=count)
+                            json_counts[json] = count
+                        elif (
+                            json in json_time_stamps  # existing file
+                            and json_time_stamps[json] + 10
+                            < time.time()  # imported over 10s ago
+                            and json.is_file()  # and still there
+                        ):  # pragma: no cover
+                            last_checked = time.time()
+                            if json_time_stamps[json] < json.stat().st_mtime:
+                                count = import_json_comparisons(logger, session, json)
+                                msg = f"Reloaded '{json.name}', now {count} entries"
+                                logger.debug(msg)
+                                if count:
+                                    progress.update(
+                                        task, advance=count - json_counts[json]
+                                    )
+                                    json_counts[json] = count
+                            # Update last checked time (even if didn't reload file):
+                            json_time_stamps[json] = last_checked
+                    except Exception:  # pragma: no cover
+                        # e.g. stat failed
+                        msg = f"Unhandled exception with '{json}':"
+                        logger.exception(msg)
 
 
 def run_snakemake_with_progress_bar(  # noqa: PLR0913

--- a/tests/snakemake/test_anib_workflow.py
+++ b/tests/snakemake/test_anib_workflow.py
@@ -136,10 +136,9 @@ def test_rule_anib(
     for file in (input_genomes_tiny / "intermediates/ANIb").glob("*_vs_*.tsv"):
         assert filecmp.cmp(file, tmp_dir / file), f"Wrong blastn output in {file.name}"
 
-    session = connect_to_db(logger, db)
-    for json in json_targets:
-        import_json_comparisons(logger, session, json)
-    session.close()
+    with connect_to_db(logger, db) as session:
+        for json in json_targets:
+            import_json_comparisons(logger, session, json)
 
     # Check output against target fixtures
     compare_db_matrices(db, input_genomes_tiny / "matrices")

--- a/tests/snakemake/test_anim_workflow.py
+++ b/tests/snakemake/test_anim_workflow.py
@@ -142,10 +142,9 @@ def test_rule_ANIm(  # noqa: N802
         working_directory=tmp_dir,
         temp=tmp_dir,
     )
-    session = connect_to_db(logger, db)
-    for json in targets:
-        import_json_comparisons(logger, session, json)
-    session.close()
+    with connect_to_db(logger, db) as session:
+        for json in targets:
+            import_json_comparisons(logger, session, json)
 
     # Check the intermediate files
 
@@ -219,10 +218,9 @@ def test_rule_ANIm_bad_align(  # noqa: N802
         working_directory=tmp_dir,
         temp=tmp_dir,
     )
-    session = connect_to_db(logger, db)
-    for json in targets:
-        import_json_comparisons(logger, session, json)
-    session.close()
+    with connect_to_db(logger, db) as session:
+        for json in targets:
+            import_json_comparisons(logger, session, json)
 
     # Check delta-filter output against target fixtures
     for fname in (input_genomes_bad_alignments / "intermediates/ANIm").glob("*.filter"):

--- a/tests/snakemake/test_dnadiff_workflow.py
+++ b/tests/snakemake/test_dnadiff_workflow.py
@@ -174,10 +174,9 @@ def test_dnadiff(
         generated = next(tmp_dir.glob(f"*/{fname.name}"))
         assert compare_files_with_skip(fname, generated, skip=0)
 
-    session = connect_to_db(logger, db)
-    for json in json_targets:
-        import_json_comparisons(logger, session, json)
-    session.close()
+    with connect_to_db(logger, db) as session:
+        for json in json_targets:
+            import_json_comparisons(logger, session, json)
 
     compare_db_matrices(db, input_genomes_tiny / "matrices", absolute_tolerance=5e-5)
 
@@ -269,10 +268,9 @@ def test_dnadiff_bad_align(
         generated = next(tmp_dir.glob(f"*/{fname.name}"))
         assert compare_files_with_skip(fname, generated, skip=0)
 
-    session = connect_to_db(logger, db)
-    for json in json_targets:
-        import_json_comparisons(logger, session, json)
-    session.close()
+    with connect_to_db(logger, db) as session:
+        for json in json_targets:
+            import_json_comparisons(logger, session, json)
 
     compare_db_matrices(
         db, input_genomes_bad_alignments / "matrices", absolute_tolerance=5e-5

--- a/tests/snakemake/test_fastani_workflow.py
+++ b/tests/snakemake/test_fastani_workflow.py
@@ -139,9 +139,8 @@ def test_rule_fastani(
     for file in (input_genomes_tiny / "intermediates/fastANI").glob("*_vs_*.fastani"):
         assert filecmp.cmp(file, tmp_dir / file), f"Wrong fastANI output in {file.name}"
 
-    session = connect_to_db(logger, db)
-    for json in json_targets:
-        import_json_comparisons(logger, session, json)
-    session.close()
+    with connect_to_db(logger, db) as session:
+        for json in json_targets:
+            import_json_comparisons(logger, session, json)
 
     compare_db_matrices(db, input_genomes_tiny / "matrices")

--- a/tests/test_anib.py
+++ b/tests/test_anib.py
@@ -129,65 +129,67 @@ def test_running_anib(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
 
-    subject_hash = list(hash_to_filename)[1]
-    private_cli.compute_anib(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        input_genomes_tiny,
-        hash_to_filename,
-        {},  # not used for ANIb
-        query_hashes=hash_to_length,  # order should not matter!
-        subject_hash=subject_hash,
-    )
-
-    private_cli.import_json_comparisons(logger, session, tmp_json)
-
-    assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
-    assert (
-        session.query(db_orm.Comparison)
-        .where(db_orm.Comparison.subject_hash == subject_hash)
-        .count()
-        == 3  # noqa: PLR2004
-    )
-
-    # Check the intermediate fragmented FASTA files match
-    for fname in (input_genomes_tiny / "intermediates/ANIb").glob("*-fragments.fna"):
-        # Intermediate uses f"{query_hash}-fragments-{fragsize}-pid{os.getpid()}.fna"
-        tmp_frag_files = list(
-            tmp_dir.glob(f"{fname.name.rsplit('-', 1)[0]}-fragments-*.fna")
+        subject_hash = list(hash_to_filename)[1]
+        private_cli.compute_anib(
+            logger,
+            tmp_dir,
+            session,
+            run,
+            tmp_json,
+            input_genomes_tiny,
+            hash_to_filename,
+            {},  # not used for ANIb
+            query_hashes=hash_to_length,  # order should not matter!
+            subject_hash=subject_hash,
         )
-        # Only computed one row, so should be only one copy of the fragment file
-        assert len(tmp_frag_files) == 1, (tmp_frag_files, fname.name)
-        assert filecmp.cmp(fname, tmp_frag_files[0])
 
-    # Check the intermediate TSV files from blastn match
-    for fname in (input_genomes_tiny / "intermediates/ANIb").glob(
-        f"*_vs_{subject_hash}.tsv"
-    ):
-        assert filecmp.cmp(fname, tmp_dir / fname.name)
+        private_cli.import_json_comparisons(logger, session, tmp_json)
 
-    # No real need to test the ANI values here, will be done elsewhere.
-    for query_hash, query_filename in hash_to_filename.items():
-        pytest.approx(
-            get_matrix_entry(
-                input_genomes_tiny / "matrices/ANIb_identity.tsv",
-                Path(query_filename).stem,
-                Path(hash_to_filename[subject_hash]).stem,
-            )
-            == session.query(db_orm.Comparison)
-            .where(db_orm.Comparison.query_hash == query_hash)
+        assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
+        assert (
+            session.query(db_orm.Comparison)
             .where(db_orm.Comparison.subject_hash == subject_hash)
-            .one()
-            .identity
+            .count()
+            == 3  # noqa: PLR2004
         )
-    session.close()
+
+        # Check the intermediate fragmented FASTA files match
+        for fname in (input_genomes_tiny / "intermediates/ANIb").glob(
+            "*-fragments.fna"
+        ):
+            # Intermediate uses f"{query_hash}-fragments-{fragsize}-pid{os.getpid()}.fna"
+            tmp_frag_files = list(
+                tmp_dir.glob(f"{fname.name.rsplit('-', 1)[0]}-fragments-*.fna")
+            )
+            # Only computed one row, so should be only one copy of the fragment file
+            assert len(tmp_frag_files) == 1, (tmp_frag_files, fname.name)
+            assert filecmp.cmp(fname, tmp_frag_files[0])
+
+        # Check the intermediate TSV files from blastn match
+        for fname in (input_genomes_tiny / "intermediates/ANIb").glob(
+            f"*_vs_{subject_hash}.tsv"
+        ):
+            assert filecmp.cmp(fname, tmp_dir / fname.name)
+
+        # No real need to test the ANI values here, will be done elsewhere.
+        for query_hash, query_filename in hash_to_filename.items():
+            pytest.approx(
+                get_matrix_entry(
+                    input_genomes_tiny / "matrices/ANIb_identity.tsv",
+                    Path(query_filename).stem,
+                    Path(hash_to_filename[subject_hash]).stem,
+                )
+                == session.query(db_orm.Comparison)
+                .where(db_orm.Comparison.query_hash == query_hash)
+                .where(db_orm.Comparison.subject_hash == subject_hash)
+                .one()
+                .identity
+            )
+
     tmp_db.unlink()

--- a/tests/test_anim.py
+++ b/tests/test_anim.py
@@ -109,59 +109,59 @@ def test_running_anim(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
 
-    subject_hash = list(hash_to_filename)[1]
-    private_cli.compute_anim(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        input_genomes_tiny,
-        hash_to_filename,
-        {},  # not used for ANIm
-        query_hashes=hash_to_length,  # order should not matter!
-        subject_hash=subject_hash,
-    )
-
-    private_cli.import_json_comparisons(logger, session, tmp_json)
-
-    assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
-    assert (
-        session.query(db_orm.Comparison)
-        .where(db_orm.Comparison.subject_hash == subject_hash)
-        .count()
-        == 3  # noqa: PLR2004
-    )
-
-    # Could check nucmer output against target fixtures?
-
-    # Check the intermediate delta-filter files
-    subject_stem = Path(hash_to_filename[subject_hash]).stem
-    for fname in (input_genomes_tiny / "intermediates/ANIb").glob(
-        f"*_vs_{subject_stem}.delta"
-    ):
-        assert (tmp_dir / fname.name).is_file(), list(tmp_dir.glob("*"))
-        assert filecmp.cmp(fname, tmp_dir / fname.name)
-
-    # No real need to test the ANI values here, will be done elsewhere.
-    for query_hash, query_filename in hash_to_filename.items():
-        pytest.approx(
-            get_matrix_entry(
-                input_genomes_tiny / "matrices/ANIm_identity.tsv",
-                Path(query_filename).stem,
-                Path(hash_to_filename[subject_hash]).stem,
-            )
-            == session.query(db_orm.Comparison)
-            .where(db_orm.Comparison.query_hash == query_hash)
-            .where(db_orm.Comparison.subject_hash == subject_hash)
-            .one()
-            .identity
+        subject_hash = list(hash_to_filename)[1]
+        private_cli.compute_anim(
+            logger,
+            tmp_dir,
+            session,
+            run,
+            tmp_json,
+            input_genomes_tiny,
+            hash_to_filename,
+            {},  # not used for ANIm
+            query_hashes=hash_to_length,  # order should not matter!
+            subject_hash=subject_hash,
         )
-    session.close()
+
+        private_cli.import_json_comparisons(logger, session, tmp_json)
+
+        assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
+        assert (
+            session.query(db_orm.Comparison)
+            .where(db_orm.Comparison.subject_hash == subject_hash)
+            .count()
+            == 3  # noqa: PLR2004
+        )
+
+        # Could check nucmer output against target fixtures?
+
+        # Check the intermediate delta-filter files
+        subject_stem = Path(hash_to_filename[subject_hash]).stem
+        for fname in (input_genomes_tiny / "intermediates/ANIb").glob(
+            f"*_vs_{subject_stem}.delta"
+        ):
+            assert (tmp_dir / fname.name).is_file(), list(tmp_dir.glob("*"))
+            assert filecmp.cmp(fname, tmp_dir / fname.name)
+
+        # No real need to test the ANI values here, will be done elsewhere.
+        for query_hash, query_filename in hash_to_filename.items():
+            pytest.approx(
+                get_matrix_entry(
+                    input_genomes_tiny / "matrices/ANIm_identity.tsv",
+                    Path(query_filename).stem,
+                    Path(hash_to_filename[subject_hash]).stem,
+                )
+                == session.query(db_orm.Comparison)
+                .where(db_orm.Comparison.query_hash == query_hash)
+                .where(db_orm.Comparison.subject_hash == subject_hash)
+                .one()
+                .identity
+            )
+
     tmp_db.unlink()

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -48,10 +48,8 @@ def do_comparison(
             **kwargs,
         )
         logger = setup_logger(None)
-        session = db_orm.connect_to_db(logger, tmp_db.name)
-        run = session.query(db_orm.Run).one()
-        session.close()
-        return run
+        with db_orm.connect_to_db(logger, tmp_db.name) as session:
+            return session.query(db_orm.Run).one()
 
 
 def test_coverage(tmp_path: str) -> None:

--- a/tests/test_dnadiff.py
+++ b/tests/test_dnadiff.py
@@ -114,52 +114,52 @@ def test_running_dnadiff(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_length = {_.genome_hash: _.length for _ in run.genomes}
 
-    subject_hash = list(hash_to_filename)[1]
-    private_cli.compute_dnadiff(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        input_genomes_tiny,
-        hash_to_filename,
-        {},  # not used for dnadiff
-        query_hashes=hash_to_length,  # order should not matter!
-        subject_hash=subject_hash,
-    )
-    assert tmp_json.is_file()
-
-    private_cli.import_json_comparisons(logger, session, tmp_json)
-
-    assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
-    assert (
-        session.query(db_orm.Comparison)
-        .where(db_orm.Comparison.subject_hash == subject_hash)
-        .count()
-        == 3  # noqa: PLR2004
-    )
-
-    # Check the intermediate files match?
-
-    # No real need to test the ANI values here, will be done elsewhere.
-    for query_hash, query_filename in hash_to_filename.items():
-        pytest.approx(
-            get_matrix_entry(
-                input_genomes_tiny / "matrices/dnadiff_identity.tsv",
-                Path(query_filename).stem,
-                Path(hash_to_filename[subject_hash]).stem,
-            )
-            == session.query(db_orm.Comparison)
-            .where(db_orm.Comparison.query_hash == query_hash)
-            .where(db_orm.Comparison.subject_hash == subject_hash)
-            .one()
-            .identity
+        subject_hash = list(hash_to_filename)[1]
+        private_cli.compute_dnadiff(
+            logger,
+            tmp_dir,
+            session,
+            run,
+            tmp_json,
+            input_genomes_tiny,
+            hash_to_filename,
+            {},  # not used for dnadiff
+            query_hashes=hash_to_length,  # order should not matter!
+            subject_hash=subject_hash,
         )
-    session.close()
+        assert tmp_json.is_file()
+
+        private_cli.import_json_comparisons(logger, session, tmp_json)
+
+        assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
+        assert (
+            session.query(db_orm.Comparison)
+            .where(db_orm.Comparison.subject_hash == subject_hash)
+            .count()
+            == 3  # noqa: PLR2004
+        )
+
+        # Check the intermediate files match?
+
+        # No real need to test the ANI values here, will be done elsewhere.
+        for query_hash, query_filename in hash_to_filename.items():
+            pytest.approx(
+                get_matrix_entry(
+                    input_genomes_tiny / "matrices/dnadiff_identity.tsv",
+                    Path(query_filename).stem,
+                    Path(hash_to_filename[subject_hash]).stem,
+                )
+                == session.query(db_orm.Comparison)
+                .where(db_orm.Comparison.query_hash == query_hash)
+                .where(db_orm.Comparison.subject_hash == subject_hash)
+                .one()
+                .identity
+            )
+
     tmp_db.unlink()

--- a/tests/test_external_alignment.py
+++ b/tests/test_external_alignment.py
@@ -141,12 +141,12 @@ def test_simple_mock_alignment_stem(
     assert "external-alignment run setup with 3 genomes" in output, output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
 
-    run = db_orm.load_run(session, 1, check_complete=True)
-    assert run.df_identity == MOCK_3_BY_11_DF_IDENTITY
-    assert run.df_cov_query == MOCK_3_BY_11_DF_COV_QUERY
+        run = db_orm.load_run(session, 1, check_complete=True)
+        assert run.df_identity == MOCK_3_BY_11_DF_IDENTITY
+        assert run.df_cov_query == MOCK_3_BY_11_DF_COV_QUERY
 
 
 def test_simple_mock_alignment_md5(
@@ -180,15 +180,15 @@ CGGAT
     assert "external-alignment run setup with 3 genomes" in output, output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
-    run = db_orm.load_run(session, 1, check_complete=True)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
+        run = db_orm.load_run(session, 1, check_complete=True)
 
-    assert run.df_identity == (
-        '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
-        '"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
-        '"data":[[1.0,0.8,0.8],[0.8,1.0,0.8],[0.8,0.8,1.0]]}'
-    )
+        assert run.df_identity == (
+            '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
+            '"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
+            '"data":[[1.0,0.8,0.8],[0.8,1.0,0.8],[0.8,0.8,1.0]]}'
+        )
 
 
 def test_simple_mock_alignment_filename(
@@ -226,14 +226,14 @@ def test_simple_mock_alignment_filename(
     assert "external-alignment run setup with 3 genomes" in output, output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
-    run = db_orm.load_run(session, 1, check_complete=True)
-    assert run.df_identity == (
-        '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
-        '"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
-        '"data":[[1.0,0.8,0.8],[0.8,1.0,0.8],[0.8,0.8,1.0]]}'
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
+        run = db_orm.load_run(session, 1, check_complete=True)
+        assert run.df_identity == (
+            '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
+            '"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],'
+            '"data":[[1.0,0.8,0.8],[0.8,1.0,0.8],[0.8,0.8,1.0]]}'
+        )
 
 
 def test_resume(
@@ -273,11 +273,11 @@ def test_resume(
     ), output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
-    run = db_orm.load_run(session, 1, check_complete=True)
-    assert run.df_identity == MOCK_3_BY_11_DF_IDENTITY
-    assert run.df_cov_query == MOCK_3_BY_11_DF_COV_QUERY
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
+        run = db_orm.load_run(session, 1, check_complete=True)
+        assert run.df_identity == MOCK_3_BY_11_DF_IDENTITY
+        assert run.df_cov_query == MOCK_3_BY_11_DF_COV_QUERY
 
 
 def test_resume_partial(
@@ -328,11 +328,11 @@ def test_resume_partial(
     ), output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
-    run = db_orm.load_run(session, 1, check_complete=True)
-    assert run.df_identity == MOCK_3_BY_11_DF_IDENTITY
-    assert run.df_cov_query == MOCK_3_BY_11_DF_COV_QUERY
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 9  # noqa: PLR2004
+        run = db_orm.load_run(session, 1, check_complete=True)
+        assert run.df_identity == MOCK_3_BY_11_DF_IDENTITY
+        assert run.df_cov_query == MOCK_3_BY_11_DF_COV_QUERY
 
 
 def test_bad_resume(
@@ -418,17 +418,16 @@ def test_wrong_method(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, 1)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, 1)
 
-    with pytest.raises(
-        SystemExit,
-        match="Run-id 1 expected guessing results",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match="Run-id 1 expected guessing results",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_bad_program(
@@ -454,17 +453,16 @@ def test_bad_program(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, 1)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, 1)
 
-    with pytest.raises(
-        SystemExit,
-        match=r"configuration\.program='should-be-blank' unexpected",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"configuration\.program='should-be-blank' unexpected",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_bad_version(
@@ -490,17 +488,16 @@ def test_bad_version(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, 1)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, 1)
 
-    with pytest.raises(
-        SystemExit,
-        match=r"configuration\.version='should-be-blank' unexpected",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"configuration\.version='should-be-blank' unexpected",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_no_config(
@@ -526,17 +523,16 @@ def test_no_config(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, 1)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, 1)
 
-    with pytest.raises(
-        SystemExit,
-        match=r"Missing configuration\.extra setting",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"Missing configuration\.extra setting",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_bad_config(
@@ -561,17 +557,16 @@ def test_bad_config(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session)
 
-    with pytest.raises(
-        SystemExit,
-        match=r"configuration\.extra='file=example\.fasta;md5=XXX;label=stem' unexpected",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"configuration\.extra='file=example\.fasta;md5=XXX;label=stem' unexpected",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_missing_alignment(
@@ -597,17 +592,16 @@ def test_missing_alignment(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session)
 
-    with pytest.raises(
-        SystemExit,
-        match=r"Missing alignment file .*/does-not-exist\.fasta",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"Missing alignment file .*/does-not-exist\.fasta",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_bad_checksum(
@@ -637,17 +631,16 @@ def test_bad_checksum(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session)
 
-    with pytest.raises(
-        SystemExit,
-        match=r"MD5 checksum of .*/example\.fasta didn't match.",
-    ):
-        private_cli.compute_external_alignment(
-            logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"MD5 checksum of .*/example\.fasta didn't match.",
+        ):
+            private_cli.compute_external_alignment(
+                logger, tmp_dir, session, run, tmp_json, tmp_dir, {}, {}, {}, ""
+            )
 
 
 def test_bad_alignment(
@@ -686,33 +679,32 @@ AA
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session)
 
-    with pytest.raises(
-        SystemExit,
-        match=(
-            "Bad external-alignment, different lengths 3 and 2"
-            " from MGV-GENOME-0266457 and MGV-GENOME-0264574"
-        ),
-    ):
-        private_cli.compute_external_alignment(
-            logger,
-            tmp_dir,
-            session,
-            run,
-            json_file,
-            tmp_dir,
-            {},
-            {},
-            {
-                "5584c7029328dc48d33f95f0a78f7e57": 57793,
-                "689d3fd6881db36b5e08329cf23cecdd": 39253,
-                "78975d5144a1cd12e98898d573cf6536": 39594,
-            },
-            "689d3fd6881db36b5e08329cf23cecdd",
-        )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=(
+                "Bad external-alignment, different lengths 3 and 2"
+                " from MGV-GENOME-0266457 and MGV-GENOME-0264574"
+            ),
+        ):
+            private_cli.compute_external_alignment(
+                logger,
+                tmp_dir,
+                session,
+                run,
+                json_file,
+                tmp_dir,
+                {},
+                {},
+                {
+                    "5584c7029328dc48d33f95f0a78f7e57": 57793,
+                    "689d3fd6881db36b5e08329cf23cecdd": 39253,
+                    "78975d5144a1cd12e98898d573cf6536": 39594,
+                },
+                "689d3fd6881db36b5e08329cf23cecdd",
+            )
 
 
 def test_partial_alignment(
@@ -749,30 +741,10 @@ AACT
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session)
 
-    # This one should work...
-    private_cli.compute_external_alignment(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        tmp_dir,
-        {},
-        {},
-        {
-            "5584c7029328dc48d33f95f0a78f7e57": 57793,
-            "689d3fd6881db36b5e08329cf23cecdd": 39253,
-            "78975d5144a1cd12e98898d573cf6536": 39594,
-        },
-        "5584c7029328dc48d33f95f0a78f7e57",
-    )
-    with pytest.raises(
-        SystemExit,
-        match=r"Did not find subject 689d3fd6881db36b5e08329cf23cecdd in broken\.fasta",
-    ):
+        # This one should work...
         private_cli.compute_external_alignment(
             logger,
             tmp_dir,
@@ -787,6 +759,25 @@ AACT
                 "689d3fd6881db36b5e08329cf23cecdd": 39253,
                 "78975d5144a1cd12e98898d573cf6536": 39594,
             },
-            "689d3fd6881db36b5e08329cf23cecdd",
+            "5584c7029328dc48d33f95f0a78f7e57",
         )
-    session.close()
+        with pytest.raises(
+            SystemExit,
+            match=r"Did not find subject 689d3fd6881db36b5e08329cf23cecdd in broken\.fasta",
+        ):
+            private_cli.compute_external_alignment(
+                logger,
+                tmp_dir,
+                session,
+                run,
+                tmp_json,
+                tmp_dir,
+                {},
+                {},
+                {
+                    "5584c7029328dc48d33f95f0a78f7e57": 57793,
+                    "689d3fd6881db36b5e08329cf23cecdd": 39253,
+                    "78975d5144a1cd12e98898d573cf6536": 39594,
+                },
+                "689d3fd6881db36b5e08329cf23cecdd",
+            )

--- a/tests/test_fastani.py
+++ b/tests/test_fastani.py
@@ -68,29 +68,28 @@ def test_running_fastani(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
 
-    private_cli.compute_fastani(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        input_genomes_tiny,
-        hash_to_filename,
-        filename_to_hash,
-        query_hashes=hash_to_lengths,
-        subject_hash=list(hash_to_filename)[1],
-    )
+        private_cli.compute_fastani(
+            logger,
+            tmp_dir,
+            session,
+            run,
+            tmp_json,
+            input_genomes_tiny,
+            hash_to_filename,
+            filename_to_hash,
+            query_hashes=hash_to_lengths,
+            subject_hash=list(hash_to_filename)[1],
+        )
 
-    private_cli.import_json_comparisons(logger, session, tmp_json)
+        private_cli.import_json_comparisons(logger, session, tmp_json)
 
-    assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
+        assert session.query(db_orm.Comparison).count() == 3  # noqa: PLR2004
 
-    session.close()
     tmp_db.unlink()

--- a/tests/test_interrupt.py
+++ b/tests/test_interrupt.py
@@ -116,21 +116,21 @@ def test_compute_column_sigint_anib(
     output = capfd.readouterr().err
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    done = session.query(db_orm.Comparison).count()
-    genomes = session.query(db_orm.Genome).count()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        done = session.query(db_orm.Comparison).count()
+        genomes = session.query(db_orm.Genome).count()
 
-    if done < genomes:
-        assert "Interrupted with " in output, output
-    else:
-        assert 0 < done < genomes, (
-            f"Expected partial ANIb progress, not {done}/{genomes} and return {rc}"
+        if done < genomes:
+            assert "Interrupted with " in output, output
+        else:
+            assert 0 < done < genomes, (
+                f"Expected partial ANIb progress, not {done}/{genomes} and return {rc}"
+            )
+        assert rc == 0, (
+            f"Expecting return 0 on clean interruption, got {rc} with {done} done"
         )
-    assert rc == 0, (
-        f"Expecting return 0 on clean interruption, got {rc} with {done} done"
-    )
-    run = db_orm.load_run(session)
-    assert run.status == "Worker interrupted"
+        run = db_orm.load_run(session)
+        assert run.status == "Worker interrupted"
 
 
 def test_compute_column_sigint_dnadiff(
@@ -181,21 +181,21 @@ def test_compute_column_sigint_dnadiff(
     output = capfd.readouterr().err
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    done = session.query(db_orm.Comparison).count()
-    genomes = session.query(db_orm.Genome).count()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        done = session.query(db_orm.Comparison).count()
+        genomes = session.query(db_orm.Genome).count()
 
-    if done < genomes:
-        assert "Interrupted with " in output, output
-    else:
-        assert 0 < done < genomes, (
-            f"Expected partial dnadiff progress, not {done}/{genomes} and return {rc}"
+        if done < genomes:
+            assert "Interrupted with " in output, output
+        else:
+            assert 0 < done < genomes, (
+                f"Expected partial dnadiff progress, not {done}/{genomes} and return {rc}"
+            )
+        assert rc == 0, (
+            f"Expecting return 0 on clean interruption, got {rc} with {done} done"
         )
-    assert rc == 0, (
-        f"Expecting return 0 on clean interruption, got {rc} with {done} done"
-    )
-    run = db_orm.load_run(session)
-    assert run.status == "Worker interrupted"
+        run = db_orm.load_run(session)
+        assert run.status == "Worker interrupted"
 
 
 def test_compute_column_sigint_anim(
@@ -247,21 +247,21 @@ def test_compute_column_sigint_anim(
     output = capfd.readouterr().err
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    done = session.query(db_orm.Comparison).count()
-    genomes = session.query(db_orm.Genome).count()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        done = session.query(db_orm.Comparison).count()
+        genomes = session.query(db_orm.Genome).count()
 
-    if done < genomes:
-        assert "Interrupted with " in output, output
-    else:
-        assert 0 < done < genomes, (
-            f"Expected partial ANIb progress, not {done}/{genomes} and return {rc}"
+        if done < genomes:
+            assert "Interrupted with " in output, output
+        else:
+            assert 0 < done < genomes, (
+                f"Expected partial ANIb progress, not {done}/{genomes} and return {rc}"
+            )
+        assert rc == 0, (
+            f"Expecting return 0 on clean interruption, got {rc} with {done} done"
         )
-    assert rc == 0, (
-        f"Expecting return 0 on clean interruption, got {rc} with {done} done"
-    )
-    run = db_orm.load_run(session)
-    assert run.status == "Worker interrupted"
+        run = db_orm.load_run(session)
+        assert run.status == "Worker interrupted"
 
 
 def test_compute_column_sigint_external_alignment(
@@ -328,19 +328,19 @@ def test_compute_column_sigint_external_alignment(
     output = capfd.readouterr().err
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    done = session.query(db_orm.Comparison).count()
-    genomes = session.query(db_orm.Genome).count()
-    full = genomes * 2 - 1  # does first column & row at once (symmetric matrix)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        done = session.query(db_orm.Comparison).count()
+        genomes = session.query(db_orm.Genome).count()
+        full = genomes * 2 - 1  # does first column & row at once (symmetric matrix)
 
-    if done < full:
-        assert "Interrupted with " in output, output
-    else:
-        assert 0 < done < full, (
-            f"Expected partial external-alignment progress, not {done}/{full} and return {rc}"
+        if done < full:
+            assert "Interrupted with " in output, output
+        else:
+            assert 0 < done < full, (
+                f"Expected partial external-alignment progress, not {done}/{full} and return {rc}"
+            )
+        assert rc == 0, (
+            f"Expecting return 0 on clean interruption, got {rc} with {done} done"
         )
-    assert rc == 0, (
-        f"Expecting return 0 on clean interruption, got {rc} with {done} done"
-    )
-    run = db_orm.load_run(session)
-    assert run.status == "Worker interrupted"
+        run = db_orm.load_run(session)
+        assert run.status == "Worker interrupted"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -224,5 +224,5 @@ def test_json_import_errors(
     private_cli.import_comparisons(tmp_db, json=[tmp_json], debug=False, log=Path("-"))
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 1
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 1

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -60,110 +60,108 @@ def test_make_and_populate_comparisons(tmp_path: str) -> None:
     assert not tmp_db.is_file()
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-
-    uname = platform.uname()
-    config = db_orm.Configuration(
-        method="guessing",
-        program="guestimate",
-        version="v0.1.2beta3",
-        fragsize=100,
-        mode="RNG",
-        kmersize=17,
-        minmatch=0.3,
-    )
-    # Test the __repr__
-    assert repr(config) == (
-        "Configuration(configuration_id=None,"
-        " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=100, mode='RNG', kmersize=17, minmatch=0.3, extra=None)"
-    )
-    session.add(config)
-    assert config.configuration_id is None
-    session.commit()
-    assert config.configuration_id == 1
-
-    hashes = {}
-    for name in NAMES:
-        seq = "ACGT" * int(DUMMY_ALIGN_LEN / 4) * len(name)
-        fasta = f">{name}\n{seq}\n"
-        md5 = str_md5sum(fasta)
-        hashes[md5] = name
-        genome = db_orm.Genome(
-            genome_hash=md5,
-            path=f"/mnt/shared/data/{name}.fasta",
-            length=len(seq),
-            description=f"Example {name}",
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        uname = platform.uname()
+        config = db_orm.Configuration(
+            method="guessing",
+            program="guestimate",
+            version="v0.1.2beta3",
+            fragsize=100,
+            mode="RNG",
+            kmersize=17,
+            minmatch=0.3,
         )
-        # Here testing the Genome class __repr__:
-        assert repr(genome) == (
-            f"Genome(genome_hash={md5!r}, path='/mnt/shared/data/{name}.fasta',"
-            f" length={len(seq)}, description='Example {name}')"
+        # Test the __repr__
+        assert repr(config) == (
+            "Configuration(configuration_id=None,"
+            " program='guestimate', version='v0.1.2beta3',"
+            " fragsize=100, mode='RNG', kmersize=17, minmatch=0.3, extra=None)"
         )
-        session.add(genome)
-    assert len(list(config.comparisons)) == 0
-    assert session.query(db_orm.Genome).count() == len(NAMES)
+        session.add(config)
+        assert config.configuration_id is None
+        session.commit()
+        assert config.configuration_id == 1
 
-    assert config.configuration_id == 1
-    for query in hashes:
-        for subject in hashes:
-            comparison = db_orm.Comparison(
-                # configuration=config,  <-- should this work?
-                configuration_id=config.configuration_id,
-                query_hash=query,
-                subject_hash=subject,
-                identity=0.96,
-                aln_length=DUMMY_ALIGN_LEN,
-                uname_machine=uname.machine,  # CPU arch
-                uname_system=uname.system,  # Operating system
-                uname_release=uname.release,
+        hashes = {}
+        for name in NAMES:
+            seq = "ACGT" * int(DUMMY_ALIGN_LEN / 4) * len(name)
+            fasta = f">{name}\n{seq}\n"
+            md5 = str_md5sum(fasta)
+            hashes[md5] = name
+            genome = db_orm.Genome(
+                genome_hash=md5,
+                path=f"/mnt/shared/data/{name}.fasta",
+                length=len(seq),
+                description=f"Example {name}",
             )
-            assert comparison.configuration_id == config.configuration_id
-            assert repr(comparison) == (
-                "Comparison(comparison_id=None,"
-                f" query_hash={query!r}, subject_hash={subject!r},"
-                f" configuration_id={config.configuration_id},"
-                f" identity=0.96, aln_length={DUMMY_ALIGN_LEN}, sim_errors=None,"
-                f" cov_query=None, cov_subject=None, uname_system={uname.system!r},"
-                f" uname_release={uname.release!r}, uname_machine={uname.machine!r})"
+            # Here testing the Genome class __repr__:
+            assert repr(genome) == (
+                f"Genome(genome_hash={md5!r}, path='/mnt/shared/data/{name}.fasta',"
+                f" length={len(seq)}, description='Example {name}')"
             )
-            # Can't test __str__ yet as .configuration not yet live?
-            session.add(comparison)
-    session.commit()
-    assert session.query(db_orm.Comparison).count() == len(NAMES) ** 2
-    assert len(list(config.comparisons)) == len(NAMES) ** 2
-    for comparison in config.comparisons:
-        assert comparison.aln_length == DUMMY_ALIGN_LEN
-        assert str(comparison) == (
-            f"Query: {comparison.query_hash}, Subject: {comparison.subject_hash},"
-            " %ID=0.96, (guestimate v0.1.2beta3), "
-            "FragSize: 100, Mode: RNG, KmerSize: 17, MinMatch: 0.3"
-        )
+            session.add(genome)
+        assert len(list(config.comparisons)) == 0
+        assert session.query(db_orm.Genome).count() == len(NAMES)
 
-        # Check the configuration object attribute:
-        assert comparison.configuration is config  # matches the object!
-        assert comparison in config.comparisons  # back link!
+        assert config.configuration_id == 1
+        for query in hashes:
+            for subject in hashes:
+                comparison = db_orm.Comparison(
+                    # configuration=config,  <-- should this work?
+                    configuration_id=config.configuration_id,
+                    query_hash=query,
+                    subject_hash=subject,
+                    identity=0.96,
+                    aln_length=DUMMY_ALIGN_LEN,
+                    uname_machine=uname.machine,  # CPU arch
+                    uname_system=uname.system,  # Operating system
+                    uname_release=uname.release,
+                )
+                assert comparison.configuration_id == config.configuration_id
+                assert repr(comparison) == (
+                    "Comparison(comparison_id=None,"
+                    f" query_hash={query!r}, subject_hash={subject!r},"
+                    f" configuration_id={config.configuration_id},"
+                    f" identity=0.96, aln_length={DUMMY_ALIGN_LEN}, sim_errors=None,"
+                    f" cov_query=None, cov_subject=None, uname_system={uname.system!r},"
+                    f" uname_release={uname.release!r}, uname_machine={uname.machine!r})"
+                )
+                # Can't test __str__ yet as .configuration not yet live?
+                session.add(comparison)
+        session.commit()
+        assert session.query(db_orm.Comparison).count() == len(NAMES) ** 2
+        assert len(list(config.comparisons)) == len(NAMES) ** 2
+        for comparison in config.comparisons:
+            assert comparison.aln_length == DUMMY_ALIGN_LEN
+            assert str(comparison) == (
+                f"Query: {comparison.query_hash}, Subject: {comparison.subject_hash},"
+                " %ID=0.96, (guestimate v0.1.2beta3), "
+                "FragSize: 100, Mode: RNG, KmerSize: 17, MinMatch: 0.3"
+            )
 
-        # Check the query object attribute:
-        assert (
-            "Example " + hashes[comparison.query_hash] == comparison.query.description
-        )
+            # Check the configuration object attribute:
+            assert comparison.configuration is config  # matches the object!
+            assert comparison in config.comparisons  # back link!
 
-        # Check the subject object attribute:
-        assert (
-            "Example " + hashes[comparison.subject_hash]
-            == comparison.subject.description
-        )
+            # Check the query object attribute:
+            assert (
+                "Example " + hashes[comparison.query_hash]
+                == comparison.query.description
+            )
 
-    for genome in session.query(db_orm.Genome):
-        assert len(genome.query_comparisons) == len(NAMES)
-        for comparison in genome.query_comparisons:
-            assert comparison.configuration is config
-        assert len(genome.subject_comparisons) == len(NAMES)
-        for comparison in genome.subject_comparisons:
-            assert comparison.configuration is config
+            # Check the subject object attribute:
+            assert (
+                "Example " + hashes[comparison.subject_hash]
+                == comparison.subject.description
+            )
 
-    del session  # disconnect
+        for genome in session.query(db_orm.Genome):
+            assert len(genome.query_comparisons) == len(NAMES)
+            for comparison in genome.query_comparisons:
+                assert comparison.configuration is config
+            assert len(genome.subject_comparisons) == len(NAMES)
+            for comparison in genome.subject_comparisons:
+                assert comparison.configuration is config
 
     assert tmp_db.is_file()
 
@@ -182,85 +180,84 @@ def test_make_and_populate_runs(tmp_path: str) -> None:
     assert not tmp_db.is_file()
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.Configuration(
+            method="guessing",
+            program="guestimate",
+            version="v0.1.2beta3",
+            fragsize=1000,
+            kmersize=31,
+        )
+        # Test the __repr__
+        assert repr(config) == (
+            "Configuration(configuration_id=None,"
+            " program='guestimate', version='v0.1.2beta3',"
+            " fragsize=1000, mode=None, kmersize=31, minmatch=None, extra=None)"
+        )
+        session.add(config)
+        assert config.configuration_id is None
+        session.commit()
+        assert config.configuration_id == 1
 
-    config = db_orm.Configuration(
-        method="guessing",
-        program="guestimate",
-        version="v0.1.2beta3",
-        fragsize=1000,
-        kmersize=31,
-    )
-    # Test the __repr__
-    assert repr(config) == (
-        "Configuration(configuration_id=None,"
-        " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=1000, mode=None, kmersize=31, minmatch=None, extra=None)"
-    )
-    session.add(config)
-    assert config.configuration_id is None
-    session.commit()
-    assert config.configuration_id == 1
+        run_one = db_orm.Run(
+            configuration_id=config.configuration_id,
+            name="Test One",
+            cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
+            fasta_directory="../my-genomes/",
+            date=datetime.date(2024, 9, 3),
+            status="Pending",
+        )
+        assert repr(run_one) == (
+            "Run(run_id=None, configuration_id=1,"
+            " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
+            " date=datetime.date(2024, 9, 3), status='Pending',"
+            " name='Test One', ...)"
+        )
+        session.add(run_one)
+        assert run_one.run_id is None
+        session.commit()
+        assert run_one.run_id == 1
 
-    run_one = db_orm.Run(
-        configuration_id=config.configuration_id,
-        name="Test One",
-        cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
-        fasta_directory="../my-genomes/",
-        date=datetime.date(2024, 9, 3),
-        status="Pending",
-    )
-    assert repr(run_one) == (
-        "Run(run_id=None, configuration_id=1,"
-        " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
-        " date=datetime.date(2024, 9, 3), status='Pending',"
-        " name='Test One', ...)"
-    )
-    session.add(run_one)
-    assert run_one.run_id is None
-    session.commit()
-    assert run_one.run_id == 1
+        # These have not been collated yet, and there are in fact no genomes yet either:
+        assert run_one.identities is None
+        assert run_one.cov_query is None
+        assert run_one.aln_length is None
+        assert run_one.sim_errors is None
+        assert run_one.hadamard is None
+        assert run_one.tani is None
+        run_one.cache_comparisons()
+        # They now exist, but are empty:
+        assert run_one.identities is not None
+        assert run_one.identities.empty
 
-    # These have not been collated yet, and there are in fact no genomes yet either:
-    assert run_one.identities is None
-    assert run_one.cov_query is None
-    assert run_one.aln_length is None
-    assert run_one.sim_errors is None
-    assert run_one.hadamard is None
-    assert run_one.tani is None
-    run_one.cache_comparisons()
-    # They now exist, but are empty:
-    assert run_one.identities is not None
-    assert run_one.identities.empty
+        run_two = db_orm.Run(
+            configuration_id=config.configuration_id,
+            name="Test Two",
+            cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
+            fasta_directory="../my-genomes/",
+            date=datetime.date(2024, 9, 4),
+            status="Pending",
+        )
+        assert repr(run_two) == (
+            "Run(run_id=None, configuration_id=1,"
+            " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
+            " date=datetime.date(2024, 9, 4), status='Pending',"
+            " name='Test Two', ...)"
+        )
+        session.add(run_two)
+        assert run_two.run_id is None
+        session.commit()
+        assert run_two.run_id == 2  # noqa: PLR2004
 
-    run_two = db_orm.Run(
-        configuration_id=config.configuration_id,
-        name="Test Two",
-        cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
-        fasta_directory="../my-genomes/",
-        date=datetime.date(2024, 9, 4),
-        status="Pending",
-    )
-    assert repr(run_two) == (
-        "Run(run_id=None, configuration_id=1,"
-        " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
-        " date=datetime.date(2024, 9, 4), status='Pending',"
-        " name='Test Two', ...)"
-    )
-    session.add(run_two)
-    assert run_two.run_id is None
-    session.commit()
-    assert run_two.run_id == 2  # noqa: PLR2004
+        assert run_one.configuration is run_two.configuration
+        # Now check can access all the runs from a configuration object
+        runs = list(config.runs)
+        assert len(runs) == 2  # noqa: PLR2004
+        assert runs[0] is run_one
+        assert runs[1] is run_two
 
-    assert run_one.configuration is run_two.configuration
-    # Now check can access all the runs from a configuration object
-    runs = list(config.runs)
-    assert len(runs) == 2  # noqa: PLR2004
-    assert runs[0] is run_one
-    assert runs[1] is run_two
-
-    del session
     assert tmp_db.is_file()
+
     with db_orm.connect_to_db(logger, tmp_db) as new_session:
         assert new_session.query(db_orm.Configuration).count() == 1
         assert new_session.query(db_orm.Genome).count() == 0
@@ -269,190 +266,191 @@ def test_make_and_populate_runs(tmp_path: str) -> None:
     tmp_db.unlink()
 
 
-def test_make_and_populate_mock_example(tmp_path: str) -> None:  # noqa: PLR0915
+def test_make_and_populate_mock_example(tmp_path: str) -> None:
     """Populate new DB with config, runs, genomes and comparisons."""
     tmp_db = Path(tmp_path) / "mock.sqlite"
     assert not tmp_db.is_file()
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-
-    config = db_orm.Configuration(
-        method="guessing",
-        program="guestimate",
-        version="v0.1.2beta3",
-        fragsize=1000,
-        kmersize=31,
-    )
-    assert repr(config) == (
-        "Configuration(configuration_id=None,"
-        " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=1000, mode=None, kmersize=31, minmatch=None, extra=None)"
-    )
-    session.add(config)
-    session.commit()
-
-    run = db_orm.Run(
-        configuration_id=config.configuration_id,
-        name="Empty",
-        cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
-        fasta_directory="../my-genomes/",
-        date=datetime.date(2023, 12, 25),
-        status="Aborted",
-    )
-    assert repr(run) == (
-        "Run(run_id=None, configuration_id=1,"
-        " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
-        " date=datetime.date(2023, 12, 25), status='Aborted',"
-        " name='Empty', ...)"
-    )
-    session.add(run)
-
-    run = db_orm.Run(
-        configuration_id=config.configuration_id,
-        name="Test Run",
-        cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
-        fasta_directory="../my-genomes/",
-        date=datetime.date(2023, 12, 25),
-        status="Complete",
-    )
-    assert repr(run) == (
-        "Run(run_id=None, configuration_id=1,"
-        " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
-        " date=datetime.date(2023, 12, 25), status='Complete',"
-        " name='Test Run', ...)"
-    )
-    session.add(run)
-
-    hashes = []
-    # Going to record 4 genomes, and all 4x4=16 comparisons
-    # However, only going to link 2 genomes to the run (so 4 comparisons)
-    for name in ("Genome A", "Genome C", "Genome G", "Genome T"):
-        seq = (name[-1] + "ACGT") * 1000
-        md5 = str_md5sum(f">{name}\n{seq}\n")
-        hashes.append(md5)
-        genome = db_orm.Genome(
-            genome_hash=md5,
-            path=f"../my-genomes/{name}.fasta",
-            length=len(seq),
-            description=name,
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.Configuration(
+            method="guessing",
+            program="guestimate",
+            version="v0.1.2beta3",
+            fragsize=1000,
+            kmersize=31,
         )
-        assert repr(genome) == (
-            f"Genome(genome_hash={md5!r}, path='../my-genomes/{name}.fasta',"
-            f" length={len(seq)}, description='{name}')"
+        assert repr(config) == (
+            "Configuration(configuration_id=None,"
+            " program='guestimate', version='v0.1.2beta3',"
+            " fragsize=1000, mode=None, kmersize=31, minmatch=None, extra=None)"
         )
-        session.add(genome)
-        if name[-1] in ("A", "T"):
-            # Don't know the run_id until the run is committed
-            session.add(
-                db_orm.RunGenomeAssociation(
-                    run=run,
-                    genome_hash=md5,
-                    fasta_filename=f"{name}.fasta",  # no path here, just filename
+        session.add(config)
+        session.commit()
+
+        run = db_orm.Run(
+            configuration_id=config.configuration_id,
+            name="Empty",
+            cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
+            fasta_directory="../my-genomes/",
+            date=datetime.date(2023, 12, 25),
+            status="Aborted",
+        )
+        assert repr(run) == (
+            "Run(run_id=None, configuration_id=1,"
+            " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
+            " date=datetime.date(2023, 12, 25), status='Aborted',"
+            " name='Empty', ...)"
+        )
+        session.add(run)
+
+        run = db_orm.Run(
+            configuration_id=config.configuration_id,
+            name="Test Run",
+            cmdline="pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite",
+            fasta_directory="../my-genomes/",
+            date=datetime.date(2023, 12, 25),
+            status="Complete",
+        )
+        assert repr(run) == (
+            "Run(run_id=None, configuration_id=1,"
+            " cmdline='pyani_plus run -m guestimate --input ../my-genomes/ -d working.sqlite',"
+            " date=datetime.date(2023, 12, 25), status='Complete',"
+            " name='Test Run', ...)"
+        )
+        session.add(run)
+
+        hashes = []
+        # Going to record 4 genomes, and all 4x4=16 comparisons
+        # However, only going to link 2 genomes to the run (so 4 comparisons)
+        for name in ("Genome A", "Genome C", "Genome G", "Genome T"):
+            seq = (name[-1] + "ACGT") * 1000
+            md5 = str_md5sum(f">{name}\n{seq}\n")
+            hashes.append(md5)
+            genome = db_orm.Genome(
+                genome_hash=md5,
+                path=f"../my-genomes/{name}.fasta",
+                length=len(seq),
+                description=name,
+            )
+            assert repr(genome) == (
+                f"Genome(genome_hash={md5!r}, path='../my-genomes/{name}.fasta',"
+                f" length={len(seq)}, description='{name}')"
+            )
+            session.add(genome)
+            if name[-1] in ("A", "T"):
+                # Don't know the run_id until the run is committed
+                session.add(
+                    db_orm.RunGenomeAssociation(
+                        run=run,
+                        genome_hash=md5,
+                        fasta_filename=f"{name}.fasta",  # no path here, just filename
+                    )
                 )
+
+        for a in hashes:
+            for b in hashes:
+                comparison = db_orm.Comparison(
+                    configuration_id=config.configuration_id,
+                    query_hash=a,
+                    subject_hash=b,
+                    identity=0.99 if a == b else 0.96,
+                    aln_length=4996 if a == b else 4975,
+                    uname_system="Darwin",
+                    uname_release="21.6.0",
+                    uname_machine="arm64",
+                )
+                assert repr(comparison) == (
+                    "Comparison(comparison_id=None,"
+                    f" query_hash={a!r}, subject_hash={b!r},"
+                    f" configuration_id={config.configuration_id},"
+                    f" identity={0.99 if a == b else 0.96},"
+                    f" aln_length={4996 if a == b else 4975},"
+                    " sim_errors=None, cov_query=None, cov_subject=None,"
+                    " uname_system='Darwin', uname_release='21.6.0', uname_machine='arm64')"
+                )
+                session.add(comparison)
+
+        # These have not been collated yet:
+        assert run.identities is None
+        run.cache_comparisons()
+        assert run.identities is not None
+
+        # The run has only 2 genomes in it by construction
+        assert run.identities.equals(
+            pd.DataFrame(
+                data=np.array([[0.99, 0.96], [0.96, 0.99]], float),
+                index=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+                columns=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
             )
-
-    for a in hashes:
-        for b in hashes:
-            comparison = db_orm.Comparison(
-                configuration_id=config.configuration_id,
-                query_hash=a,
-                subject_hash=b,
-                identity=0.99 if a == b else 0.96,
-                aln_length=4996 if a == b else 4975,
-                uname_system="Darwin",
-                uname_release="21.6.0",
-                uname_machine="arm64",
+        )
+        assert run.cov_query.equals(
+            pd.DataFrame(
+                data=np.array([[np.nan, np.nan], [np.nan, np.nan]], float),
+                index=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+                columns=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
             )
-            assert repr(comparison) == (
-                "Comparison(comparison_id=None,"
-                f" query_hash={a!r}, subject_hash={b!r},"
-                f" configuration_id={config.configuration_id},"
-                f" identity={0.99 if a == b else 0.96},"
-                f" aln_length={4996 if a == b else 4975},"
-                " sim_errors=None, cov_query=None, cov_subject=None,"
-                " uname_system='Darwin', uname_release='21.6.0', uname_machine='arm64')"
+        )
+        assert run.aln_length.equals(
+            pd.DataFrame(
+                data=np.array([[4996, 4975], [4975, 4996]], int),
+                index=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+                columns=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
             )
-            session.add(comparison)
+        )
+        assert run.sim_errors.equals(
+            pd.DataFrame(
+                data=np.array([[np.nan, np.nan], [np.nan, np.nan]], float),
+                index=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+                columns=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+            )
+        )
+        # float * nan = nan, so hadamard is all nan:
+        assert run.hadamard.equals(
+            pd.DataFrame(
+                data=np.array([[np.nan, np.nan], [np.nan, np.nan]], float),
+                index=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+                columns=[
+                    "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
+                    "4bce437e7bdd91e35d18bfe294dee207",
+                ],
+            )
+        )
 
-    # These have not been collated yet:
-    assert run.identities is None
-    run.cache_comparisons()
-    assert run.identities is not None
-
-    # The run has only 2 genomes in it by construction
-    assert run.identities.equals(
-        pd.DataFrame(
-            data=np.array([[0.99, 0.96], [0.96, 0.99]], float),
-            index=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-            columns=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-        )
-    )
-    assert run.cov_query.equals(
-        pd.DataFrame(
-            data=np.array([[np.nan, np.nan], [np.nan, np.nan]], float),
-            index=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-            columns=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-        )
-    )
-    assert run.aln_length.equals(
-        pd.DataFrame(
-            data=np.array([[4996, 4975], [4975, 4996]], int),
-            index=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-            columns=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-        )
-    )
-    assert run.sim_errors.equals(
-        pd.DataFrame(
-            data=np.array([[np.nan, np.nan], [np.nan, np.nan]], float),
-            index=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-            columns=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-        )
-    )
-    # float * nan = nan, so hadamard is all nan:
-    assert run.hadamard.equals(
-        pd.DataFrame(
-            data=np.array([[np.nan, np.nan], [np.nan, np.nan]], float),
-            index=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-            columns=[
-                "0ac5f24c37ea8ef2d0e37fbfa61e2a43",
-                "4bce437e7bdd91e35d18bfe294dee207",
-            ],
-        )
-    )
-
-    session.commit()
+        session.commit()
 
     # For debug testing with sqlite3: import shutil; shutil.copy(tmp_db, "demo.sqlite")
-    del session, config, run, genome, comparison
+    # del session, config, run, genome, comparison
+
     assert tmp_db.is_file()
+
     with db_orm.connect_to_db(logger, tmp_db) as new_session:
         config = new_session.query(db_orm.Configuration).one()
         assert new_session.query(db_orm.Genome).count() == 4  # noqa: PLR2004
@@ -484,47 +482,46 @@ def test_add_config(tmp_path: str) -> None:
     assert not tmp_db.is_file()
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        with pytest.raises(
+            NoResultFound,
+            match="Requested configuration not already in DB",
+        ):
+            db_orm.db_configuration(
+                session,
+                method="guessing",
+                program="guestimate",
+                version="v0.1.2beta3",
+                fragsize=100,
+                kmersize=17,
+                create=False,
+            )
 
-    with pytest.raises(
-        NoResultFound,
-        match="Requested configuration not already in DB",
-    ):
-        db_orm.db_configuration(
+        config = db_orm.db_configuration(
             session,
             method="guessing",
             program="guestimate",
             version="v0.1.2beta3",
             fragsize=100,
             kmersize=17,
-            create=False,
+            create=True,
+        )
+        assert repr(config) == (
+            "Configuration(configuration_id=1,"
+            " program='guestimate', version='v0.1.2beta3',"
+            " fragsize=100, mode=None, kmersize=17, minmatch=None, extra=None)"
         )
 
-    config = db_orm.db_configuration(
-        session,
-        method="guessing",
-        program="guestimate",
-        version="v0.1.2beta3",
-        fragsize=100,
-        kmersize=17,
-        create=True,
-    )
-    assert repr(config) == (
-        "Configuration(configuration_id=1,"
-        " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=100, mode=None, kmersize=17, minmatch=None, extra=None)"
-    )
-
-    # Trying to add the exact same values should return the existing entry:
-    assert config is db_orm.db_configuration(
-        session,
-        method="guessing",
-        program="guestimate",
-        version="v0.1.2beta3",
-        fragsize=100,
-        kmersize=17,
-        create=True,
-    )
+        # Trying to add the exact same values should return the existing entry:
+        assert config is db_orm.db_configuration(
+            session,
+            method="guessing",
+            program="guestimate",
+            version="v0.1.2beta3",
+            fragsize=100,
+            kmersize=17,
+            create=True,
+        )
 
 
 def test_add_genome(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -535,17 +532,17 @@ def test_add_genome(tmp_path: str, input_genomes_tiny: Path) -> None:
     fasta = next(input_genomes_tiny.glob("*.f*"))
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    md5 = file_md5sum(fasta)
-    with pytest.raises(
-        NoResultFound,
-        match="Requested genome not already in DB",
-    ):
-        db_orm.db_genome(logger, session, fasta, md5, create=False)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        md5 = file_md5sum(fasta)
+        with pytest.raises(
+            NoResultFound,
+            match="Requested genome not already in DB",
+        ):
+            db_orm.db_genome(logger, session, fasta, md5, create=False)
 
-    genome = db_orm.db_genome(logger, session, fasta, md5, create=True)
-    # Adding again should return the original row again
-    assert genome is db_orm.db_genome(logger, session, fasta, md5, create=True)
+        genome = db_orm.db_genome(logger, session, fasta, md5, create=True)
+        # Adding again should return the original row again
+        assert genome is db_orm.db_genome(logger, session, fasta, md5, create=True)
 
 
 def test_add_genome_not_gzipped(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -560,13 +557,13 @@ def test_add_genome_not_gzipped(tmp_path: str, input_genomes_tiny: Path) -> None
     fasta.symlink_to(file)
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    md5 = file_md5sum(fasta)
-    with pytest.raises(
-        SystemExit,
-        match=r"Has \.gz ending, but .*\.gz is NOT gzip compressed",
-    ):
-        db_orm.db_genome(logger, session, fasta, md5, create=True)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        md5 = file_md5sum(fasta)
+        with pytest.raises(
+            SystemExit,
+            match=r"Has \.gz ending, but .*\.gz is NOT gzip compressed",
+        ):
+            db_orm.db_genome(logger, session, fasta, md5, create=True)
 
 
 def test_add_genome_no_gz_ext(tmp_path: str, input_gzip_bacteria: Path) -> None:
@@ -581,13 +578,13 @@ def test_add_genome_no_gz_ext(tmp_path: str, input_gzip_bacteria: Path) -> None:
     fasta.symlink_to(file)
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    md5 = file_md5sum(fasta)
-    with pytest.raises(
-        SystemExit,
-        match=r"No \.gz ending, but .*\.f.* is gzip compressed",
-    ):
-        db_orm.db_genome(logger, session, fasta, md5, create=True)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        md5 = file_md5sum(fasta)
+        with pytest.raises(
+            SystemExit,
+            match=r"No \.gz ending, but .*\.f.* is gzip compressed",
+        ):
+            db_orm.db_genome(logger, session, fasta, md5, create=True)
 
 
 def test_helper_functions(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -596,70 +593,70 @@ def test_helper_functions(tmp_path: str, input_genomes_tiny: Path) -> None:
     assert not tmp_db.is_file()
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            method="guessing",
+            program="guestimate",
+            version="v0.1.2beta3",
+            fragsize=1000,
+            kmersize=31,
+            create=True,
+        )
+        assert repr(config) == (
+            "Configuration(configuration_id=1,"
+            " program='guestimate', version='v0.1.2beta3',"
+            " fragsize=1000, mode=None, kmersize=31, minmatch=None, extra=None)"
+        )
+        fasta_to_hash = {}
+        for fasta_filename in input_genomes_tiny.glob("*.f*"):
+            md5 = file_md5sum(fasta_filename)
+            db_orm.db_genome(logger, session, fasta_filename, md5, create=True)
+            fasta_to_hash[fasta_filename] = md5
 
-    config = db_orm.db_configuration(
-        session,
-        method="guessing",
-        program="guestimate",
-        version="v0.1.2beta3",
-        fragsize=1000,
-        kmersize=31,
-        create=True,
-    )
-    assert repr(config) == (
-        "Configuration(configuration_id=1,"
-        " program='guestimate', version='v0.1.2beta3',"
-        " fragsize=1000, mode=None, kmersize=31, minmatch=None, extra=None)"
-    )
-    fasta_to_hash = {}
-    for fasta_filename in input_genomes_tiny.glob("*.f*"):
-        md5 = file_md5sum(fasta_filename)
-        db_orm.db_genome(logger, session, fasta_filename, md5, create=True)
-        fasta_to_hash[fasta_filename] = md5
+        run = db_orm.add_run(
+            session,
+            configuration=config,
+            fasta_to_hash=fasta_to_hash,
+            status="Started",
+            fasta_directory=Path("/mnt/shared/genomes/"),
+            name="Guess Run",
+            date=None,
+            cmdline="pyani_plus run --method guestimate --fasta blah blah",
+        )
+        now = run.date
+        assert repr(run) == (
+            "Run(run_id=1, configuration_id=1, "
+            "cmdline='pyani_plus run --method guestimate --fasta blah blah', "
+            f"date={now!r}, status='Started', name='Guess Run', ...)"
+        )
+        assert run.genomes.count() == len(fasta_to_hash)  # type: ignore[call-arg]
+        assert run.comparisons().count() == 0  # type: ignore[attr-defined]
 
-    run = db_orm.add_run(
-        session,
-        configuration=config,
-        fasta_to_hash=fasta_to_hash,
-        status="Started",
-        fasta_directory=Path("/mnt/shared/genomes/"),
-        name="Guess Run",
-        date=None,
-        cmdline="pyani_plus run --method guestimate --fasta blah blah",
-    )
-    now = run.date
-    assert repr(run) == (
-        "Run(run_id=1, configuration_id=1, "
-        "cmdline='pyani_plus run --method guestimate --fasta blah blah', "
-        f"date={now!r}, status='Started', name='Guess Run', ...)"
-    )
-    assert run.genomes.count() == len(fasta_to_hash)
-    assert run.comparisons().count() == 0  # not logged yet
+        # At this point in a real run we would start parallel worker jobs
+        # to compute the comparisons (possible spread over a cluster):
+        for a in fasta_to_hash.values():
+            for b in fasta_to_hash.values():
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    a,
+                    b,
+                    1 if a == b else 0.99,
+                    12345,
+                    cov_query=0.99,
+                    cov_subject=0.99,
+                )
 
-    # At this point in a real run we would start parallel worker jobs
-    # to compute the comparisons (possible spread over a cluster):
-    for a in fasta_to_hash.values():
-        for b in fasta_to_hash.values():
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                a,
-                b,
-                1 if a == b else 0.99,
-                12345,
-                cov_query=0.99,
-                cov_subject=0.99,
-            )
+        # Now that all the comparisons are in the DB, can collate and cache matrices
+        assert run.comparisons().count() == len(fasta_to_hash) ** 2  # type: ignore[attr-defined]
+        run.cache_comparisons()
+        run.status = "Complete"
+        session.commit()
+        assert run.df_hadamard == (
+            '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],"data":[[0.99,0.9801,0.9801],[0.9801,0.99,0.9801],[0.9801,0.9801,0.99]]}'
+        )
 
-    # Now that all the comparisons are in the DB, can collate and cache matrices
-    assert run.comparisons().count() == len(fasta_to_hash) ** 2
-    run.cache_comparisons()
-    run.status = "Complete"
-    session.commit()
-    assert run.df_hadamard == (
-        '{"columns":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],"index":["5584c7029328dc48d33f95f0a78f7e57","689d3fd6881db36b5e08329cf23cecdd","78975d5144a1cd12e98898d573cf6536"],"data":[[0.99,0.9801,0.9801],[0.9801,0.99,0.9801],[0.9801,0.9801,0.99]]}'
-    )
     tmp_db.unlink()
 
 
@@ -667,7 +664,6 @@ def test_insert_no_comps(tmp_path: str) -> None:
     """Checking a corner case with recording no comparisons."""
     tmp_db = Path(tmp_path) / "empty.db"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert db_orm.insert_comparisons_with_retries(logger, session, [], "test only")
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert db_orm.insert_comparisons_with_retries(logger, session, [], "test only")
     # Is there an easy way to test if this called commit or not?

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -196,9 +196,8 @@ def test_log_comparison_no_config(tmp_path: str, input_genomes_tiny: Path) -> No
     tmp_db = Path(tmp_path) / "empty.sqlite"
     assert not tmp_db.is_file()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.commit()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        session.commit()
 
     with pytest.raises(
         SystemExit, match=r"empty\.sqlite does not contain configuration_id=1"
@@ -267,12 +266,12 @@ def test_log_comparison_duplicate(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == 1
-    comp = session.query(db_orm.Comparison).one()
-    # first value should not be replaced:
-    assert comp.identity == 0.96  # noqa: PLR2004
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == 1
+        comp = session.query(db_orm.Comparison).one()
+        # first value should not be replaced:
+        assert comp.identity == 0.96  # noqa: PLR2004
+
     tmp_db.unlink()
 
 
@@ -348,14 +347,16 @@ def test_log_comparison_serial_and_skip_process_genomes(
     assert "Run identifier 1" in output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == len(fasta) ** 2
-    assert session.query(db_orm.Configuration).count() == 1
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == len(fasta) ** 2
+        assert session.query(db_orm.Configuration).count() == 1
 
-    caplog.clear()
-    private_cli.prepare_genomes(database=tmp_db, run_id=1, cache=tmp_dir)
-    output = caplog.text
-    assert "Skipping preparation, run already has all 9=3² pairwise values" in output
+        caplog.clear()
+        private_cli.prepare_genomes(database=tmp_db, run_id=1, cache=tmp_dir)
+        output = caplog.text
+        assert (
+            "Skipping preparation, run already has all 9=3² pairwise values" in output
+        )
 
 
 def test_log_comparison_parallel(
@@ -452,8 +453,8 @@ def test_log_comparison_parallel(
     assert "Run identifier 1" in output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert session.query(db_orm.Comparison).count() == len(fasta) ** 2
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert session.query(db_orm.Comparison).count() == len(fasta) ** 2
 
 
 def test_missing_db(tmp_path: str) -> None:
@@ -794,9 +795,8 @@ def test_compute_column_fastani(
     assert "Calling fastANI for 3 queries vs 5584c7029328dc48d33f95f0a78f7e57" in output
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    private_cli.import_json_comparisons(logger, session, tmp_json)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        private_cli.import_json_comparisons(logger, session, tmp_json)
 
     # This time should skip any computation:
     caplog.clear()

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -37,7 +37,7 @@ import pandas as pd
 import pytest
 
 from pyani_plus import GRAPHICS_FORMATS, db_orm, public_cli, setup_logger, tools
-from pyani_plus.public_cli_args import EnumModeSkani, ToolExecutor
+from pyani_plus.public_cli_args import EnumModeClassify, EnumModeSkani, ToolExecutor
 from pyani_plus.utils import file_md5sum
 
 
@@ -146,8 +146,8 @@ def test_delete_empty(tmp_path: str) -> None:
 
     tmp_db = Path(tmp_path) / "list-runs-empty.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as _session:
+        pass
 
     with pytest.raises(SystemExit, match=r"Database contains no runs\."):
         public_cli.delete_run(database=tmp_db)
@@ -163,8 +163,8 @@ def test_list_runs_empty(capsys: pytest.CaptureFixture[str], tmp_path: str) -> N
 
     tmp_db = Path(tmp_path) / "list runs empty.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as _session:
+        pass
 
     public_cli.list_runs(database=tmp_db)
     output = capsys.readouterr().out
@@ -178,8 +178,8 @@ def test_resume_empty(tmp_path: str) -> None:
 
     tmp_db = Path(tmp_path) / "resume-empty.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as _session:
+        pass
 
     with pytest.raises(SystemExit, match=r"Database contains no runs\."):
         public_cli.resume(database=tmp_db)
@@ -199,165 +199,167 @@ def test_partial_run(  # noqa: PLR0915
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "list runs.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 4 of the possible 9 comparisons:
-    for query_hash in list(fasta_to_hash.values())[1:]:
-        for subject_hash in list(fasta_to_hash.values())[1:]:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash == subject_hash else 0.99,
-                12345,
-            )
+        # Record 4 of the possible 9 comparisons:
+        for query_hash in list(fasta_to_hash.values())[1:]:
+            for subject_hash in list(fasta_to_hash.values())[1:]:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash == subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Empty",
-        name="Trial A",
-        fasta_to_hash={},
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Running",  # simulate a partial run not ended cleanly
-        name="Trial B",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 4/9 comparisons
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Done",
-        name="Trial C",
-        # This run uses just 2/3 genomes, but has all 4/4 = 2*2 comparisons:
-        fasta_to_hash=dict(list(fasta_to_hash.items())[1:]),
-    )
-
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 3 analysis runs in " in output, output
-    assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " fastANI │    0 │    0 │    0 │  0=0² │ Empty " in output, output
-    assert " fastANI │    4 │    0 │    5 │  9=3² │ Running " in output, output
-    assert " fastANI │    4 │    0 │    0 │  4=2² │ Done " in output, output
-
-    # Unlike a typical method calculation, we have not triggered
-    # .cache_comparisons() yet, so that will happen in export_run.
-    caplog.clear()
-    public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="md5")
-    output = caplog.text
-    assert f"Wrote matrices to {tmp_path}" in output, output
-    with (tmp_dir / "fastANI_identity.tsv").open() as handle:
-        assert (
-            handle.readline()
-            == "\t5584c7029328dc48d33f95f0a78f7e57\t78975d5144a1cd12e98898d573cf6536\n"
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Empty",
+            name="Trial A",
+            fasta_to_hash={},
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Running",  # simulate a partial run not ended cleanly
+            name="Trial B",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 4/9 comparisons
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Done",
+            name="Trial C",
+            # This run uses just 2/3 genomes, but has all 4/4 = 2*2 comparisons:
+            fasta_to_hash=dict(list(fasta_to_hash.items())[1:]),
         )
 
-    caplog.clear()
-    public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="stem")
-    output = caplog.text
-    assert f"Wrote matrices to {tmp_path}" in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 3 analysis runs in " in output, output
+        assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " fastANI │    0 │    0 │    0 │  0=0² │ Empty " in output, output
+        assert " fastANI │    4 │    0 │    5 │  9=3² │ Running " in output, output
+        assert " fastANI │    4 │    0 │    0 │  4=2² │ Done " in output, output
 
-    with (tmp_dir / "fastANI_identity.tsv").open() as handle:
-        assert handle.readline() == "\tMGV-GENOME-0266457\tOP073605\n"
+        # Unlike a typical method calculation, we have not triggered
+        # .cache_comparisons() yet, so that will happen in export_run.
+        caplog.clear()
+        public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="md5")
+        output = caplog.text
+        assert f"Wrote matrices to {tmp_path}" in output, output
+        with (tmp_dir / "fastANI_identity.tsv").open() as handle:
+            assert (
+                handle.readline()
+                == "\t5584c7029328dc48d33f95f0a78f7e57\t78975d5144a1cd12e98898d573cf6536\n"
+            )
 
-    caplog.clear()
-    public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="filename")
-    output = caplog.text
-    assert f"Wrote matrices to {tmp_path}" in output, output
-    with (tmp_dir / "fastANI_identity.tsv").open() as handle:
-        assert handle.readline() == "\tMGV-GENOME-0266457.fna\tOP073605.fasta\n"
-    caplog.clear()  # clear the above commands
+        caplog.clear()
+        public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="stem")
+        output = caplog.text
+        assert f"Wrote matrices to {tmp_path}" in output, output
 
-    # By construction run 2 is partial, only 4 of 9 matrix entries are
-    # defined - this should fail
-    with pytest.raises(
-        SystemExit,
-        match=("run-id 2 has only 4 of 3²=9 comparisons, 5 needed"),
-    ):
-        public_cli.export_run(database=tmp_db, run_id=2, outdir=tmp_dir)
-    long_file = tmp_dir / "fastANI_run_2.tsv"
-    assert long_file.is_file()
-    with long_file.open() as handle:
-        header = handle.readline().rstrip("\n").split("\t")
-        assert header == [
-            "#Query",
-            "Subject",
-            "Identity",
-            "Query-Cov",
-            "Subject-Cov",
-            "Hadamard",
-            "tANI",
-            "Align-Len",
-            "Sim-Errors",
-        ]
-        assert sum(1 for _ in handle) == 4  # noqa: PLR2004
+        with (tmp_dir / "fastANI_identity.tsv").open() as handle:
+            assert handle.readline() == "\tMGV-GENOME-0266457\tOP073605\n"
 
-    # Resuming the partial job should fail as the fastANI version won't match:
-    with pytest.raises(
-        SystemExit,
-        match=r"We have fastANI version .*, but run-id 2 used fastani version 1\.2\.3 instead\.",
-    ):
-        public_cli.resume(database=tmp_db, run_id=2)
+        caplog.clear()
+        public_cli.export_run(
+            database=tmp_db, run_id=3, outdir=tmp_dir, label="filename"
+        )
+        output = caplog.text
+        assert f"Wrote matrices to {tmp_path}" in output, output
+        with (tmp_dir / "fastANI_identity.tsv").open() as handle:
+            assert handle.readline() == "\tMGV-GENOME-0266457.fna\tOP073605.fasta\n"
+        caplog.clear()  # clear the above commands
 
-    # Resuming run 1 should fail as no genomes:
-    with pytest.raises(
-        SystemExit,
-        match=r"No genomes recorded for run-id 1, cannot resume\.",
-    ):
-        public_cli.resume(database=tmp_db, run_id=1)
+        # By construction run 2 is partial, only 4 of 9 matrix entries are
+        # defined - this should fail
+        with pytest.raises(
+            SystemExit,
+            match=("run-id 2 has only 4 of 3²=9 comparisons, 5 needed"),
+        ):
+            public_cli.export_run(database=tmp_db, run_id=2, outdir=tmp_dir)
+        long_file = tmp_dir / "fastANI_run_2.tsv"
+        assert long_file.is_file()
+        with long_file.open() as handle:
+            header = handle.readline().rstrip("\n").split("\t")
+            assert header == [
+                "#Query",
+                "Subject",
+                "Identity",
+                "Query-Cov",
+                "Subject-Cov",
+                "Hadamard",
+                "tANI",
+                "Align-Len",
+                "Sim-Errors",
+            ]
+            assert sum(1 for _ in handle) == 4  # noqa: PLR2004
 
-    output = capsys.readouterr().out
+        # Resuming the partial job should fail as the fastANI version won't match:
+        with pytest.raises(
+            SystemExit,
+            match=r"We have fastANI version .*, but run-id 2 used fastani version 1\.2\.3 instead\.",
+        ):
+            public_cli.resume(database=tmp_db, run_id=2)
 
-    # Now delete the runs, and confirm what is left behind...
-    caplog.clear()
-    public_cli.delete_run(database=tmp_db, run_id=1)
-    output = caplog.text
-    assert "Run 1 contains 0/0=0² fastANI comparisons, status: Empty\n" in output
+        # Resuming run 1 should fail as no genomes:
+        with pytest.raises(
+            SystemExit,
+            match=r"No genomes recorded for run-id 1, cannot resume\.",
+        ):
+            public_cli.resume(database=tmp_db, run_id=1)
 
-    # Forcing as this has data
-    caplog.clear()
-    public_cli.delete_run(database=tmp_db, run_id=3, force=True)
-    output = caplog.text
-    assert "Run 3 contains all 4=2² fastANI comparisons, status: Done\n" in output
+        output = capsys.readouterr().out
 
-    # Finally delete run 2, this will assume last one remaining
-    caplog.clear()
-    public_cli.delete_run(database=tmp_db, force=True)
-    output = caplog.text
-    assert "Deleting most recent run" in output, output
-    assert "Run 2 contains 4/9=3² fastANI comparisons, status: Running" in output, (
-        output
-    )
-    assert "Run name: Trial B" in output, output
-    assert "Deleting a run still being computed will cause it to fail!" in output, (
-        output
-    )
+        # Now delete the runs, and confirm what is left behind...
+        caplog.clear()
+        public_cli.delete_run(database=tmp_db, run_id=1)
+        output = caplog.text
+        assert "Run 1 contains 0/0=0² fastANI comparisons, status: Empty\n" in output
 
-    assert session.query(db_orm.Run).count() == 0
-    assert session.query(db_orm.RunGenomeAssociation).count() == 0
-    assert session.query(db_orm.Configuration).count() == 1
-    assert session.query(db_orm.Genome).count() == 3  # noqa: PLR2004
-    assert session.query(db_orm.Comparison).count() == 4  # noqa: PLR2004
-    session.close()
+        # Forcing as this has data
+        caplog.clear()
+        public_cli.delete_run(database=tmp_db, run_id=3, force=True)
+        output = caplog.text
+        assert "Run 3 contains all 4=2² fastANI comparisons, status: Done\n" in output
+
+        # Finally delete run 2, this will assume last one remaining
+        caplog.clear()
+        public_cli.delete_run(database=tmp_db, force=True)
+        output = caplog.text
+        assert "Deleting most recent run" in output, output
+        assert "Run 2 contains 4/9=3² fastANI comparisons, status: Running" in output, (
+            output
+        )
+        assert "Run name: Trial B" in output, output
+        assert "Deleting a run still being computed will cause it to fail!" in output, (
+            output
+        )
+
+        assert session.query(db_orm.Run).count() == 0
+        assert session.query(db_orm.RunGenomeAssociation).count() == 0
+        assert session.query(db_orm.Configuration).count() == 1
+        assert session.query(db_orm.Genome).count() == 3  # noqa: PLR2004
+        assert session.query(db_orm.Comparison).count() == 4  # noqa: PLR2004
+
     tmp_db.unlink()
 
 
@@ -375,39 +377,40 @@ def test_export_run_failures(tmp_path: str) -> None:
 
     tmp_db = tmp_dir / "export.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial A",
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial B",
-    )
-    with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
-        public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=3)
-    with pytest.raises(
-        SystemExit,
-        match="run-id 1 has no comparisons",
-    ):
-        public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=1)
-    # Should default to latest run, run-id 2
-    with pytest.raises(
-        SystemExit,
-        match="run-id 2 has no comparisons",
-    ):
-        public_cli.export_run(database=tmp_db, outdir=tmp_dir)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial A",
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial B",
+        )
+        with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
+            public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=3)
+        with pytest.raises(
+            SystemExit,
+            match="run-id 1 has no comparisons",
+        ):
+            public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=1)
+        # Should default to latest run, run-id 2
+        with pytest.raises(
+            SystemExit,
+            match="run-id 2 has no comparisons",
+        ):
+            public_cli.export_run(database=tmp_db, outdir=tmp_dir)
+
     tmp_db.unlink()
 
 
@@ -431,36 +434,35 @@ def test_export_duplicate_stem(tmp_path: str, input_genomes_tiny: Path) -> None:
 
     tmp_db = tmp_dir / "dup-stems.db"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    fasta_to_hash = {fasta: file_md5sum(fasta) for fasta in tmp_fasta.glob("*.fa*")}
-    for fasta, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, fasta, md5, create=True)
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Done",
-        name="Trial B",
-        fasta_to_hash=fasta_to_hash,
-    )
-    for query_hash in list(fasta_to_hash.values()):
-        for subject_hash in list(fasta_to_hash.values()):
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash == subject_hash else 0.99,
-                12345,
-                cov_subject=1.0 if query_hash == subject_hash else 0.95,
-                cov_query=1.0 if query_hash == subject_hash else 0.95,
-            )
-    session.commit()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        fasta_to_hash = {fasta: file_md5sum(fasta) for fasta in tmp_fasta.glob("*.fa*")}
+        for fasta, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, fasta, md5, create=True)
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Done",
+            name="Trial B",
+            fasta_to_hash=fasta_to_hash,
+        )
+        for query_hash in list(fasta_to_hash.values()):
+            for subject_hash in list(fasta_to_hash.values()):
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash == subject_hash else 0.99,
+                    12345,
+                    cov_subject=1.0 if query_hash == subject_hash else 0.95,
+                    cov_query=1.0 if query_hash == subject_hash else 0.95,
+                )
+        session.commit()
 
     with pytest.raises(
         SystemExit,
@@ -489,42 +491,42 @@ def test_plot_run_failures(tmp_path: str) -> None:
 
     logger = setup_logger(None)
     tmp_db = tmp_dir / "export.sqlite"
-    session = db_orm.connect_to_db(logger, tmp_db)
-    with pytest.raises(SystemExit, match=r"Database contains no runs\."):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        with pytest.raises(SystemExit, match=r"Database contains no runs\."):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
 
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial A",
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial B",
-    )
-    with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=3)
-    with pytest.raises(
-        SystemExit,
-        match="run-id 1 has no comparisons",
-    ):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=1)
-    # Should default to latest run, run-id 2
-    with pytest.raises(
-        SystemExit,
-        match="run-id 2 has no comparisons",
-    ):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial A",
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial B",
+        )
+        with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=3)
+        with pytest.raises(
+            SystemExit,
+            match="run-id 1 has no comparisons",
+        ):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=1)
+        # Should default to latest run, run-id 2
+        with pytest.raises(
+            SystemExit,
+            match="run-id 2 has no comparisons",
+        ):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
 
 
 def test_plot_run_comp_failures(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -538,64 +540,66 @@ def test_plot_run_comp_failures(tmp_path: str, input_genomes_tiny: Path) -> None
 
     tmp_db = tmp_dir / "export.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    with pytest.raises(
-        SystemExit,
-        match=r"Database has no run-id 1\. Use the list-runs command for more information.",
-    ):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        with pytest.raises(
+            SystemExit,
+            match=r"Database has no run-id 1\. Use the list-runs command for more information.",
+        ):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
 
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial A",
-    )
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial B",
-        fasta_to_hash=fasta_to_hash,
-    )
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial A",
+        )
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial B",
+            fasta_to_hash=fasta_to_hash,
+        )
 
-    with pytest.raises(SystemExit, match="Run 1 has no comparisons"):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
+        with pytest.raises(SystemExit, match="Run 1 has no comparisons"):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
 
-    with pytest.raises(SystemExit, match="Need at least two runs for a comparison"):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2")
+        with pytest.raises(SystemExit, match="Need at least two runs for a comparison"):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2")
 
-    with pytest.raises(
-        SystemExit, match="Expected comma separated list of runs, not: 2-1"
-    ):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2-1")
+        with pytest.raises(
+            SystemExit, match="Expected comma separated list of runs, not: 2-1"
+        ):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2-1")
 
-    with pytest.raises(SystemExit, match="Runs 2 and 1 have no comparisons in common"):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2,1")
+        with pytest.raises(
+            SystemExit, match="Runs 2 and 1 have no comparisons in common"
+        ):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2,1")
 
 
 def test_anim(
@@ -620,24 +624,23 @@ def test_anim(
     assert "Database already has 0 of 3²=9 ANIm comparisons, 9 needed\n" in output
     logger = setup_logger(None)
 
-    session = db_orm.connect_to_db(logger, tmp_db)
-    count = session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        count = session.query(db_orm.Comparison).count()
+        session.close()
 
-    # Now do it again - it should reuse the calculations:
-    caplog.clear()
-    public_cli.cli_anim(
-        database=tmp_db,
-        fasta=input_genomes_tiny,
-        name="Simple names",
-        create_db=False,
-    )
-    output = caplog.text
-    assert "Database already has all 3²=9 ANIm comparisons\n" in output
+        # Now do it again - it should reuse the calculations:
+        caplog.clear()
+        public_cli.cli_anim(
+            database=tmp_db,
+            fasta=input_genomes_tiny,
+            name="Simple names",
+            create_db=False,
+        )
+        output = caplog.text
+        assert "Database already has all 3²=9 ANIm comparisons\n" in output
 
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert count == session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert count == session.query(db_orm.Comparison).count()
 
     public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=2)
     compare_matrix_files(
@@ -664,17 +667,15 @@ def test_anim_gzip(
 
     logger = setup_logger(None)
     # Now do it again but with the decompressed files - should reuse calculations:
-    session = db_orm.connect_to_db(logger, tmp_db)
-    count = session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        count = session.query(db_orm.Comparison).count()
 
     public_cli.cli_anim(
         database=tmp_db, fasta=input_genomes_tiny, name="Test Run", create_db=False
     )
 
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert count == session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert count == session.query(db_orm.Comparison).count()
 
 
 def test_anim_fasta_empty(
@@ -729,10 +730,9 @@ def test_dnadiff(
     output = caplog.text
     assert "Database already has 0 of 3²=9 dnadiff comparisons, 9 needed\n" in output
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.name == "3 genomes using dnadiff"
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.name == "3 genomes using dnadiff"
 
     # Now do it again - it should reuse the calculations:
     caplog.clear()
@@ -770,10 +770,9 @@ def test_dnadiff_gzip(
         atol=5e-5,
     )
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.name == "3 genomes using dnadiff"
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.name == "3 genomes using dnadiff"
 
 
 def test_anib(
@@ -1095,68 +1094,68 @@ def test_resume_partial_fastani(
     tmp_db = Path(tmp_path) / "partial resume.sqlite"
     tool = tools.get_fastani()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "fastANI",
-        tool.exe_path.stem,
-        tool.version,
-        kmersize=14,
-        fragsize=2500,
-        minmatch=0.3,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "fastANI",
+            tool.exe_path.stem,
+            tool.version,
+            kmersize=14,
+            fragsize=2500,
+            minmatch=0.3,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 8 of the possible 9 comparisons:
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            if query_hash == genomes[2] and subject_hash == genomes[0]:
-                # Skip one comparison
-                continue
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record 8 of the possible 9 comparisons:
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                if query_hash == genomes[2] and subject_hash == genomes[0]:
+                    # Skip one comparison
+                    continue
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " fastANI │    8 │    0 │    1 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " fastANI │    8 │    0 │    1 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 8 of 3²=9 fastANI comparisons, 1 needed" in output, (
-        output
-    )
+        caplog.clear()
+        public_cli.resume(database=tmp_db)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert (
+            "Database already has 8 of 3²=9 fastANI comparisons, 1 needed" in output
+        ), output
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " fastANI │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " fastANI │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_anib(
@@ -1170,64 +1169,66 @@ def test_resume_partial_anib(
     tmp_db = Path(tmp_path) / "resume.sqlite"
     tool = tools.get_blastn()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "ANIb",
-        tool.exe_path.stem,
-        tool.version,
-        fragsize=1234,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "ANIb",
+            tool.exe_path.stem,
+            tool.version,
+            fragsize=1234,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 8 of the possible 9 comparisons:
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            if query_hash == genomes[2] and subject_hash == genomes[0]:
-                # Skip one comparison
-                continue
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record 8 of the possible 9 comparisons:
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                if query_hash == genomes[2] and subject_hash == genomes[0]:
+                    # Skip one comparison
+                    continue
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus anib ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " ANIb   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus anib ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " ANIb   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 8 of 3²=9 ANIb comparisons, 1 needed" in output, output
+        caplog.clear()
+        public_cli.resume(database=tmp_db)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert "Database already has 8 of 3²=9 ANIb comparisons, 1 needed" in output, (
+            output
+        )
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " ANIb   │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " ANIb   │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_anim(
@@ -1241,64 +1242,66 @@ def test_resume_partial_anim(
     tmp_db = Path(tmp_path) / "resume.sqlite"
     tool = tools.get_nucmer()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "ANIm",
-        tool.exe_path.stem,
-        tool.version,
-        mode="maxmatch",
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "ANIm",
+            tool.exe_path.stem,
+            tool.version,
+            mode="maxmatch",
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 8 of the possible 9 comparisons:
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            if query_hash == genomes[2] and subject_hash == genomes[0]:
-                # Skip one comparison
-                continue
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record 8 of the possible 9 comparisons:
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                if query_hash == genomes[2] and subject_hash == genomes[0]:
+                    # Skip one comparison
+                    continue
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus ANIm --mode maxmatch ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " ANIm   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus ANIm --mode maxmatch ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " ANIm   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 8 of 3²=9 ANIm comparisons, 1 needed" in output, output
+        caplog.clear()
+        public_cli.resume(database=tmp_db)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert "Database already has 8 of 3²=9 ANIm comparisons, 1 needed" in output, (
+            output
+        )
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " ANIm   │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " ANIm   │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_skani(
@@ -1313,63 +1316,63 @@ def test_resume_partial_skani(
     tmp_db = tmp_dir / "resume_skani.sqlite"
     tool = tools.get_skani()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "skani",
-        tool.exe_path.stem,
-        tool.version,
-        mode=EnumModeSkani.fast,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "skani",
+            tool.exe_path.stem,
+            tool.version,
+            mode=EnumModeSkani.fast,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 4 of the possible 9 comparisons,
-    # mimicking what might happen when a 2x2 run is expanded to 3x3
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes[:-1]:
-        for subject_hash in genomes[:-1]:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-            )
+        # Record 4 of the possible 9 comparisons,
+        # mimicking what might happen when a 2x2 run is expanded to 3x3
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes[:-1]:
+            for subject_hash in genomes[:-1]:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus skani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " skani  │    4 │    0 │    5 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus skani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " skani  │    4 │    0 │    5 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db, cache=tmp_dir)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 4 of 3²=9 skani comparisons, 5 needed" in output, (
-        output
-    )
+        caplog.clear()
+        public_cli.resume(database=tmp_db, cache=tmp_dir)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert "Database already has 4 of 3²=9 skani comparisons, 5 needed" in output, (
+            output
+        )
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " skani  │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " skani  │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_sourmash(
@@ -1384,64 +1387,64 @@ def test_resume_partial_sourmash(
     tmp_db = tmp_dir / "resume sourmash.sqlite"
     tool = tools.get_sourmash()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "sourmash",
-        tool.exe_path.stem,
-        tool.version,
-        kmersize=31,  # must be 31 to match the sig files in fixtures
-        extra="scaled=300",
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "sourmash",
+            tool.exe_path.stem,
+            tool.version,
+            kmersize=31,  # must be 31 to match the sig files in fixtures
+            extra="scaled=300",
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 4 of the possible 9 comparisons,
-    # mimicking what might happen when a 2x2 run is expanded to 3x3
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes[:-1]:
-        for subject_hash in genomes[:-1]:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-            )
+        # Record 4 of the possible 9 comparisons,
+        # mimicking what might happen when a 2x2 run is expanded to 3x3
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes[:-1]:
+            for subject_hash in genomes[:-1]:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus sourmash ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method   ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " sourmash │    4 │    0 │    5 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus sourmash ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method   ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " sourmash │    4 │    0 │    5 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db, cache=tmp_dir)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 4 of 3²=9 sourmash comparisons, 5 needed" in output, (
-        output
-    )
+        caplog.clear()
+        public_cli.resume(database=tmp_db, cache=tmp_dir)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert (
+            "Database already has 4 of 3²=9 sourmash comparisons, 5 needed" in output
+        ), output
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " sourmash │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " sourmash │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_dir_gone(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -1449,76 +1452,75 @@ def test_resume_dir_gone(tmp_path: str, input_genomes_tiny: Path) -> None:
     tmp_db = Path(tmp_path) / "resume.sqlite"
     tool = tools.get_fastani()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "fastANI",
-        tool.exe_path.stem,
-        tool.version,
-        kmersize=14,
-        fragsize=2500,
-        minmatch=0.3,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "fastANI",
+            tool.exe_path.stem,
+            tool.version,
+            kmersize=14,
+            fragsize=2500,
+            minmatch=0.3,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani ...",
-        fasta_directory=Path("/mnt/shared/old"),
-        status="Partial",
-        name="Test how resuming without input directory present fails",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani ...",
+            fasta_directory=Path("/mnt/shared/old"),
+            status="Partial",
+            name="Test how resuming without input directory present fails",
+            fasta_to_hash=fasta_to_hash,
+        )
+        session.close()
 
-    with pytest.raises(
-        SystemExit,
-        match=r"run-id 1 used input folder /mnt/shared/old, but that is not a directory \(now\).",
-    ):
-        public_cli.resume(database=tmp_db)
+        with pytest.raises(
+            SystemExit,
+            match=r"run-id 1 used input folder /mnt/shared/old, but that is not a directory \(now\).",
+        ):
+            public_cli.resume(database=tmp_db)
 
 
 def test_resume_unknown(tmp_path: str, input_genomes_tiny: Path) -> None:
     """Check expected failure trying to resume an unknown method."""
     tmp_db = Path(tmp_path) / "resume.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "guessing",
-        "gestimator",
-        "1.2.3b4",
-        kmersize=51,
-        fragsize=999,
-        minmatch=0.25,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "guessing",
+            "gestimator",
+            "1.2.3b4",
+            kmersize=51,
+            fragsize=999,
+            minmatch=0.25,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test how resuming from an unknown method fails",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test how resuming from an unknown method fails",
+            fasta_to_hash=fasta_to_hash,
+        )
 
     with pytest.raises(
         SystemExit,
@@ -1536,32 +1538,101 @@ def test_resume_complete(
     caplog.set_level(logging.INFO)
     tmp_db = Path(tmp_path) / "resume.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        for index, (method, tool) in enumerate(
+            [
+                ("ANIm", tools.get_nucmer()),
+                ("dnadiff", tools.get_nucmer()),
+                ("ANIb", tools.get_blastn()),
+                ("fastANI", tools.get_fastani()),
+                ("skani", tools.get_skani()),
+                ("sourmash", tools.get_sourmash()),
+            ]
+        ):
+            config = db_orm.db_configuration(
+                session,
+                method,
+                tool.exe_path.stem,
+                tool.version,
+                create=True,
+            )
 
-    for index, (method, tool) in enumerate(
-        [
-            ("ANIm", tools.get_nucmer()),
-            ("dnadiff", tools.get_nucmer()),
-            ("ANIb", tools.get_blastn()),
-            ("fastANI", tools.get_fastani()),
-            ("skani", tools.get_skani()),
-            ("sourmash", tools.get_sourmash()),
-        ]
-    ):
+            fasta_to_hash = {
+                filename: file_md5sum(filename)
+                for filename in sorted(input_genomes_tiny.glob("*.f*"))
+            }
+            for filename, md5 in fasta_to_hash.items():
+                db_orm.db_genome(logger, session, filename, md5, create=True)
+
+            # Record dummy values for all of the possible 9 comparisons:
+            for query_hash in fasta_to_hash.values():
+                for subject_hash in fasta_to_hash.values():
+                    db_orm.db_comparison(
+                        session,
+                        config.configuration_id,
+                        query_hash,
+                        subject_hash,
+                        1.0 if query_hash == subject_hash else 0.99,
+                        12345,
+                    )
+
+            db_orm.add_run(
+                session,
+                config,
+                cmdline=f"pyani {method} --database ...",
+                fasta_directory=input_genomes_tiny,
+                status="Complete",
+                name=f"Test resuming a complete {method} run",
+                fasta_to_hash=fasta_to_hash,
+            )
+            caplog.clear()
+            public_cli.resume(database=tmp_db)
+            output = caplog.text
+            assert f"Resuming run-id {index + 1}\n" in output, output
+            assert f"Database already has all 3²=9 {method} comparisons" in output, (
+                output
+            )
+
+
+def test_resume_fasta_gone(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: str,
+    input_genomes_tiny: Path,
+) -> None:
+    """Check resume error handling when a FASTA file is missing."""
+    caplog.set_level(logging.INFO)
+    tmp_dir = Path(tmp_path)
+    tmp_indir = tmp_dir / "input"
+    tmp_indir.mkdir()
+    tmp_db = tmp_dir / "resume.sqlite"
+    logger = setup_logger(None)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        tool = tools.get_blastn()
         config = db_orm.db_configuration(
             session,
-            method,
+            "ANIb",
             tool.exe_path.stem,
             tool.version,
+            fragsize=1500,
             create=True,
         )
 
+        # Record the genome entries under input_genomes_tiny
         fasta_to_hash = {
             filename: file_md5sum(filename)
             for filename in sorted(input_genomes_tiny.glob("*.f*"))
         }
         for filename, md5 in fasta_to_hash.items():
             db_orm.db_genome(logger, session, filename, md5, create=True)
+
+        # Setup a subset under tmp_dir
+        for filename in list(fasta_to_hash)[:-1]:
+            fasta = Path(filename)
+            (tmp_indir / fasta.name).symlink_to(fasta)
+        assert len(fasta_to_hash) - 1 == len(list(tmp_indir.glob("*.f*"))), list(
+            tmp_indir.glob("*.f*")
+        )
+        missing = list(fasta_to_hash)[-1]
 
         # Record dummy values for all of the possible 9 comparisons:
         for query_hash in fasta_to_hash.values():
@@ -1578,110 +1649,42 @@ def test_resume_complete(
         db_orm.add_run(
             session,
             config,
-            cmdline=f"pyani {method} --database ...",
-            fasta_directory=input_genomes_tiny,
+            cmdline="pyani ANIb --database ...",
+            fasta_directory=tmp_indir,  # NOT using input_genomes_tiny
             status="Complete",
-            name=f"Test resuming a complete {method} run",
+            name="Test resuming when the FASTA files have gone",
             fasta_to_hash=fasta_to_hash,
         )
+
+        # Won't work with a FASTA missing:
+        with pytest.raises(
+            SystemExit,
+            match=(
+                f"run-id 1 used .*/{Path(missing).name} with MD5 {fasta_to_hash[missing]}"
+                " but this FASTA file no longer exists"
+            ),
+        ):
+            public_cli.resume(database=tmp_db)
+
+        # Should work with all the FASTA files, even though now in a different directory
+        # to that logged in the genome table (as could happen via an older run):
+        (tmp_indir / Path(missing).name).symlink_to(Path(missing))
         caplog.clear()
         public_cli.resume(database=tmp_db)
         output = caplog.text
-        assert f"Resuming run-id {index + 1}\n" in output, output
-        assert f"Database already has all 3²=9 {method} comparisons" in output, output
+        assert "Database already has all 3²=9 ANIb comparisons" in output, output
 
-
-def test_resume_fasta_gone(
-    caplog: pytest.LogCaptureFixture,
-    tmp_path: str,
-    input_genomes_tiny: Path,
-) -> None:
-    """Check resume error handling when a FASTA file is missing."""
-    caplog.set_level(logging.INFO)
-    tmp_dir = Path(tmp_path)
-    tmp_indir = tmp_dir / "input"
-    tmp_indir.mkdir()
-    tmp_db = tmp_dir / "resume.sqlite"
-    logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    tool = tools.get_blastn()
-    config = db_orm.db_configuration(
-        session,
-        "ANIb",
-        tool.exe_path.stem,
-        tool.version,
-        fragsize=1500,
-        create=True,
-    )
-
-    # Record the genome entries under input_genomes_tiny
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
-
-    # Setup a subset under tmp_dir
-    for filename in list(fasta_to_hash)[:-1]:
-        fasta = Path(filename)
-        (tmp_indir / fasta.name).symlink_to(fasta)
-    assert len(fasta_to_hash) - 1 == len(list(tmp_indir.glob("*.f*"))), list(
-        tmp_indir.glob("*.f*")
-    )
-    missing = list(fasta_to_hash)[-1]
-
-    # Record dummy values for all of the possible 9 comparisons:
-    for query_hash in fasta_to_hash.values():
-        for subject_hash in fasta_to_hash.values():
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash == subject_hash else 0.99,
-                12345,
-            )
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani ANIb --database ...",
-        fasta_directory=tmp_indir,  # NOT using input_genomes_tiny
-        status="Complete",
-        name="Test resuming when the FASTA files have gone",
-        fasta_to_hash=fasta_to_hash,
-    )
-
-    # Won't work with a FASTA missing:
-    with pytest.raises(
-        SystemExit,
-        match=(
-            f"run-id 1 used .*/{Path(missing).name} with MD5 {fasta_to_hash[missing]}"
-            " but this FASTA file no longer exists"
-        ),
-    ):
+        # Should work even with extra FASTA files, real world use case:
+        # Using input directory like /mnt/shared/genomes
+        # Start a run when there are 100 genomes (but it was not completed)
+        # Add some more genomes, say now 150 genomes
+        # Resume the run - it should only operate on the first 100 genomes!
+        with (tmp_indir / "extra.fasta").open("w") as handle:
+            handle.write(">recently-added-genome\nACGTACGTAGT\n")
+        caplog.clear()
         public_cli.resume(database=tmp_db)
-
-    # Should work with all the FASTA files, even though now in a different directory
-    # to that logged in the genome table (as could happen via an older run):
-    (tmp_indir / Path(missing).name).symlink_to(Path(missing))
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Database already has all 3²=9 ANIb comparisons" in output, output
-
-    # Should work even with extra FASTA files, real world use case:
-    # Using input directory like /mnt/shared/genomes
-    # Start a run when there are 100 genomes (but it was not completed)
-    # Add some more genomes, say now 150 genomes
-    # Resume the run - it should only operate on the first 100 genomes!
-    with (tmp_indir / "extra.fasta").open("w") as handle:
-        handle.write(">recently-added-genome\nACGTACGTAGT\n")
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Database already has all 3²=9 ANIb comparisons" in output, output
+        output = caplog.text
+        assert "Database already has all 3²=9 ANIb comparisons" in output, output
 
 
 def test_plot_skip_nulls(
@@ -1693,48 +1696,47 @@ def test_plot_skip_nulls(
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "plot_null.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "guessing",
-        "gestimator",
-        "1.2.3b4",
-        kmersize=51,
-        fragsize=999,
-        minmatch=0.25,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "guessing",
+            "gestimator",
+            "1.2.3b4",
+            kmersize=51,
+            fragsize=999,
+            minmatch=0.25,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record all of the possible comparisons, leaving coverage null
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record all of the possible comparisons, leaving coverage null
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani guessing ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test plotting when some data is null",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani guessing ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test plotting when some data is null",
+            fasta_to_hash=fasta_to_hash,
+        )
 
     plot_out = tmp_dir / "plots"
     caplog.clear()
@@ -1761,49 +1763,48 @@ def test_plot_bad_nulls(
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "plot_null.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "guessing",
-        "gestimator",
-        "1.2.3b4",
-        kmersize=51,
-        fragsize=999,
-        minmatch=0.25,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "guessing",
+            "gestimator",
+            "1.2.3b4",
+            kmersize=51,
+            fragsize=999,
+            minmatch=0.25,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.fa*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.fa*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record all of the possible comparisons, leaving coverage null
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else None,
-                12345,
-                cov_query=1.0 if query_hash is subject_hash else None,
-            )
+        # Record all of the possible comparisons, leaving coverage null
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else None,
+                    12345,
+                    cov_query=1.0 if query_hash is subject_hash else None,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani guessing ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test plotting when off-diagonal is null",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani guessing ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test plotting when off-diagonal is null",
+            fasta_to_hash=fasta_to_hash,
+        )
 
     plot_out = tmp_dir / "plots"
     plot_out.mkdir()
@@ -1843,73 +1844,73 @@ def test_classify_warnings(
     # Record only one comparison (self-to-self)
     tmp_db = tmp_dir / "classify_complete.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                cov_query=1.0,
-                identity=1.0,
-                sim_errors=0,
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    cov_query=1.0,
+                    identity=1.0,
+                    sim_errors=0,
+                )
+
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastANI ...",
+            fasta_directory=input_genomes_tiny,
+            status="Complete",
+            name="Test classify when all data present",
+            fasta_to_hash=dict(list(fasta_to_hash.items())[2:]),
+        )
+
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastANI ...",
+            fasta_directory=input_genomes_tiny,
+            status="Complete",
+            name="Test classify when all data present",
+            fasta_to_hash=fasta_to_hash,
+        )
+
+        caplog.clear()
+        public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=1)
+        output = caplog.text
+        assert (
+            "Run 1 has 1 comparison across 1 genome. Reporting single clique." in output
+        ), output
+
+        with (tmp_dir / "fastANI_classify.tsv").open() as handle:
+            assert (
+                handle.readline()
+                == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
             )
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastANI ...",
-        fasta_directory=input_genomes_tiny,
-        status="Complete",
-        name="Test classify when all data present",
-        fasta_to_hash=dict(list(fasta_to_hash.items())[2:]),
-    )
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastANI ...",
-        fasta_directory=input_genomes_tiny,
-        status="Complete",
-        name="Test classify when all data present",
-        fasta_to_hash=fasta_to_hash,
-    )
-
-    caplog.clear()
-    public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=1)
-    output = caplog.text
-    assert (
-        "Run 1 has 1 comparison across 1 genome. Reporting single clique." in output
-    ), output
-
-    with (tmp_dir / "fastANI_classify.tsv").open() as handle:
-        assert (
-            handle.readline()
-            == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
-        )
-    caplog.clear()
-    caplog.set_level(logging.INFO)
-    public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=2, cov_min=1.0)
-    output = caplog.text
-    assert "All genomes are singletons. No plot can be generated." in output, output
-    with (tmp_dir / "fastANI_classify.tsv").open() as handle:
-        assert (
-            handle.readline()
-            == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
-        )
+        caplog.clear()
+        caplog.set_level(logging.INFO)
+        public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=2, cov_min=1.0)
+        output = caplog.text
+        assert "All genomes are singletons. No plot can be generated." in output, output
+        with (tmp_dir / "fastANI_classify.tsv").open() as handle:
+            assert (
+                handle.readline()
+                == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
+            )
 
 
 def test_classify_normal(
@@ -1921,53 +1922,57 @@ def test_classify_normal(
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "classify_complete.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record all of the possible comparisons
-    genomes = list(fasta_to_hash.values())
-    cov_increment = 0.88
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-                cov_query=1.0 if query_hash is subject_hash else cov_increment,
+        # Record all of the possible comparisons
+        genomes = list(fasta_to_hash.values())
+        cov_increment = 0.88
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                    cov_query=1.0 if query_hash is subject_hash else cov_increment,
+                )
+                # Increment cov_increment if the hashes are not the same
+                if query_hash is not subject_hash:
+                    cov_increment += 0.01
+
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastANI ...",
+            fasta_directory=input_genomes_tiny,
+            status="Complete",
+            name="Test classify when all data present",
+            fasta_to_hash=fasta_to_hash,
+        )
+
+        caplog.clear()
+        caplog.set_level(logging.INFO)
+        public_cli.cli_classify(
+            database=tmp_db, outdir=tmp_dir, cov_min=0.9, mode=EnumModeClassify.tani
+        )
+        output = caplog.text
+        assert f"Wrote classify output to {tmp_path}" in output, output
+        with (tmp_dir / "fastANI_classify.tsv").open() as handle:
+            assert (
+                handle.readline() == "n_nodes\tmax_cov\tmin_-tANI\tmax_-tANI\tmembers\n"
             )
-            # Increment cov_increment if the hashes are not the same
-            if query_hash is not subject_hash:
-                cov_increment += 0.01
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastANI ...",
-        fasta_directory=input_genomes_tiny,
-        status="Complete",
-        name="Test classify when all data present",
-        fasta_to_hash=fasta_to_hash,
-    )
-
-    caplog.clear()
-    caplog.set_level(logging.INFO)
-    public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, cov_min=0.9, mode="tANI")
-    output = caplog.text
-    assert f"Wrote classify output to {tmp_path}" in output, output
-    with (tmp_dir / "fastANI_classify.tsv").open() as handle:
-        assert handle.readline() == "n_nodes\tmax_cov\tmin_-tANI\tmax_-tANI\tmembers\n"
 
 
 def test_plot_run_comp(
@@ -1980,43 +1985,46 @@ def test_plot_run_comp(
     tmp_db = tmp_dir / "⚔️.db"
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
-    genomes = list(fasta_to_hash.values())
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
+        genomes = list(fasta_to_hash.values())
 
-    config_a = db_orm.db_configuration(session, "ANIb", "blastn", "0.0", create=True)
-    config_b = db_orm.db_configuration(session, "ANIm", "nucmer", "0.0", create=True)
-    config_c = db_orm.db_configuration(
-        session, "fastANI", "fastani", "0.0", create=True
-    )
-
-    for i, config in enumerate((config_a, config_b, config_c)):
-        for query_hash in genomes:
-            for subject_hash in genomes:
-                db_orm.db_comparison(
-                    session,
-                    config.configuration_id,
-                    query_hash,
-                    subject_hash,
-                    1.0 if query_hash is subject_hash else 0.99 ** (i + 1),
-                    12345,
-                )
-        db_orm.add_run(
-            session,
-            config,
-            cmdline="pyani-plus ...",
-            fasta_directory=input_genomes_tiny,
-            status="Done",
-            name="Trial " + "ABC"[i],
-            fasta_to_hash=fasta_to_hash,
+        config_a = db_orm.db_configuration(
+            session, "ANIb", "blastn", "0.0", create=True
         )
-    session.commit()
-    session.close()
+        config_b = db_orm.db_configuration(
+            session, "ANIm", "nucmer", "0.0", create=True
+        )
+        config_c = db_orm.db_configuration(
+            session, "fastANI", "fastani", "0.0", create=True
+        )
+
+        for i, config in enumerate((config_a, config_b, config_c)):
+            for query_hash in genomes:
+                for subject_hash in genomes:
+                    db_orm.db_comparison(
+                        session,
+                        config.configuration_id,
+                        query_hash,
+                        subject_hash,
+                        1.0 if query_hash is subject_hash else 0.99 ** (i + 1),
+                        12345,
+                    )
+            db_orm.add_run(
+                session,
+                config,
+                cmdline="pyani-plus ...",
+                fasta_directory=input_genomes_tiny,
+                status="Done",
+                name="Trial " + "ABC"[i],
+                fasta_to_hash=fasta_to_hash,
+            )
+        session.commit()
 
     for cols in (0, 1):
         plot_out = tmp_dir / f"📊{cols}col"

--- a/tests/test_public_cli.py
+++ b/tests/test_public_cli.py
@@ -37,7 +37,7 @@ import pandas as pd
 import pytest
 
 from pyani_plus import GRAPHICS_FORMATS, db_orm, public_cli, setup_logger, tools
-from pyani_plus.public_cli_args import EnumModeSkani, ToolExecutor
+from pyani_plus.public_cli_args import EnumModeClassify, EnumModeSkani, ToolExecutor
 from pyani_plus.utils import file_md5sum
 
 
@@ -146,8 +146,8 @@ def test_delete_empty(tmp_path: str) -> None:
 
     tmp_db = Path(tmp_path) / "list-runs-empty.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as _session:
+        pass
 
     with pytest.raises(SystemExit, match=r"Database contains no runs\."):
         public_cli.delete_run(database=tmp_db)
@@ -163,8 +163,8 @@ def test_list_runs_empty(capsys: pytest.CaptureFixture[str], tmp_path: str) -> N
 
     tmp_db = Path(tmp_path) / "list runs empty.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as _session:
+        pass
 
     public_cli.list_runs(database=tmp_db)
     output = capsys.readouterr().out
@@ -178,8 +178,8 @@ def test_resume_empty(tmp_path: str) -> None:
 
     tmp_db = Path(tmp_path) / "resume-empty.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as _session:
+        pass
 
     with pytest.raises(SystemExit, match=r"Database contains no runs\."):
         public_cli.resume(database=tmp_db)
@@ -199,165 +199,167 @@ def test_partial_run(  # noqa: PLR0915
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "list runs.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 4 of the possible 9 comparisons:
-    for query_hash in list(fasta_to_hash.values())[1:]:
-        for subject_hash in list(fasta_to_hash.values())[1:]:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash == subject_hash else 0.99,
-                12345,
-            )
+        # Record 4 of the possible 9 comparisons:
+        for query_hash in list(fasta_to_hash.values())[1:]:
+            for subject_hash in list(fasta_to_hash.values())[1:]:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash == subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Empty",
-        name="Trial A",
-        fasta_to_hash={},
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Running",  # simulate a partial run not ended cleanly
-        name="Trial B",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 4/9 comparisons
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Done",
-        name="Trial C",
-        # This run uses just 2/3 genomes, but has all 4/4 = 2*2 comparisons:
-        fasta_to_hash=dict(list(fasta_to_hash.items())[1:]),
-    )
-
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 3 analysis runs in " in output, output
-    assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " fastANI │    0 │    0 │    0 │  0=0² │ Empty " in output, output
-    assert " fastANI │    4 │    0 │    5 │  9=3² │ Running " in output, output
-    assert " fastANI │    4 │    0 │    0 │  4=2² │ Done " in output, output
-
-    # Unlike a typical method calculation, we have not triggered
-    # .cache_comparisons() yet, so that will happen in export_run.
-    caplog.clear()
-    public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="md5")
-    output = caplog.text
-    assert f"Wrote matrices to {tmp_path}" in output, output
-    with (tmp_dir / "fastANI_identity.tsv").open() as handle:
-        assert (
-            handle.readline()
-            == "\t5584c7029328dc48d33f95f0a78f7e57\t78975d5144a1cd12e98898d573cf6536\n"
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Empty",
+            name="Trial A",
+            fasta_to_hash={},
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Running",  # simulate a partial run not ended cleanly
+            name="Trial B",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 4/9 comparisons
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Done",
+            name="Trial C",
+            # This run uses just 2/3 genomes, but has all 4/4 = 2*2 comparisons:
+            fasta_to_hash=dict(list(fasta_to_hash.items())[1:]),
         )
 
-    caplog.clear()
-    public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="stem")
-    output = caplog.text
-    assert f"Wrote matrices to {tmp_path}" in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 3 analysis runs in " in output, output
+        assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " fastANI │    0 │    0 │    0 │  0=0² │ Empty " in output, output
+        assert " fastANI │    4 │    0 │    5 │  9=3² │ Running " in output, output
+        assert " fastANI │    4 │    0 │    0 │  4=2² │ Done " in output, output
 
-    with (tmp_dir / "fastANI_identity.tsv").open() as handle:
-        assert handle.readline() == "\tMGV-GENOME-0266457\tOP073605\n"
+        # Unlike a typical method calculation, we have not triggered
+        # .cache_comparisons() yet, so that will happen in export_run.
+        caplog.clear()
+        public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="md5")
+        output = caplog.text
+        assert f"Wrote matrices to {tmp_path}" in output, output
+        with (tmp_dir / "fastANI_identity.tsv").open() as handle:
+            assert (
+                handle.readline()
+                == "\t5584c7029328dc48d33f95f0a78f7e57\t78975d5144a1cd12e98898d573cf6536\n"
+            )
 
-    caplog.clear()
-    public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="filename")
-    output = caplog.text
-    assert f"Wrote matrices to {tmp_path}" in output, output
-    with (tmp_dir / "fastANI_identity.tsv").open() as handle:
-        assert handle.readline() == "\tMGV-GENOME-0266457.fna\tOP073605.fasta\n"
-    caplog.clear()  # clear the above commands
+        caplog.clear()
+        public_cli.export_run(database=tmp_db, run_id=3, outdir=tmp_dir, label="stem")
+        output = caplog.text
+        assert f"Wrote matrices to {tmp_path}" in output, output
 
-    # By construction run 2 is partial, only 4 of 9 matrix entries are
-    # defined - this should fail
-    with pytest.raises(
-        SystemExit,
-        match=("run-id 2 has only 4 of 3²=9 comparisons, 5 needed"),
-    ):
-        public_cli.export_run(database=tmp_db, run_id=2, outdir=tmp_dir)
-    long_file = tmp_dir / "fastANI_run_2.tsv"
-    assert long_file.is_file()
-    with long_file.open() as handle:
-        header = handle.readline().rstrip("\n").split("\t")
-        assert header == [
-            "#Query",
-            "Subject",
-            "Identity",
-            "Query-Cov",
-            "Subject-Cov",
-            "Hadamard",
-            "tANI",
-            "Align-Len",
-            "Sim-Errors",
-        ]
-        assert sum(1 for _ in handle) == 4  # noqa: PLR2004
+        with (tmp_dir / "fastANI_identity.tsv").open() as handle:
+            assert handle.readline() == "\tMGV-GENOME-0266457\tOP073605\n"
 
-    # Resuming the partial job should fail as the fastANI version won't match:
-    with pytest.raises(
-        SystemExit,
-        match=r"We have fastANI version .*, but run-id 2 used fastani version 1\.2\.3 instead\.",
-    ):
-        public_cli.resume(database=tmp_db, run_id=2)
+        caplog.clear()
+        public_cli.export_run(
+            database=tmp_db, run_id=3, outdir=tmp_dir, label="filename"
+        )
+        output = caplog.text
+        assert f"Wrote matrices to {tmp_path}" in output, output
+        with (tmp_dir / "fastANI_identity.tsv").open() as handle:
+            assert handle.readline() == "\tMGV-GENOME-0266457.fna\tOP073605.fasta\n"
+        caplog.clear()  # clear the above commands
 
-    # Resuming run 1 should fail as no genomes:
-    with pytest.raises(
-        SystemExit,
-        match=r"No genomes recorded for run-id 1, cannot resume\.",
-    ):
-        public_cli.resume(database=tmp_db, run_id=1)
+        # By construction run 2 is partial, only 4 of 9 matrix entries are
+        # defined - this should fail
+        with pytest.raises(
+            SystemExit,
+            match=("run-id 2 has only 4 of 3²=9 comparisons, 5 needed"),
+        ):
+            public_cli.export_run(database=tmp_db, run_id=2, outdir=tmp_dir)
+        long_file = tmp_dir / "fastANI_run_2.tsv"
+        assert long_file.is_file()
+        with long_file.open() as handle:
+            header = handle.readline().rstrip("\n").split("\t")
+            assert header == [
+                "#Query",
+                "Subject",
+                "Identity",
+                "Query-Cov",
+                "Subject-Cov",
+                "Hadamard",
+                "tANI",
+                "Align-Len",
+                "Sim-Errors",
+            ]
+            assert sum(1 for _ in handle) == 4  # noqa: PLR2004
 
-    output = capsys.readouterr().out
+        # Resuming the partial job should fail as the fastANI version won't match:
+        with pytest.raises(
+            SystemExit,
+            match=r"We have fastANI version .*, but run-id 2 used fastani version 1\.2\.3 instead\.",
+        ):
+            public_cli.resume(database=tmp_db, run_id=2)
 
-    # Now delete the runs, and confirm what is left behind...
-    caplog.clear()
-    public_cli.delete_run(database=tmp_db, run_id=1)
-    output = caplog.text
-    assert "Run 1 contains 0/0=0² fastANI comparisons, status: Empty\n" in output
+        # Resuming run 1 should fail as no genomes:
+        with pytest.raises(
+            SystemExit,
+            match=r"No genomes recorded for run-id 1, cannot resume\.",
+        ):
+            public_cli.resume(database=tmp_db, run_id=1)
 
-    # Forcing as this has data
-    caplog.clear()
-    public_cli.delete_run(database=tmp_db, run_id=3, force=True)
-    output = caplog.text
-    assert "Run 3 contains all 4=2² fastANI comparisons, status: Done\n" in output
+        output = capsys.readouterr().out
 
-    # Finally delete run 2, this will assume last one remaining
-    caplog.clear()
-    public_cli.delete_run(database=tmp_db, force=True)
-    output = caplog.text
-    assert "Deleting most recent run" in output, output
-    assert "Run 2 contains 4/9=3² fastANI comparisons, status: Running" in output, (
-        output
-    )
-    assert "Run name: Trial B" in output, output
-    assert "Deleting a run still being computed will cause it to fail!" in output, (
-        output
-    )
+        # Now delete the runs, and confirm what is left behind...
+        caplog.clear()
+        public_cli.delete_run(database=tmp_db, run_id=1)
+        output = caplog.text
+        assert "Run 1 contains 0/0=0² fastANI comparisons, status: Empty\n" in output
 
-    assert session.query(db_orm.Run).count() == 0
-    assert session.query(db_orm.RunGenomeAssociation).count() == 0
-    assert session.query(db_orm.Configuration).count() == 1
-    assert session.query(db_orm.Genome).count() == 3  # noqa: PLR2004
-    assert session.query(db_orm.Comparison).count() == 4  # noqa: PLR2004
-    session.close()
+        # Forcing as this has data
+        caplog.clear()
+        public_cli.delete_run(database=tmp_db, run_id=3, force=True)
+        output = caplog.text
+        assert "Run 3 contains all 4=2² fastANI comparisons, status: Done\n" in output
+
+        # Finally delete run 2, this will assume last one remaining
+        caplog.clear()
+        public_cli.delete_run(database=tmp_db, force=True)
+        output = caplog.text
+        assert "Deleting most recent run" in output, output
+        assert "Run 2 contains 4/9=3² fastANI comparisons, status: Running" in output, (
+            output
+        )
+        assert "Run name: Trial B" in output, output
+        assert "Deleting a run still being computed will cause it to fail!" in output, (
+            output
+        )
+
+        assert session.query(db_orm.Run).count() == 0
+        assert session.query(db_orm.RunGenomeAssociation).count() == 0
+        assert session.query(db_orm.Configuration).count() == 1
+        assert session.query(db_orm.Genome).count() == 3  # noqa: PLR2004
+        assert session.query(db_orm.Comparison).count() == 4  # noqa: PLR2004
+
     tmp_db.unlink()
 
 
@@ -375,39 +377,40 @@ def test_export_run_failures(tmp_path: str) -> None:
 
     tmp_db = tmp_dir / "export.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial A",
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial B",
-    )
-    with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
-        public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=3)
-    with pytest.raises(
-        SystemExit,
-        match="run-id 1 has no comparisons",
-    ):
-        public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=1)
-    # Should default to latest run, run-id 2
-    with pytest.raises(
-        SystemExit,
-        match="run-id 2 has no comparisons",
-    ):
-        public_cli.export_run(database=tmp_db, outdir=tmp_dir)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial A",
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial B",
+        )
+        with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
+            public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=3)
+        with pytest.raises(
+            SystemExit,
+            match="run-id 1 has no comparisons",
+        ):
+            public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=1)
+        # Should default to latest run, run-id 2
+        with pytest.raises(
+            SystemExit,
+            match="run-id 2 has no comparisons",
+        ):
+            public_cli.export_run(database=tmp_db, outdir=tmp_dir)
+
     tmp_db.unlink()
 
 
@@ -431,36 +434,35 @@ def test_export_duplicate_stem(tmp_path: str, input_genomes_tiny: Path) -> None:
 
     tmp_db = tmp_dir / "dup-stems.db"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    fasta_to_hash = {fasta: file_md5sum(fasta) for fasta in tmp_fasta.glob("*.fa*")}
-    for fasta, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, fasta, md5, create=True)
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Done",
-        name="Trial B",
-        fasta_to_hash=fasta_to_hash,
-    )
-    for query_hash in list(fasta_to_hash.values()):
-        for subject_hash in list(fasta_to_hash.values()):
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash == subject_hash else 0.99,
-                12345,
-                cov_subject=1.0 if query_hash == subject_hash else 0.95,
-                cov_query=1.0 if query_hash == subject_hash else 0.95,
-            )
-    session.commit()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        fasta_to_hash = {fasta: file_md5sum(fasta) for fasta in tmp_fasta.glob("*.fa*")}
+        for fasta, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, fasta, md5, create=True)
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Done",
+            name="Trial B",
+            fasta_to_hash=fasta_to_hash,
+        )
+        for query_hash in list(fasta_to_hash.values()):
+            for subject_hash in list(fasta_to_hash.values()):
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash == subject_hash else 0.99,
+                    12345,
+                    cov_subject=1.0 if query_hash == subject_hash else 0.95,
+                    cov_query=1.0 if query_hash == subject_hash else 0.95,
+                )
+        session.commit()
 
     with pytest.raises(
         SystemExit,
@@ -489,42 +491,42 @@ def test_plot_run_failures(tmp_path: str) -> None:
 
     logger = setup_logger(None)
     tmp_db = tmp_dir / "export.sqlite"
-    session = db_orm.connect_to_db(logger, tmp_db)
-    with pytest.raises(SystemExit, match=r"Database contains no runs\."):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        with pytest.raises(SystemExit, match=r"Database contains no runs\."):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
 
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial A",
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial B",
-    )
-    with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=3)
-    with pytest.raises(
-        SystemExit,
-        match="run-id 1 has no comparisons",
-    ):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=1)
-    # Should default to latest run, run-id 2
-    with pytest.raises(
-        SystemExit,
-        match="run-id 2 has no comparisons",
-    ):
-        public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial A",
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial B",
+        )
+        with pytest.raises(SystemExit, match=r"Database has no run-id 3\."):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=3)
+        with pytest.raises(
+            SystemExit,
+            match="run-id 1 has no comparisons",
+        ):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir, run_id=1)
+        # Should default to latest run, run-id 2
+        with pytest.raises(
+            SystemExit,
+            match="run-id 2 has no comparisons",
+        ):
+            public_cli.plot_run(database=tmp_db, outdir=tmp_dir)
 
 
 def test_plot_run_comp_failures(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -538,64 +540,66 @@ def test_plot_run_comp_failures(tmp_path: str, input_genomes_tiny: Path) -> None
 
     tmp_db = tmp_dir / "export.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    with pytest.raises(
-        SystemExit,
-        match=r"Database has no run-id 1\. Use the list-runs command for more information.",
-    ):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        with pytest.raises(
+            SystemExit,
+            match=r"Database has no run-id 1\. Use the list-runs command for more information.",
+        ):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
 
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial A",
-    )
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastani ...",
-        fasta_directory=Path("/does/not/exist"),
-        status="Empty",
-        name="Trial B",
-        fasta_to_hash=fasta_to_hash,
-    )
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial A",
+        )
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastani ...",
+            fasta_directory=Path("/does/not/exist"),
+            status="Empty",
+            name="Trial B",
+            fasta_to_hash=fasta_to_hash,
+        )
 
-    with pytest.raises(SystemExit, match="Run 1 has no comparisons"):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
+        with pytest.raises(SystemExit, match="Run 1 has no comparisons"):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="1,2")
 
-    with pytest.raises(SystemExit, match="Need at least two runs for a comparison"):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2")
+        with pytest.raises(SystemExit, match="Need at least two runs for a comparison"):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2")
 
-    with pytest.raises(
-        SystemExit, match="Expected comma separated list of runs, not: 2-1"
-    ):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2-1")
+        with pytest.raises(
+            SystemExit, match="Expected comma separated list of runs, not: 2-1"
+        ):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2-1")
 
-    with pytest.raises(SystemExit, match="Runs 2 and 1 have no comparisons in common"):
-        public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2,1")
+        with pytest.raises(
+            SystemExit, match="Runs 2 and 1 have no comparisons in common"
+        ):
+            public_cli.plot_run_comp(database=tmp_db, outdir=tmp_dir, run_ids="2,1")
 
 
 def test_anim(
@@ -620,24 +624,23 @@ def test_anim(
     assert "Database already has 0 of 3²=9 ANIm comparisons, 9 needed\n" in output
     logger = setup_logger(None)
 
-    session = db_orm.connect_to_db(logger, tmp_db)
-    count = session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        count = session.query(db_orm.Comparison).count()
+        session.close()
 
-    # Now do it again - it should reuse the calculations:
-    caplog.clear()
-    public_cli.cli_anim(
-        database=tmp_db,
-        fasta=input_genomes_tiny,
-        name="Simple names",
-        create_db=False,
-    )
-    output = caplog.text
-    assert "Database already has all 3²=9 ANIm comparisons\n" in output
+        # Now do it again - it should reuse the calculations:
+        caplog.clear()
+        public_cli.cli_anim(
+            database=tmp_db,
+            fasta=input_genomes_tiny,
+            name="Simple names",
+            create_db=False,
+        )
+        output = caplog.text
+        assert "Database already has all 3²=9 ANIm comparisons\n" in output
 
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert count == session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert count == session.query(db_orm.Comparison).count()
 
     public_cli.export_run(database=tmp_db, outdir=tmp_dir, run_id=2)
     compare_matrix_files(
@@ -664,17 +667,15 @@ def test_anim_gzip(
 
     logger = setup_logger(None)
     # Now do it again but with the decompressed files - should reuse calculations:
-    session = db_orm.connect_to_db(logger, tmp_db)
-    count = session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        count = session.query(db_orm.Comparison).count()
 
     public_cli.cli_anim(
         database=tmp_db, fasta=input_genomes_tiny, name="Test Run", create_db=False
     )
 
-    session = db_orm.connect_to_db(logger, tmp_db)
-    assert count == session.query(db_orm.Comparison).count()
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        assert count == session.query(db_orm.Comparison).count()
 
 
 def test_anim_fasta_empty(
@@ -729,10 +730,9 @@ def test_dnadiff(
     output = caplog.text
     assert "Database already has 0 of 3²=9 dnadiff comparisons, 9 needed\n" in output
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.name == "3 genomes using dnadiff"
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.name == "3 genomes using dnadiff"
 
     # Now do it again - it should reuse the calculations:
     caplog.clear()
@@ -770,10 +770,9 @@ def test_dnadiff_gzip(
         atol=5e-5,
     )
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.name == "3 genomes using dnadiff"
-    session.close()
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.name == "3 genomes using dnadiff"
 
 
 def test_anib(
@@ -1093,68 +1092,68 @@ def test_resume_partial_fastani(
     tmp_db = Path(tmp_path) / "partial resume.sqlite"
     tool = tools.get_fastani()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "fastANI",
-        tool.exe_path.stem,
-        tool.version,
-        kmersize=14,
-        fragsize=2500,
-        minmatch=0.3,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "fastANI",
+            tool.exe_path.stem,
+            tool.version,
+            kmersize=14,
+            fragsize=2500,
+            minmatch=0.3,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 8 of the possible 9 comparisons:
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            if query_hash == genomes[2] and subject_hash == genomes[0]:
-                # Skip one comparison
-                continue
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record 8 of the possible 9 comparisons:
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                if query_hash == genomes[2] and subject_hash == genomes[0]:
+                    # Skip one comparison
+                    continue
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus fastani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " fastANI │    8 │    0 │    1 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus fastani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method  ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " fastANI │    8 │    0 │    1 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 8 of 3²=9 fastANI comparisons, 1 needed" in output, (
-        output
-    )
+        caplog.clear()
+        public_cli.resume(database=tmp_db)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert (
+            "Database already has 8 of 3²=9 fastANI comparisons, 1 needed" in output
+        ), output
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " fastANI │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " fastANI │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_anib(
@@ -1168,64 +1167,66 @@ def test_resume_partial_anib(
     tmp_db = Path(tmp_path) / "resume.sqlite"
     tool = tools.get_blastn()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "ANIb",
-        tool.exe_path.stem,
-        tool.version,
-        fragsize=1234,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "ANIb",
+            tool.exe_path.stem,
+            tool.version,
+            fragsize=1234,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 8 of the possible 9 comparisons:
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            if query_hash == genomes[2] and subject_hash == genomes[0]:
-                # Skip one comparison
-                continue
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record 8 of the possible 9 comparisons:
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                if query_hash == genomes[2] and subject_hash == genomes[0]:
+                    # Skip one comparison
+                    continue
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus anib ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " ANIb   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus anib ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " ANIb   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 8 of 3²=9 ANIb comparisons, 1 needed" in output, output
+        caplog.clear()
+        public_cli.resume(database=tmp_db)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert "Database already has 8 of 3²=9 ANIb comparisons, 1 needed" in output, (
+            output
+        )
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " ANIb   │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " ANIb   │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_anim(
@@ -1239,64 +1240,66 @@ def test_resume_partial_anim(
     tmp_db = Path(tmp_path) / "resume.sqlite"
     tool = tools.get_nucmer()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "ANIm",
-        tool.exe_path.stem,
-        tool.version,
-        mode="maxmatch",
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "ANIm",
+            tool.exe_path.stem,
+            tool.version,
+            mode="maxmatch",
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 8 of the possible 9 comparisons:
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            if query_hash == genomes[2] and subject_hash == genomes[0]:
-                # Skip one comparison
-                continue
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record 8 of the possible 9 comparisons:
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                if query_hash == genomes[2] and subject_hash == genomes[0]:
+                    # Skip one comparison
+                    continue
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus ANIm --mode maxmatch ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " ANIm   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus ANIm --mode maxmatch ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # 3/3 genomes, so only have 8/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " ANIm   │    8 │    0 │    1 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 8 of 3²=9 ANIm comparisons, 1 needed" in output, output
+        caplog.clear()
+        public_cli.resume(database=tmp_db)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert "Database already has 8 of 3²=9 ANIm comparisons, 1 needed" in output, (
+            output
+        )
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " ANIm   │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " ANIm   │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_skani(
@@ -1311,63 +1314,63 @@ def test_resume_partial_skani(
     tmp_db = tmp_dir / "resume_skani.sqlite"
     tool = tools.get_skani()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "skani",
-        tool.exe_path.stem,
-        tool.version,
-        mode=EnumModeSkani.fast,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "skani",
+            tool.exe_path.stem,
+            tool.version,
+            mode=EnumModeSkani.fast,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 4 of the possible 9 comparisons,
-    # mimicking what might happen when a 2x2 run is expanded to 3x3
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes[:-1]:
-        for subject_hash in genomes[:-1]:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-            )
+        # Record 4 of the possible 9 comparisons,
+        # mimicking what might happen when a 2x2 run is expanded to 3x3
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes[:-1]:
+            for subject_hash in genomes[:-1]:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus skani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " skani  │    4 │    0 │    5 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus skani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " skani  │    4 │    0 │    5 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db, cache=tmp_dir)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 4 of 3²=9 skani comparisons, 5 needed" in output, (
-        output
-    )
+        caplog.clear()
+        public_cli.resume(database=tmp_db, cache=tmp_dir)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert "Database already has 4 of 3²=9 skani comparisons, 5 needed" in output, (
+            output
+        )
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " skani  │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " skani  │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_partial_sourmash(
@@ -1382,64 +1385,64 @@ def test_resume_partial_sourmash(
     tmp_db = tmp_dir / "resume sourmash.sqlite"
     tool = tools.get_sourmash()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "sourmash",
-        tool.exe_path.stem,
-        tool.version,
-        kmersize=31,  # must be 31 to match the sig files in fixtures
-        extra="scaled=300",
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "sourmash",
+            tool.exe_path.stem,
+            tool.version,
+            kmersize=31,  # must be 31 to match the sig files in fixtures
+            extra="scaled=300",
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record 4 of the possible 9 comparisons,
-    # mimicking what might happen when a 2x2 run is expanded to 3x3
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes[:-1]:
-        for subject_hash in genomes[:-1]:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-            )
+        # Record 4 of the possible 9 comparisons,
+        # mimicking what might happen when a 2x2 run is expanded to 3x3
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes[:-1]:
+            for subject_hash in genomes[:-1]:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani-plus sourmash ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test Resuming A Run",
-        fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
-    )
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " Method   ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
-    assert " sourmash │    4 │    0 │    5 │  9=3² │ Partial " in output, output
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani-plus sourmash ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test Resuming A Run",
+            fasta_to_hash=fasta_to_hash,  # all 3/3 genomes, but only have 4/9 comparisons
+        )
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " Method   ┃ Done ┃ Null ┃ Miss ┃ Total ┃ Status " in output, output
+        assert " sourmash │    4 │    0 │    5 │  9=3² │ Partial " in output, output
 
-    caplog.clear()
-    public_cli.resume(database=tmp_db, cache=tmp_dir)
-    output = caplog.text
-    assert "Resuming run-id 1\n" in output, output
-    assert "Database already has 4 of 3²=9 sourmash comparisons, 5 needed" in output, (
-        output
-    )
+        caplog.clear()
+        public_cli.resume(database=tmp_db, cache=tmp_dir)
+        output = caplog.text
+        assert "Resuming run-id 1\n" in output, output
+        assert (
+            "Database already has 4 of 3²=9 sourmash comparisons, 5 needed" in output
+        ), output
 
-    public_cli.list_runs(database=tmp_db)
-    output = capsys.readouterr().out
-    assert " 1 analysis runs in " in output, output
-    assert " sourmash │    9 │    0 │    0 │  9=3² │ Done " in output, output
+        public_cli.list_runs(database=tmp_db)
+        output = capsys.readouterr().out
+        assert " 1 analysis runs in " in output, output
+        assert " sourmash │    9 │    0 │    0 │  9=3² │ Done " in output, output
 
 
 def test_resume_dir_gone(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -1447,76 +1450,75 @@ def test_resume_dir_gone(tmp_path: str, input_genomes_tiny: Path) -> None:
     tmp_db = Path(tmp_path) / "resume.sqlite"
     tool = tools.get_fastani()
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "fastANI",
-        tool.exe_path.stem,
-        tool.version,
-        kmersize=14,
-        fragsize=2500,
-        minmatch=0.3,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "fastANI",
+            tool.exe_path.stem,
+            tool.version,
+            kmersize=14,
+            fragsize=2500,
+            minmatch=0.3,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani ...",
-        fasta_directory=Path("/mnt/shared/old"),
-        status="Partial",
-        name="Test how resuming without input directory present fails",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani ...",
+            fasta_directory=Path("/mnt/shared/old"),
+            status="Partial",
+            name="Test how resuming without input directory present fails",
+            fasta_to_hash=fasta_to_hash,
+        )
+        session.close()
 
-    with pytest.raises(
-        SystemExit,
-        match=r"run-id 1 used input folder /mnt/shared/old, but that is not a directory \(now\).",
-    ):
-        public_cli.resume(database=tmp_db)
+        with pytest.raises(
+            SystemExit,
+            match=r"run-id 1 used input folder /mnt/shared/old, but that is not a directory \(now\).",
+        ):
+            public_cli.resume(database=tmp_db)
 
 
 def test_resume_unknown(tmp_path: str, input_genomes_tiny: Path) -> None:
     """Check expected failure trying to resume an unknown method."""
     tmp_db = Path(tmp_path) / "resume.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "guessing",
-        "gestimator",
-        "1.2.3b4",
-        kmersize=51,
-        fragsize=999,
-        minmatch=0.25,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "guessing",
+            "gestimator",
+            "1.2.3b4",
+            kmersize=51,
+            fragsize=999,
+            minmatch=0.25,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test how resuming from an unknown method fails",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test how resuming from an unknown method fails",
+            fasta_to_hash=fasta_to_hash,
+        )
 
     with pytest.raises(
         SystemExit,
@@ -1534,32 +1536,101 @@ def test_resume_complete(
     caplog.set_level(logging.INFO)
     tmp_db = Path(tmp_path) / "resume.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        for index, (method, tool) in enumerate(
+            [
+                ("ANIm", tools.get_nucmer()),
+                ("dnadiff", tools.get_nucmer()),
+                ("ANIb", tools.get_blastn()),
+                ("fastANI", tools.get_fastani()),
+                ("skani", tools.get_skani()),
+                ("sourmash", tools.get_sourmash()),
+            ]
+        ):
+            config = db_orm.db_configuration(
+                session,
+                method,
+                tool.exe_path.stem,
+                tool.version,
+                create=True,
+            )
 
-    for index, (method, tool) in enumerate(
-        [
-            ("ANIm", tools.get_nucmer()),
-            ("dnadiff", tools.get_nucmer()),
-            ("ANIb", tools.get_blastn()),
-            ("fastANI", tools.get_fastani()),
-            ("skani", tools.get_skani()),
-            ("sourmash", tools.get_sourmash()),
-        ]
-    ):
+            fasta_to_hash = {
+                filename: file_md5sum(filename)
+                for filename in sorted(input_genomes_tiny.glob("*.f*"))
+            }
+            for filename, md5 in fasta_to_hash.items():
+                db_orm.db_genome(logger, session, filename, md5, create=True)
+
+            # Record dummy values for all of the possible 9 comparisons:
+            for query_hash in fasta_to_hash.values():
+                for subject_hash in fasta_to_hash.values():
+                    db_orm.db_comparison(
+                        session,
+                        config.configuration_id,
+                        query_hash,
+                        subject_hash,
+                        1.0 if query_hash == subject_hash else 0.99,
+                        12345,
+                    )
+
+            db_orm.add_run(
+                session,
+                config,
+                cmdline=f"pyani {method} --database ...",
+                fasta_directory=input_genomes_tiny,
+                status="Complete",
+                name=f"Test resuming a complete {method} run",
+                fasta_to_hash=fasta_to_hash,
+            )
+            caplog.clear()
+            public_cli.resume(database=tmp_db)
+            output = caplog.text
+            assert f"Resuming run-id {index + 1}\n" in output, output
+            assert f"Database already has all 3²=9 {method} comparisons" in output, (
+                output
+            )
+
+
+def test_resume_fasta_gone(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: str,
+    input_genomes_tiny: Path,
+) -> None:
+    """Check resume error handling when a FASTA file is missing."""
+    caplog.set_level(logging.INFO)
+    tmp_dir = Path(tmp_path)
+    tmp_indir = tmp_dir / "input"
+    tmp_indir.mkdir()
+    tmp_db = tmp_dir / "resume.sqlite"
+    logger = setup_logger(None)
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        tool = tools.get_blastn()
         config = db_orm.db_configuration(
             session,
-            method,
+            "ANIb",
             tool.exe_path.stem,
             tool.version,
+            fragsize=1500,
             create=True,
         )
 
+        # Record the genome entries under input_genomes_tiny
         fasta_to_hash = {
             filename: file_md5sum(filename)
             for filename in sorted(input_genomes_tiny.glob("*.f*"))
         }
         for filename, md5 in fasta_to_hash.items():
             db_orm.db_genome(logger, session, filename, md5, create=True)
+
+        # Setup a subset under tmp_dir
+        for filename in list(fasta_to_hash)[:-1]:
+            fasta = Path(filename)
+            (tmp_indir / fasta.name).symlink_to(fasta)
+        assert len(fasta_to_hash) - 1 == len(list(tmp_indir.glob("*.f*"))), list(
+            tmp_indir.glob("*.f*")
+        )
+        missing = list(fasta_to_hash)[-1]
 
         # Record dummy values for all of the possible 9 comparisons:
         for query_hash in fasta_to_hash.values():
@@ -1576,110 +1647,42 @@ def test_resume_complete(
         db_orm.add_run(
             session,
             config,
-            cmdline=f"pyani {method} --database ...",
-            fasta_directory=input_genomes_tiny,
+            cmdline="pyani ANIb --database ...",
+            fasta_directory=tmp_indir,  # NOT using input_genomes_tiny
             status="Complete",
-            name=f"Test resuming a complete {method} run",
+            name="Test resuming when the FASTA files have gone",
             fasta_to_hash=fasta_to_hash,
         )
+
+        # Won't work with a FASTA missing:
+        with pytest.raises(
+            SystemExit,
+            match=(
+                f"run-id 1 used .*/{Path(missing).name} with MD5 {fasta_to_hash[missing]}"
+                " but this FASTA file no longer exists"
+            ),
+        ):
+            public_cli.resume(database=tmp_db)
+
+        # Should work with all the FASTA files, even though now in a different directory
+        # to that logged in the genome table (as could happen via an older run):
+        (tmp_indir / Path(missing).name).symlink_to(Path(missing))
         caplog.clear()
         public_cli.resume(database=tmp_db)
         output = caplog.text
-        assert f"Resuming run-id {index + 1}\n" in output, output
-        assert f"Database already has all 3²=9 {method} comparisons" in output, output
+        assert "Database already has all 3²=9 ANIb comparisons" in output, output
 
-
-def test_resume_fasta_gone(
-    caplog: pytest.LogCaptureFixture,
-    tmp_path: str,
-    input_genomes_tiny: Path,
-) -> None:
-    """Check resume error handling when a FASTA file is missing."""
-    caplog.set_level(logging.INFO)
-    tmp_dir = Path(tmp_path)
-    tmp_indir = tmp_dir / "input"
-    tmp_indir.mkdir()
-    tmp_db = tmp_dir / "resume.sqlite"
-    logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    tool = tools.get_blastn()
-    config = db_orm.db_configuration(
-        session,
-        "ANIb",
-        tool.exe_path.stem,
-        tool.version,
-        fragsize=1500,
-        create=True,
-    )
-
-    # Record the genome entries under input_genomes_tiny
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
-
-    # Setup a subset under tmp_dir
-    for filename in list(fasta_to_hash)[:-1]:
-        fasta = Path(filename)
-        (tmp_indir / fasta.name).symlink_to(fasta)
-    assert len(fasta_to_hash) - 1 == len(list(tmp_indir.glob("*.f*"))), list(
-        tmp_indir.glob("*.f*")
-    )
-    missing = list(fasta_to_hash)[-1]
-
-    # Record dummy values for all of the possible 9 comparisons:
-    for query_hash in fasta_to_hash.values():
-        for subject_hash in fasta_to_hash.values():
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash == subject_hash else 0.99,
-                12345,
-            )
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani ANIb --database ...",
-        fasta_directory=tmp_indir,  # NOT using input_genomes_tiny
-        status="Complete",
-        name="Test resuming when the FASTA files have gone",
-        fasta_to_hash=fasta_to_hash,
-    )
-
-    # Won't work with a FASTA missing:
-    with pytest.raises(
-        SystemExit,
-        match=(
-            f"run-id 1 used .*/{Path(missing).name} with MD5 {fasta_to_hash[missing]}"
-            " but this FASTA file no longer exists"
-        ),
-    ):
+        # Should work even with extra FASTA files, real world use case:
+        # Using input directory like /mnt/shared/genomes
+        # Start a run when there are 100 genomes (but it was not completed)
+        # Add some more genomes, say now 150 genomes
+        # Resume the run - it should only operate on the first 100 genomes!
+        with (tmp_indir / "extra.fasta").open("w") as handle:
+            handle.write(">recently-added-genome\nACGTACGTAGT\n")
+        caplog.clear()
         public_cli.resume(database=tmp_db)
-
-    # Should work with all the FASTA files, even though now in a different directory
-    # to that logged in the genome table (as could happen via an older run):
-    (tmp_indir / Path(missing).name).symlink_to(Path(missing))
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Database already has all 3²=9 ANIb comparisons" in output, output
-
-    # Should work even with extra FASTA files, real world use case:
-    # Using input directory like /mnt/shared/genomes
-    # Start a run when there are 100 genomes (but it was not completed)
-    # Add some more genomes, say now 150 genomes
-    # Resume the run - it should only operate on the first 100 genomes!
-    with (tmp_indir / "extra.fasta").open("w") as handle:
-        handle.write(">recently-added-genome\nACGTACGTAGT\n")
-    caplog.clear()
-    public_cli.resume(database=tmp_db)
-    output = caplog.text
-    assert "Database already has all 3²=9 ANIb comparisons" in output, output
+        output = caplog.text
+        assert "Database already has all 3²=9 ANIb comparisons" in output, output
 
 
 def test_plot_skip_nulls(
@@ -1691,48 +1694,47 @@ def test_plot_skip_nulls(
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "plot_null.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "guessing",
-        "gestimator",
-        "1.2.3b4",
-        kmersize=51,
-        fragsize=999,
-        minmatch=0.25,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "guessing",
+            "gestimator",
+            "1.2.3b4",
+            kmersize=51,
+            fragsize=999,
+            minmatch=0.25,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record all of the possible comparisons, leaving coverage null
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-            )
+        # Record all of the possible comparisons, leaving coverage null
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani guessing ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test plotting when some data is null",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani guessing ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test plotting when some data is null",
+            fasta_to_hash=fasta_to_hash,
+        )
 
     plot_out = tmp_dir / "plots"
     caplog.clear()
@@ -1759,49 +1761,48 @@ def test_plot_bad_nulls(
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "plot_null.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session,
-        "guessing",
-        "gestimator",
-        "1.2.3b4",
-        kmersize=51,
-        fragsize=999,
-        minmatch=0.25,
-        create=True,
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session,
+            "guessing",
+            "gestimator",
+            "1.2.3b4",
+            kmersize=51,
+            fragsize=999,
+            minmatch=0.25,
+            create=True,
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.fa*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.fa*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record all of the possible comparisons, leaving coverage null
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else None,
-                12345,
-                cov_query=1.0 if query_hash is subject_hash else None,
-            )
+        # Record all of the possible comparisons, leaving coverage null
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else None,
+                    12345,
+                    cov_query=1.0 if query_hash is subject_hash else None,
+                )
 
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani guessing ...",
-        fasta_directory=input_genomes_tiny,
-        status="Partial",
-        name="Test plotting when off-diagonal is null",
-        fasta_to_hash=fasta_to_hash,
-    )
-    session.close()
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani guessing ...",
+            fasta_directory=input_genomes_tiny,
+            status="Partial",
+            name="Test plotting when off-diagonal is null",
+            fasta_to_hash=fasta_to_hash,
+        )
 
     plot_out = tmp_dir / "plots"
     plot_out.mkdir()
@@ -1841,73 +1842,73 @@ def test_classify_warnings(
     # Record only one comparison (self-to-self)
     tmp_db = tmp_dir / "classify_complete.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    genomes = list(fasta_to_hash.values())
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                cov_query=1.0,
-                identity=1.0,
-                sim_errors=0,
+        genomes = list(fasta_to_hash.values())
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    cov_query=1.0,
+                    identity=1.0,
+                    sim_errors=0,
+                )
+
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastANI ...",
+            fasta_directory=input_genomes_tiny,
+            status="Complete",
+            name="Test classify when all data present",
+            fasta_to_hash=dict(list(fasta_to_hash.items())[2:]),
+        )
+
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastANI ...",
+            fasta_directory=input_genomes_tiny,
+            status="Complete",
+            name="Test classify when all data present",
+            fasta_to_hash=fasta_to_hash,
+        )
+
+        caplog.clear()
+        public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=1)
+        output = caplog.text
+        assert (
+            "Run 1 has 1 comparison across 1 genome. Reporting single clique." in output
+        ), output
+
+        with (tmp_dir / "fastANI_classify.tsv").open() as handle:
+            assert (
+                handle.readline()
+                == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
             )
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastANI ...",
-        fasta_directory=input_genomes_tiny,
-        status="Complete",
-        name="Test classify when all data present",
-        fasta_to_hash=dict(list(fasta_to_hash.items())[2:]),
-    )
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastANI ...",
-        fasta_directory=input_genomes_tiny,
-        status="Complete",
-        name="Test classify when all data present",
-        fasta_to_hash=fasta_to_hash,
-    )
-
-    caplog.clear()
-    public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=1)
-    output = caplog.text
-    assert (
-        "Run 1 has 1 comparison across 1 genome. Reporting single clique." in output
-    ), output
-
-    with (tmp_dir / "fastANI_classify.tsv").open() as handle:
-        assert (
-            handle.readline()
-            == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
-        )
-    caplog.clear()
-    caplog.set_level(logging.INFO)
-    public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=2, cov_min=1.0)
-    output = caplog.text
-    assert "All genomes are singletons. No plot can be generated." in output, output
-    with (tmp_dir / "fastANI_classify.tsv").open() as handle:
-        assert (
-            handle.readline()
-            == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
-        )
+        caplog.clear()
+        caplog.set_level(logging.INFO)
+        public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, run_id=2, cov_min=1.0)
+        output = caplog.text
+        assert "All genomes are singletons. No plot can be generated." in output, output
+        with (tmp_dir / "fastANI_classify.tsv").open() as handle:
+            assert (
+                handle.readline()
+                == "n_nodes\tmax_cov\tmin_identity\tmax_identity\tmembers\n"
+            )
 
 
 def test_classify_normal(
@@ -1919,53 +1920,57 @@ def test_classify_normal(
     tmp_dir = Path(tmp_path)
     tmp_db = tmp_dir / "classify_complete.sqlite"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    config = db_orm.db_configuration(
-        session, "fastANI", "fastani", "1.2.3", create=True
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        config = db_orm.db_configuration(
+            session, "fastANI", "fastani", "1.2.3", create=True
+        )
 
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
 
-    # Record all of the possible comparisons
-    genomes = list(fasta_to_hash.values())
-    cov_increment = 0.88
-    for query_hash in genomes:
-        for subject_hash in genomes:
-            db_orm.db_comparison(
-                session,
-                config.configuration_id,
-                query_hash,
-                subject_hash,
-                1.0 if query_hash is subject_hash else 0.99,
-                12345,
-                cov_query=1.0 if query_hash is subject_hash else cov_increment,
+        # Record all of the possible comparisons
+        genomes = list(fasta_to_hash.values())
+        cov_increment = 0.88
+        for query_hash in genomes:
+            for subject_hash in genomes:
+                db_orm.db_comparison(
+                    session,
+                    config.configuration_id,
+                    query_hash,
+                    subject_hash,
+                    1.0 if query_hash is subject_hash else 0.99,
+                    12345,
+                    cov_query=1.0 if query_hash is subject_hash else cov_increment,
+                )
+                # Increment cov_increment if the hashes are not the same
+                if query_hash is not subject_hash:
+                    cov_increment += 0.01
+
+        db_orm.add_run(
+            session,
+            config,
+            cmdline="pyani fastANI ...",
+            fasta_directory=input_genomes_tiny,
+            status="Complete",
+            name="Test classify when all data present",
+            fasta_to_hash=fasta_to_hash,
+        )
+
+        caplog.clear()
+        caplog.set_level(logging.INFO)
+        public_cli.cli_classify(
+            database=tmp_db, outdir=tmp_dir, cov_min=0.9, mode=EnumModeClassify.tani
+        )
+        output = caplog.text
+        assert f"Wrote classify output to {tmp_path}" in output, output
+        with (tmp_dir / "fastANI_classify.tsv").open() as handle:
+            assert (
+                handle.readline() == "n_nodes\tmax_cov\tmin_-tANI\tmax_-tANI\tmembers\n"
             )
-            # Increment cov_increment if the hashes are not the same
-            if query_hash is not subject_hash:
-                cov_increment += 0.01
-
-    db_orm.add_run(
-        session,
-        config,
-        cmdline="pyani fastANI ...",
-        fasta_directory=input_genomes_tiny,
-        status="Complete",
-        name="Test classify when all data present",
-        fasta_to_hash=fasta_to_hash,
-    )
-
-    caplog.clear()
-    caplog.set_level(logging.INFO)
-    public_cli.cli_classify(database=tmp_db, outdir=tmp_dir, cov_min=0.9, mode="tANI")
-    output = caplog.text
-    assert f"Wrote classify output to {tmp_path}" in output, output
-    with (tmp_dir / "fastANI_classify.tsv").open() as handle:
-        assert handle.readline() == "n_nodes\tmax_cov\tmin_-tANI\tmax_-tANI\tmembers\n"
 
 
 def test_plot_run_comp(
@@ -1978,43 +1983,46 @@ def test_plot_run_comp(
     tmp_db = tmp_dir / "⚔️.db"
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    fasta_to_hash = {
-        filename: file_md5sum(filename)
-        for filename in sorted(input_genomes_tiny.glob("*.f*"))
-    }
-    for filename, md5 in fasta_to_hash.items():
-        db_orm.db_genome(logger, session, filename, md5, create=True)
-    genomes = list(fasta_to_hash.values())
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        fasta_to_hash = {
+            filename: file_md5sum(filename)
+            for filename in sorted(input_genomes_tiny.glob("*.f*"))
+        }
+        for filename, md5 in fasta_to_hash.items():
+            db_orm.db_genome(logger, session, filename, md5, create=True)
+        genomes = list(fasta_to_hash.values())
 
-    config_a = db_orm.db_configuration(session, "ANIb", "blastn", "0.0", create=True)
-    config_b = db_orm.db_configuration(session, "ANIm", "nucmer", "0.0", create=True)
-    config_c = db_orm.db_configuration(
-        session, "fastANI", "fastani", "0.0", create=True
-    )
-
-    for i, config in enumerate((config_a, config_b, config_c)):
-        for query_hash in genomes:
-            for subject_hash in genomes:
-                db_orm.db_comparison(
-                    session,
-                    config.configuration_id,
-                    query_hash,
-                    subject_hash,
-                    1.0 if query_hash is subject_hash else 0.99 ** (i + 1),
-                    12345,
-                )
-        db_orm.add_run(
-            session,
-            config,
-            cmdline="pyani-plus ...",
-            fasta_directory=input_genomes_tiny,
-            status="Done",
-            name="Trial " + "ABC"[i],
-            fasta_to_hash=fasta_to_hash,
+        config_a = db_orm.db_configuration(
+            session, "ANIb", "blastn", "0.0", create=True
         )
-    session.commit()
-    session.close()
+        config_b = db_orm.db_configuration(
+            session, "ANIm", "nucmer", "0.0", create=True
+        )
+        config_c = db_orm.db_configuration(
+            session, "fastANI", "fastani", "0.0", create=True
+        )
+
+        for i, config in enumerate((config_a, config_b, config_c)):
+            for query_hash in genomes:
+                for subject_hash in genomes:
+                    db_orm.db_comparison(
+                        session,
+                        config.configuration_id,
+                        query_hash,
+                        subject_hash,
+                        1.0 if query_hash is subject_hash else 0.99 ** (i + 1),
+                        12345,
+                    )
+            db_orm.add_run(
+                session,
+                config,
+                cmdline="pyani-plus ...",
+                fasta_directory=input_genomes_tiny,
+                status="Done",
+                name="Trial " + "ABC"[i],
+                fasta_to_hash=fasta_to_hash,
+            )
+        session.commit()
 
     for cols in (0, 1):
         plot_out = tmp_dir / f"📊{cols}col"

--- a/tests/test_self_vs_self.py
+++ b/tests/test_self_vs_self.py
@@ -58,10 +58,9 @@ def do_self_compare(
         assert " run setup with 1 genomes in database\n" in output
 
         logger = setup_logger(None)
-        session = db_orm.connect_to_db(logger, tmp_db.name)
-        comp = session.query(db_orm.Comparison).one()
-        session.close()
-        return comp
+
+        with db_orm.connect_to_db(logger, tmp_db.name) as session:
+            return session.query(db_orm.Comparison).one()
 
 
 def test_self_vs_self_anim(caplog: pytest.LogCaptureFixture, tmp_path: str) -> None:

--- a/tests/test_skani.py
+++ b/tests/test_skani.py
@@ -115,25 +115,26 @@ def test_running_skani(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
 
-    private_cli.compute_skani(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        input_genomes_tiny,
-        hash_to_filename,
-        filename_to_hash,
-        query_hashes=hash_to_lengths,
-        subject_hash=list(hash_to_filename)[1],
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
+
+        private_cli.compute_skani(
+            logger,
+            tmp_dir,
+            session,
+            run,
+            tmp_json,
+            input_genomes_tiny,
+            hash_to_filename,
+            filename_to_hash,
+            query_hashes=hash_to_lengths,
+            subject_hash=list(hash_to_filename)[1],
+        )
 
 
 def test_skani_missing_mode(
@@ -161,26 +162,29 @@ def test_skani_missing_mode(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
 
-    with pytest.raises(SystemExit, match="skani run-id 1 is missing mode parameter"):
-        private_cli.compute_skani(
-            logger,
-            tmp_dir,
-            session,
-            run,
-            tmp_json,
-            input_genomes_tiny,
-            hash_to_filename,
-            filename_to_hash,
-            query_hashes=hash_to_lengths,
-            subject_hash=list(hash_to_filename)[1],
-        )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
+
+        with pytest.raises(
+            SystemExit, match="skani run-id 1 is missing mode parameter"
+        ):
+            private_cli.compute_skani(
+                logger,
+                tmp_dir,
+                session,
+                run,
+                tmp_json,
+                input_genomes_tiny,
+                hash_to_filename,
+                filename_to_hash,
+                query_hashes=hash_to_lengths,
+                subject_hash=list(hash_to_filename)[1],
+            )
 
 
 def test_running_skani_gzip(
@@ -209,22 +213,23 @@ def test_running_skani_gzip(
     )
 
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = session.query(db_orm.Run).one()
-    assert run.run_id == 1
-    filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
-    hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
-    hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
 
-    private_cli.compute_skani(
-        logger,
-        tmp_dir,
-        session,
-        run,
-        tmp_json,
-        input_gzip_bacteria,
-        hash_to_filename,
-        filename_to_hash,
-        query_hashes=hash_to_lengths,
-        subject_hash=list(hash_to_filename)[1],
-    )
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = session.query(db_orm.Run).one()
+        assert run.run_id == 1
+        filename_to_hash = {_.fasta_filename: _.genome_hash for _ in run.fasta_hashes}
+        hash_to_filename = {_.genome_hash: _.fasta_filename for _ in run.fasta_hashes}
+        hash_to_lengths = {_.genome_hash: _.length for _ in run.genomes}
+
+        private_cli.compute_skani(
+            logger,
+            tmp_dir,
+            session,
+            run,
+            tmp_json,
+            input_gzip_bacteria,
+            hash_to_filename,
+            filename_to_hash,
+            query_hashes=hash_to_lengths,
+            subject_hash=list(hash_to_filename)[1],
+        )

--- a/tests/test_sourmash.py
+++ b/tests/test_sourmash.py
@@ -52,16 +52,16 @@ def test_prepare_genomes_bad_method(tmp_path: str, input_genomes_tiny: Path) -> 
         create_db=True,
     )
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, run_id=1)
-    with pytest.raises(
-        SystemExit,
-        match="Expected run to be for sourmash, not method guessing",
-    ):
-        next(
-            sourmash.prepare_genomes(logger, run, tmp_dir)
-        )  # should error before checks cache
-    session.close()
+
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, run_id=1)
+        with pytest.raises(
+            SystemExit,
+            match="Expected run to be for sourmash, not method guessing",
+        ):
+            next(
+                sourmash.prepare_genomes(logger, run, tmp_dir)
+            )  # should error before checks cache
 
 
 def test_prepare_genomes_bad_kmer(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -82,16 +82,16 @@ def test_prepare_genomes_bad_kmer(tmp_path: str, input_genomes_tiny: Path) -> No
         create_db=True,
     )
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, run_id=1)
-    with pytest.raises(
-        SystemExit,
-        match=f"sourmash requires a k-mer size, default is {sourmash.KMER_SIZE}",
-    ):
-        next(
-            sourmash.prepare_genomes(logger, run, cache=tmp_dir)
-        )  # should error before checks cache
-    session.close()
+
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, run_id=1)
+        with pytest.raises(
+            SystemExit,
+            match=f"sourmash requires a k-mer size, default is {sourmash.KMER_SIZE}",
+        ):
+            next(
+                sourmash.prepare_genomes(logger, run, cache=tmp_dir)
+            )  # should error before checks cache
 
 
 def test_prepare_genomes_bad_cache(tmp_path: str, input_genomes_tiny: Path) -> None:
@@ -113,16 +113,16 @@ def test_prepare_genomes_bad_cache(tmp_path: str, input_genomes_tiny: Path) -> N
         create_db=True,
     )
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, run_id=1)
-    with pytest.raises(
-        ValueError,
-        match="Cache directory '/does/not/exist' does not exist",
-    ):
-        next(
-            sourmash.prepare_genomes(logger, run, cache=Path("/does/not/exist"))
-        )  # should error before checks cache
-    session.close()
+
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, run_id=1)
+        with pytest.raises(
+            ValueError,
+            match="Cache directory '/does/not/exist' does not exist",
+        ):
+            next(
+                sourmash.prepare_genomes(logger, run, cache=Path("/does/not/exist"))
+            )  # should error before checks cache
 
 
 def test_prepare_genomes_bad_extra(
@@ -146,16 +146,16 @@ def test_prepare_genomes_bad_extra(
         create_db=True,
     )
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.load_run(session, run_id=1)
-    with pytest.raises(
-        SystemExit,
-        match=f"sourmash requires extra setting, default is scaled={sourmash.SCALED}",
-    ):
-        next(
-            sourmash.prepare_genomes(logger, run, cache=tmp_dir)
-        )  # should error before checks cache
-    session.close()
+
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.load_run(session, run_id=1)
+        with pytest.raises(
+            SystemExit,
+            match=f"sourmash requires extra setting, default is scaled={sourmash.SCALED}",
+        ):
+            next(
+                sourmash.prepare_genomes(logger, run, cache=tmp_dir)
+            )  # should error before checks cache
 
 
 def test_parser_with_bad_branchwater(tmp_path: str) -> None:
@@ -221,37 +221,38 @@ def test_compute_bad_args(tmp_path: str) -> None:
     tmp_db = tmp_dir / "bad args.db"
     tmp_json = tmp_dir / "bad args.json"
     logger = setup_logger(None)
-    session = db_orm.connect_to_db(logger, tmp_db)
-    run = db_orm.Run()  # empty
-    tool = tools.get_sourmash()
-    config = db_orm.Configuration(
-        method="sourmash",
-        program=tool.exe_path.name,
-        version=tool.version,
-        kmersize=31,
-        extra="scaled=1234",
-    )
-    run = db_orm.Run(configuration=config)
-    with pytest.raises(
-        SystemExit,
-        match=(
-            "Missing sourmash signatures directory"
-            f" '{tmp_dir}/sourmash_k=31_scaled=1234' - check cache setting."
-        ),
-    ):
-        private_cli.compute_sourmash(
-            logger,
-            tmp_dir,
-            session,
-            run,
-            tmp_json,
-            tmp_dir,
-            {},
-            {},
-            {"ABCDE": 12345},
-            "HIJKL",
-            cache=tmp_dir,
+
+    with db_orm.connect_to_db(logger, tmp_db) as session:
+        run = db_orm.Run()  # empty
+        tool = tools.get_sourmash()
+        config = db_orm.Configuration(
+            method="sourmash",
+            program=tool.exe_path.name,
+            version=tool.version,
+            kmersize=31,
+            extra="scaled=1234",
         )
+        run = db_orm.Run(configuration=config)
+        with pytest.raises(
+            SystemExit,
+            match=(
+                "Missing sourmash signatures directory"
+                f" '{tmp_dir}/sourmash_k=31_scaled=1234' - check cache setting."
+            ),
+        ):
+            private_cli.compute_sourmash(
+                logger,
+                tmp_dir,
+                session,
+                run,
+                tmp_json,
+                tmp_dir,
+                {},
+                {},
+                {"ABCDE": 12345},
+                "HIJKL",
+                cache=tmp_dir,
+            )
 
 
 def test_compute_tile_bad_args(tmp_path: str) -> None:


### PR DESCRIPTION
Changes the idiom of database connection to context management, from:

```python
session = db_orm.connect_to_db(logger, database)
```

to 

```python
with db_orm.connect_to_db(logger, database) as session:
```

so we can take advantage of automatic cleanup, etc.

Unfortunately this does not avoid `ResourceWarning` issues related to unclosed databases. For instance:

```bash
$ pytest -v tests/test_self_vs_self.py::test_self_vs_self_fastani --cov-report=html --cov=pyani_plus
[...]
tests/test_self_vs_self.py::test_self_vs_self_fastani
  /Users/lpritc/miniconda3/envs/pyani-plus_py313/lib/python3.13/site-packages/sqlalchemy/pool/impl.py:153: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x14845be20>
    def _do_get(self) -> ConnectionPoolEntry:
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_self_vs_self.py::test_self_vs_self_fastani
  /Users/lpritc/miniconda3/envs/pyani-plus_py313/lib/python3.13/site-packages/sqlalchemy/sql/annotation.py:152: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x1483a13f0>
    def _deannotate(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_self_vs_self.py::test_self_vs_self_fastani
  /Users/lpritc/miniconda3/envs/pyani-plus_py313/lib/python3.13/site-packages/sqlalchemy/sql/annotation.py:152: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x1484047c0>
    def _deannotate(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/test_self_vs_self.py::test_self_vs_self_fastani
  /Users/lpritc/miniconda3/envs/pyani-plus_py313/lib/python3.13/site-packages/sqlalchemy/orm/session.py:1152: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x1484074c0>
    @_StateChange.declare_states(
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

and fixing these warnings was the motivation for the idiom change. All tests continue to pass locally.

**This PR is intended to be merged ahead of the `add_lzani` branch**

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest -v` **non-passing code will not be merged**
- [ ] Rebase against `origin/master`
- [X] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [X] Request a code review
- [X] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository
