### PR TITLE
Use typer>=0.19.0 with literals for choices, rather than click

### DIFF
--- a/pyani_plus/public_cli.py
+++ b/pyani_plus/public_cli.py
@@ -33,9 +33,8 @@ import tempfile
 from contextlib import nullcontext
 from math import log as math_log
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
-import click
 import networkx as nx
 import typer
 from rich.console import Console
@@ -618,11 +617,10 @@ def external_alignment(  # noqa: PLR0913
         ),
     ],
     label: Annotated[
-        str,
+        Literal["md5", "filename", "stem"],
         typer.Option(
-            click_type=click.Choice(["md5", "filename", "stem"]),
             rich_help_panel="Method parameters",
-            help="How are the sequences in the MSA labelled vs the FASTA genomes?",
+            help="How are the sequences in the MSA labeled vs the FASTA genomes?",
         ),
     ] = "stem",
 ) -> int:
@@ -902,7 +900,7 @@ def delete_run(
         confirm = True
 
     if confirm and not force:
-        click.confirm("Do you want to continue?", abort=True)  # pragma: no cover
+        typer.confirm("Do you want to continue?", abort=True)  # pragma: no cover
 
     # Plan to offer an extended mode, perhaps --all, which will also
     # delete orphaned entries in the configuration,  genomes, and

--- a/pyani_plus/public_cli_args.py
+++ b/pyani_plus/public_cli_args.py
@@ -29,9 +29,8 @@ the private and public API definitions without needed to import from each other
 import sys
 from enum import Enum
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
-import click
 import typer
 
 from pyani_plus import FASTA_EXTENSIONS, LOG_FILE, __version__
@@ -280,9 +279,8 @@ OPT_ARG_TYPE_CACHE = Annotated[
 ]
 # Would like to replace this with Literal["md5", "filename", "stem"] once typer updated
 OPT_ARG_TYPE_LABEL = Annotated[
-    str,
+    Literal["md5", "filename", "stem"],
     typer.Option(
-        click_type=click.Choice(["md5", "filename", "stem"]),
         help="How to label the genomes.",
     ),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "snakemake>=8.24",
     "snakemake-executor-plugin-slurm !=2.0.1, !=2.0.2",
     "sqlalchemy>=2.0",
-    "typer >=0.12, <0.26",
+    "typer>=0.19.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Closes #436.

Avoid using `click` (which was an implicit dependency via `typer` until 0.26.0) for CLI arguments from a list of strings by using the much more elegant literals support added in `typer` 0.19.0 instead. 

See https://typer.tiangolo.com/release-notes/#0190-2025-09-20

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [x] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [ ] Fork the `pyani-plus` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [x] Set up an appropriate development environment (please see `CONTRIBUTING.md` for this repository)
- [x] Create a new branch with a short, descriptive name
- [x] Work on this branch
  - [x] style guidelines have been followed (please see `CONTRIBUTING.md` for this repository)
  - [x] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [x] tests for the change have been added that demonstrate the fix or feature works
- [x] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [x] Check changes with linting/formatting tools before submission (please see `CONTRIBUTING.md` for this repository)
- [x] Commit branch
- [x] Submit pull request, describing the content and intent of the pull request
- [x] Request a code review
- [x] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/pyani-plus/pulls) in the `pyan-plus` repository

Closes #436 